### PR TITLE
adds vim to docker image for debug/troubleshooting purposes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,17 @@ FROM ruby:2.5.1
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 RUN apt-get update -qq && \
-    apt-get install -y build-essential libpq-dev nodejs libreoffice imagemagick unzip ghostscript && \
-    rm -rf /var/lib/apt/lists/*
+  apt-get install -y build-essential libpq-dev nodejs libreoffice imagemagick unzip ghostscript vim && \
+  rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /opt/fits && \
-    curl -fSL -o /opt/fits-1.0.5.zip http://projects.iq.harvard.edu/files/fits/files/fits-1.0.5.zip && \
-    cd /opt && unzip fits-1.0.5.zip && chmod +X fits-1.0.5/fits.sh
+  curl -fSL -o /opt/fits-1.0.5.zip http://projects.iq.harvard.edu/files/fits/files/fits-1.0.5.zip && \
+  cd /opt && unzip fits-1.0.5.zip && chmod +X fits-1.0.5/fits.sh
 
 RUN mkdir /data
 WORKDIR /data
 ADD Gemfile /data/Gemfile
 ADD Gemfile.lock /data/Gemfile.lock
 RUN gem install bundler
-RUN bundle install
 ADD . /data
-#RUN bundle exec rake assets:precompile
+RUN bundle install
 EXPOSE 3000


### PR DESCRIPTION
The idea here is to have easy access to vim when opening a shell for troubleshooting a running container, I think the image size is well worth the addition.