### PR TITLE
allows docker containers to use webconsole in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,5 +55,5 @@ Rails.application.configure do
   config.active_job.queue_adapter = ENV.fetch('ACTIVE_JOB_QUEUE_ADAPTER', 'inline').to_sym
 
   # Whitelist docker containers for webconsole during development
-  config.web_console.whitelisted_ips = '172.0.0.0/8'
+  config.web_console.whitelisted_ips = ['172.0.0.0/8', '192.0.0.0/8']
 end


### PR DESCRIPTION
adds 192.* addresses to webconsole in development