### PR TITLE
persists solr server between uses

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,8 +162,6 @@ services:
       - solr-dev:/opt/solr/server/solr
   solr-test:
     <<: *solr
-    volumes:
-      - ./tmp/solr:/opt/solr/server/solr
 
   ##
   # Fedora repository server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,11 +159,11 @@ services:
   solr-dev:
     <<: *solr
     volumes:
-      - solr-dev:/opt/solr/server/solr/mycores
+      - solr-dev:/opt/solr/server/solr
   solr-test:
     <<: *solr
     volumes:
-      - ./tmp/solr/mycores:/opt/solr/server/solr/mycores
+      - ./tmp/solr:/opt/solr/server/solr
 
   ##
   # Fedora repository server


### PR DESCRIPTION
The `cloud` style of Solr needs to persist more than just the cores for Docker.