### PR TITLE
Fix docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git*
+db/*.sqlite3
+db/*.sqlite3-journal
+log/*
+tmp/*
+Dockerfile
+README.rdoc

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 .byebug_history
 
 coverage/*
+
+# Ignore local overrides
+/docker-compose.override.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -475,6 +475,7 @@ GEM
       rails (> 3.2.0)
     orm_adapter (0.5.0)
     os (0.9.6)
+    pg (0.21.0)
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     public_suffix (3.0.0)
@@ -685,7 +686,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     stomp (1.4.4)
     sxp (1.0.0)
       rdf (~> 2.0)
@@ -735,6 +735,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  pg
   puma (~> 3.7)
   rails (~> 5.1.4)
   rsolr (>= 1.0)
@@ -744,7 +745,6 @@ DEPENDENCIES
   solr_wrapper (>= 0.3)
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,10 @@
 
 ActiveRecord::Schema.define(version: 20171031194248) do
 
-  create_table "bookmarks", force: :cascade do |t|
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "bookmarks", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -24,7 +27,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "checksum_audit_logs", force: :cascade do |t|
+  create_table "checksum_audit_logs", id: :serial, force: :cascade do |t|
     t.string "file_set_id"
     t.string "file_id"
     t.string "checked_uri"
@@ -37,7 +40,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["file_set_id", "file_id"], name: "by_file_set_id_and_file_id"
   end
 
-  create_table "content_blocks", force: :cascade do |t|
+  create_table "content_blocks", id: :serial, force: :cascade do |t|
     t.string "name"
     t.text "value"
     t.datetime "created_at", null: false
@@ -45,7 +48,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.string "external_key"
   end
 
-  create_table "curation_concerns_operations", force: :cascade do |t|
+  create_table "curation_concerns_operations", id: :serial, force: :cascade do |t|
     t.string "status"
     t.string "operation_type"
     t.string "job_class"
@@ -66,7 +69,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
   end
 
-  create_table "featured_works", force: :cascade do |t|
+  create_table "featured_works", id: :serial, force: :cascade do |t|
     t.integer "order", default: 5
     t.string "work_id"
     t.datetime "created_at", null: false
@@ -75,7 +78,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["work_id"], name: "index_featured_works_on_work_id"
   end
 
-  create_table "file_download_stats", force: :cascade do |t|
+  create_table "file_download_stats", id: :serial, force: :cascade do |t|
     t.datetime "date"
     t.integer "downloads"
     t.string "file_id"
@@ -86,7 +89,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["user_id"], name: "index_file_download_stats_on_user_id"
   end
 
-  create_table "file_view_stats", force: :cascade do |t|
+  create_table "file_view_stats", id: :serial, force: :cascade do |t|
     t.datetime "date"
     t.integer "views"
     t.string "file_id"
@@ -97,14 +100,14 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["user_id"], name: "index_file_view_stats_on_user_id"
   end
 
-  create_table "hyrax_features", force: :cascade do |t|
+  create_table "hyrax_features", id: :serial, force: :cascade do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "job_io_wrappers", force: :cascade do |t|
+  create_table "job_io_wrappers", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "uploaded_file_id"
     t.string "file_set_id"
@@ -118,7 +121,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["user_id"], name: "index_job_io_wrappers_on_user_id"
   end
 
-  create_table "mailboxer_conversation_opt_outs", force: :cascade do |t|
+  create_table "mailboxer_conversation_opt_outs", id: :serial, force: :cascade do |t|
     t.string "unsubscriber_type"
     t.integer "unsubscriber_id"
     t.integer "conversation_id"
@@ -126,13 +129,13 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
   end
 
-  create_table "mailboxer_conversations", force: :cascade do |t|
+  create_table "mailboxer_conversations", id: :serial, force: :cascade do |t|
     t.string "subject", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "mailboxer_notifications", force: :cascade do |t|
+  create_table "mailboxer_notifications", id: :serial, force: :cascade do |t|
     t.string "type"
     t.text "body"
     t.string "subject", default: ""
@@ -155,7 +158,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["type"], name: "index_mailboxer_notifications_on_type"
   end
 
-  create_table "mailboxer_receipts", force: :cascade do |t|
+  create_table "mailboxer_receipts", id: :serial, force: :cascade do |t|
     t.string "receiver_type"
     t.integer "receiver_id"
     t.integer "notification_id", null: false
@@ -172,18 +175,18 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end
 
-  create_table "minter_states", force: :cascade do |t|
+  create_table "minter_states", id: :serial, force: :cascade do |t|
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
     t.text "counters"
-    t.integer "seq", limit: 8, default: 0
+    t.bigint "seq", default: 0
     t.binary "rand"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["namespace"], name: "index_minter_states_on_namespace", unique: true
   end
 
-  create_table "permission_template_accesses", force: :cascade do |t|
+  create_table "permission_template_accesses", id: :serial, force: :cascade do |t|
     t.integer "permission_template_id"
     t.string "agent_type"
     t.string "agent_id"
@@ -192,7 +195,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.datetime "updated_at"
   end
 
-  create_table "permission_templates", force: :cascade do |t|
+  create_table "permission_templates", id: :serial, force: :cascade do |t|
     t.string "admin_set_id"
     t.string "visibility"
     t.datetime "created_at"
@@ -202,7 +205,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["admin_set_id"], name: "index_permission_templates_on_admin_set_id", unique: true
   end
 
-  create_table "proxy_deposit_requests", force: :cascade do |t|
+  create_table "proxy_deposit_requests", id: :serial, force: :cascade do |t|
     t.string "work_id", null: false
     t.integer "sending_user_id", null: false
     t.integer "receiving_user_id", null: false
@@ -216,7 +219,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["sending_user_id"], name: "index_proxy_deposit_requests_on_sending_user_id"
   end
 
-  create_table "proxy_deposit_rights", force: :cascade do |t|
+  create_table "proxy_deposit_rights", id: :serial, force: :cascade do |t|
     t.integer "grantor_id"
     t.integer "grantee_id"
     t.datetime "created_at", null: false
@@ -233,7 +236,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
   end
 
   create_table "qa_local_authority_entries", force: :cascade do |t|
-    t.integer "local_authority_id"
+    t.bigint "local_authority_id"
     t.string "label"
     t.string "uri"
     t.datetime "created_at", null: false
@@ -242,7 +245,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
-  create_table "searches", force: :cascade do |t|
+  create_table "searches", id: :serial, force: :cascade do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -251,7 +254,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "single_use_links", force: :cascade do |t|
+  create_table "single_use_links", id: :serial, force: :cascade do |t|
     t.string "downloadKey"
     t.string "path"
     t.string "itemId"
@@ -260,7 +263,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "sipity_agents", force: :cascade do |t|
+  create_table "sipity_agents", id: :serial, force: :cascade do |t|
     t.string "proxy_for_id", null: false
     t.string "proxy_for_type", null: false
     t.datetime "created_at", null: false
@@ -268,7 +271,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["proxy_for_id", "proxy_for_type"], name: "sipity_agents_proxy_for", unique: true
   end
 
-  create_table "sipity_comments", force: :cascade do |t|
+  create_table "sipity_comments", id: :serial, force: :cascade do |t|
     t.integer "entity_id", null: false
     t.integer "agent_id", null: false
     t.text "comment"
@@ -279,7 +282,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["entity_id"], name: "index_sipity_comments_on_entity_id"
   end
 
-  create_table "sipity_entities", force: :cascade do |t|
+  create_table "sipity_entities", id: :serial, force: :cascade do |t|
     t.string "proxy_for_global_id", null: false
     t.integer "workflow_id", null: false
     t.integer "workflow_state_id"
@@ -290,7 +293,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["workflow_state_id"], name: "index_sipity_entities_on_workflow_state_id"
   end
 
-  create_table "sipity_entity_specific_responsibilities", force: :cascade do |t|
+  create_table "sipity_entity_specific_responsibilities", id: :serial, force: :cascade do |t|
     t.integer "workflow_role_id", null: false
     t.string "entity_id", null: false
     t.integer "agent_id", null: false
@@ -302,7 +305,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["workflow_role_id"], name: "sipity_entity_specific_responsibilities_role"
   end
 
-  create_table "sipity_notifiable_contexts", force: :cascade do |t|
+  create_table "sipity_notifiable_contexts", id: :serial, force: :cascade do |t|
     t.integer "scope_for_notification_id", null: false
     t.string "scope_for_notification_type", null: false
     t.string "reason_for_notification", null: false
@@ -315,7 +318,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["scope_for_notification_id", "scope_for_notification_type"], name: "sipity_notifiable_contexts_concern"
   end
 
-  create_table "sipity_notification_recipients", force: :cascade do |t|
+  create_table "sipity_notification_recipients", id: :serial, force: :cascade do |t|
     t.integer "notification_id", null: false
     t.integer "role_id", null: false
     t.string "recipient_strategy", null: false
@@ -327,7 +330,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["role_id"], name: "sipity_notification_recipients_role"
   end
 
-  create_table "sipity_notifications", force: :cascade do |t|
+  create_table "sipity_notifications", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "notification_type", null: false
     t.datetime "created_at", null: false
@@ -336,7 +339,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["notification_type"], name: "index_sipity_notifications_on_notification_type"
   end
 
-  create_table "sipity_roles", force: :cascade do |t|
+  create_table "sipity_roles", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -344,7 +347,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["name"], name: "index_sipity_roles_on_name", unique: true
   end
 
-  create_table "sipity_workflow_actions", force: :cascade do |t|
+  create_table "sipity_workflow_actions", id: :serial, force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.integer "resulting_workflow_state_id"
     t.string "name", null: false
@@ -355,7 +358,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["workflow_id"], name: "sipity_workflow_actions_workflow"
   end
 
-  create_table "sipity_workflow_methods", force: :cascade do |t|
+  create_table "sipity_workflow_methods", id: :serial, force: :cascade do |t|
     t.string "service_name", null: false
     t.integer "weight", null: false
     t.integer "workflow_action_id", null: false
@@ -364,7 +367,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["workflow_action_id"], name: "index_sipity_workflow_methods_on_workflow_action_id"
   end
 
-  create_table "sipity_workflow_responsibilities", force: :cascade do |t|
+  create_table "sipity_workflow_responsibilities", id: :serial, force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "workflow_role_id", null: false
     t.datetime "created_at", null: false
@@ -372,7 +375,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["agent_id", "workflow_role_id"], name: "sipity_workflow_responsibilities_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_roles", force: :cascade do |t|
+  create_table "sipity_workflow_roles", id: :serial, force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.integer "role_id", null: false
     t.datetime "created_at", null: false
@@ -380,7 +383,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["workflow_id", "role_id"], name: "sipity_workflow_roles_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_action_permissions", force: :cascade do |t|
+  create_table "sipity_workflow_state_action_permissions", id: :serial, force: :cascade do |t|
     t.integer "workflow_role_id", null: false
     t.integer "workflow_state_action_id", null: false
     t.datetime "created_at", null: false
@@ -388,7 +391,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["workflow_role_id", "workflow_state_action_id"], name: "sipity_workflow_state_action_permissions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_actions", force: :cascade do |t|
+  create_table "sipity_workflow_state_actions", id: :serial, force: :cascade do |t|
     t.integer "originating_workflow_state_id", null: false
     t.integer "workflow_action_id", null: false
     t.datetime "created_at", null: false
@@ -396,7 +399,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["originating_workflow_state_id", "workflow_action_id"], name: "sipity_workflow_state_actions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_states", force: :cascade do |t|
+  create_table "sipity_workflow_states", id: :serial, force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -405,7 +408,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["workflow_id", "name"], name: "sipity_type_state_aggregate", unique: true
   end
 
-  create_table "sipity_workflows", force: :cascade do |t|
+  create_table "sipity_workflows", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "label"
     t.text "description"
@@ -417,20 +420,20 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
   end
 
-  create_table "tinymce_assets", force: :cascade do |t|
+  create_table "tinymce_assets", id: :serial, force: :cascade do |t|
     t.string "file"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "trophies", force: :cascade do |t|
+  create_table "trophies", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.string "work_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "uploaded_files", force: :cascade do |t|
+  create_table "uploaded_files", id: :serial, force: :cascade do |t|
     t.string "file"
     t.integer "user_id"
     t.string "file_set_uri"
@@ -440,7 +443,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end
 
-  create_table "user_stats", force: :cascade do |t|
+  create_table "user_stats", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.datetime "date"
     t.integer "file_views"
@@ -493,7 +496,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "version_committers", force: :cascade do |t|
+  create_table "version_committers", id: :serial, force: :cascade do |t|
     t.string "obj_id"
     t.string "datastream_id"
     t.string "version_id"
@@ -502,7 +505,7 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "work_view_stats", force: :cascade do |t|
+  create_table "work_view_stats", id: :serial, force: :cascade do |t|
     t.datetime "date"
     t.integer "work_views"
     t.string "work_id"
@@ -513,4 +516,11 @@ ActiveRecord::Schema.define(version: 20171031194248) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "curation_concerns_operations", "users"
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
+  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
+  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
+  add_foreign_key "permission_template_accesses", "permission_templates"
+  add_foreign_key "qa_local_authority_entries", "qa_local_authorities", column: "local_authority_id"
+  add_foreign_key "uploaded_files", "users"
 end

--- a/docker-compose.override.yml-example
+++ b/docker-compose.override.yml-example
@@ -1,0 +1,8 @@
+# Example for exposing the load balancer for local dev; just copy this to docker-compose.override.yml
+version: '2'
+
+services:
+  lb:
+    ports:
+      - 8080:80
+      - 8443:443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,6 @@ services:
     expose:
       - 8983
     volumes:
-      - .:/app
       - solr:/opt/solr/server/solr
     networks:
       internal:
@@ -117,6 +116,7 @@ services:
       - SECRET_KEY_BASE=asdf
       - RAILS_CACHE_STORE_URL=memcache
     volumes:
+      - .:/data
       - app:/data/tmp/uploads
     networks:
       internal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,9 +178,6 @@ services:
       - DOCKER_TLS_VERIFY
       - DOCKER_HOST
       - DOCKER_CERT_PATH
-    ports:
-      - 8080:80
-      - 8443:443
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # You must uncomment this line if and only if you are running docker-machine


### PR DESCRIPTION
- Ignores potentially huge stuff when building docker images, stolen from @revgum 
- No ports are exposed by `docker-compose.yml`; devs can copy `docker-compose.override.yml-example` to `docker-compose.override.yml` (or create their own) to customize ports as it makes sense