### PR TITLE
adds configuration to allow for remote debugging the web app in a docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ coverage/*
 .byebug_history
 
 config/local_env.yml
+
+fits.log
+.vscode/*

--- a/Gemfile
+++ b/Gemfile
@@ -60,4 +60,7 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
+  gem 'debase'
+  gem 'debase-ruby_core_source'
+  gem 'ruby-debug-ide'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,9 @@ GEM
     connection_pool (2.2.1)
     crass (1.0.3)
     daemons (1.2.5)
+    debase (0.2.2)
+      debase-ruby_core_source (>= 0.10.2)
+    debase-ruby_core_source (0.10.2)
     declarative (0.0.10)
     declarative-option (0.1.0)
     deprecation (1.0.0)
@@ -614,6 +617,8 @@ GEM
       json
       multipart-post
       oauth2
+    ruby-debug-ide (0.6.1)
+      rake (>= 0.8.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
@@ -737,6 +742,8 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
+  debase
+  debase-ruby_core_source
   devise
   devise-guests (~> 0.6)
   fcrepo_wrapper
@@ -749,6 +756,7 @@ DEPENDENCIES
   rails (~> 5.1.4)
   rsolr (>= 1.0)
   rspec-rails
+  ruby-debug-ide
   sass-rails (~> 5.0)
   selenium-webdriver
   sidekiq
@@ -761,4 +769,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/config/puma/development.rb
+++ b/config/puma/development.rb
@@ -1,2 +1,3 @@
-workers 3
+# worker pools kill the capability for ruby-debug-ide integration
+# workers 1
 preload_app!

--- a/docker-compose.override.yml-example
+++ b/docker-compose.override.yml-example
@@ -1,4 +1,4 @@
-# Example for exposing the load balancer for local dev; just copy this to docker-compose.override.yml
+# Example for exposing the load balancer for local dev and ruby remote debugger; just copy this to docker-compose.override.yml
 version: '2'
 
 services:
@@ -6,3 +6,15 @@ services:
     ports:
       - 8080:80
       - 8443:443
+  # Expose the web application to the external network, and start the server allowing for remote debugging
+  web:
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rdebug-ide --host 0.0.0.0 --port 1234 -- bin/rails server -p 3000 -b 0.0.0.0"
+    ports:
+      - 3000:3000
+      - 1234:1234
+    expose:
+      - 3000
+      - 1234
+    networks:
+      internal:
+      external:


### PR DESCRIPTION
Gems for remote debugging, and an example override for running the server in debug mode. 

Thrashed around a lot with this until I figured out that puma, running with workers, was the underlying problem preventing the remote debugging from working properly.