### PR TITLE
add audio model and model specs

### DIFF
--- a/app/actors/hyrax/actors/audio_actor.rb
+++ b/app/actors/hyrax/actors/audio_actor.rb
@@ -1,0 +1,8 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+module Hyrax
+  module Actors
+    class AudioActor < Hyrax::Actors::BaseActor
+    end
+  end
+end

--- a/app/controllers/hyrax/audios_controller.rb
+++ b/app/controllers/hyrax/audios_controller.rb
@@ -1,0 +1,14 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+module Hyrax
+  # Generated controller for Audio
+  class AudiosController < ApplicationController
+    # Adds Hyrax behaviors to the controller.
+    include Hyrax::WorksControllerBehavior
+    include Hyrax::BreadcrumbsForWorks
+    self.curation_concern_type = ::Audio
+
+    # Use this line if you want to use a custom presenter
+    self.show_presenter = Hyrax::AudioPresenter
+  end
+end

--- a/app/forms/hyrax/audio_form.rb
+++ b/app/forms/hyrax/audio_form.rb
@@ -1,0 +1,16 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+module Hyrax
+  # Generated form for Audio
+  class AudioForm < Hyrax::Forms::WorkForm
+    include ::OregonDigital::TriplePoweredProperties::TriplePoweredForm
+    self.terms += OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym)
+    self.model_class = ::Audio
+
+    self.required_fields = []
+
+    def primary_terms
+      OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym) + [:keyword, :title]
+    end
+  end
+end

--- a/app/indexers/audio_indexer.rb
+++ b/app/indexers/audio_indexer.rb
@@ -1,0 +1,18 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+class AudioIndexer < Hyrax::WorkIndexer
+  # This indexes the default metadata. You can remove it if you want to
+  # provide your own metadata and indexing.
+  include Hyrax::IndexesBasicMetadata
+
+  # Fetch remote labels for based_near. You can remove this if you don't want
+  # this behavior
+  include Hyrax::IndexesLinkedMetadata
+
+  # Uncomment this block if you want to add custom indexing behavior:
+  # def generate_solr_document
+  #  super.tap do |solr_doc|
+  #    solr_doc['my_custom_field_ssim'] = object.my_custom_property
+  #  end
+  # end
+end

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -1,11 +1,10 @@
 # Generated via
-#  `rails generate hyrax:work Image`
-class Image < ActiveFedora::Base
+#  `rails generate hyrax:work Audio`
+class Audio < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include ::OregonDigital::TriplePoweredProperties::WorkBehavior
-  include ::OregonDigital::ImageMetadata
 
-  self.indexer = ImageIndexer
+  self.indexer = AudioIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -2,6 +2,7 @@
 #  `rails generate hyrax:work Video`
 class Video < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include ::OregonDigital::TriplePoweredProperties::WorkBehavior
   include ::OregonDigital::VideoMetadata
 
   self.indexer = VideoIndexer
@@ -11,5 +12,5 @@ class Video < ActiveFedora::Base
 
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
-  include ::Hyrax::BasicMetadata
+  include ::OregonDigital::GenericMetadata
 end

--- a/app/presenters/hyrax/audio_presenter.rb
+++ b/app/presenters/hyrax/audio_presenter.rb
@@ -1,0 +1,6 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+module Hyrax
+  class AudioPresenter < Hyrax::WorkShowPresenter
+  end
+end

--- a/app/views/hyrax/audios/_audio.html.erb
+++ b/app/views/hyrax/audios/_audio.html.erb
@@ -1,0 +1,2 @@
+<%# This is a search result view %>
+<%= render 'catalog/document', document: audio, document_counter: audio_counter  %>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -7,7 +7,8 @@ Hyrax.config do |config|
   config.register_curation_concern :video
   # Injected via `rails g hyrax:work Document`
   config.register_curation_concern :document
-
+  # Injected via `rails g hyrax:work Audio`
+  config.register_curation_concern :audio
   # Register roles that are expected by your implementation.
   # @see Hyrax::RoleRegistry for additional details.
   # @note there are magical roles as defined in Hyrax::RoleRegistry::MAGIC_ROLES

--- a/config/locales/audio.de.yml
+++ b/config/locales/audio.de.yml
@@ -1,0 +1,8 @@
+de:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        description:        "Audio Werke"
+        name:               "Audio"

--- a/config/locales/audio.en.yml
+++ b/config/locales/audio.en.yml
@@ -1,0 +1,8 @@
+en:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        description:        "Audio works"
+        name:               "Audio"

--- a/config/locales/audio.es.yml
+++ b/config/locales/audio.es.yml
@@ -1,0 +1,10 @@
+es:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        # TODO: translate `human_name` into Spanish
+        description:        "Audio trabajos"
+        name:               "Audio"
+        # TODO: translate `human_name` into Spanish

--- a/config/locales/audio.fr.yml
+++ b/config/locales/audio.fr.yml
@@ -1,0 +1,8 @@
+fr:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        description:        "Audio œuvres"
+        name:               "Audio"

--- a/config/locales/audio.it.yml
+++ b/config/locales/audio.it.yml
@@ -1,0 +1,8 @@
+it:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        description:        "Audio opere"
+        name:               "Audio"

--- a/config/locales/audio.pt-BR.yml
+++ b/config/locales/audio.pt-BR.yml
@@ -1,0 +1,8 @@
+pt-BR:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        description:        "Audio trabalhos"
+        name:               "Audio"

--- a/config/locales/audio.zh.yml
+++ b/config/locales/audio.zh.yml
@@ -1,0 +1,10 @@
+zh:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        # TODO: translate `human_name` into Chinese
+        description:        "Audio 作品"
+        name:               "Audio"
+        # TODO: translate `human_name` into Chinese

--- a/spec/actors/hyrax/actors/audio_actor_spec.rb
+++ b/spec/actors/hyrax/actors/audio_actor_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+require 'rails_helper'
+
+RSpec.describe Hyrax::Actors::AudioActor do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/controllers/hyrax/audios_controller_spec.rb
+++ b/spec/controllers/hyrax/audios_controller_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+require 'rails_helper'
+
+RSpec.describe Hyrax::AudiosController do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/forms/hyrax/audio_form_spec.rb
+++ b/spec/forms/hyrax/audio_form_spec.rb
@@ -1,0 +1,21 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+require 'rails_helper'
+
+RSpec.describe Hyrax::AudioForm do
+  let(:new_form) { described_class.new(Audio.new, nil, double('Controller')) }
+  let(:user) { create(:user) }
+  let(:ability) { double('Ability') }
+  let(:props) {OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym)}
+
+  before do
+    allow(new_form).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
+  end
+
+  it "responds to terms with the proper list of terms" do
+    props.each do |prop|
+      expect(described_class.terms).to include(prop)
+    end
+  end
+end

--- a/spec/models/audio_spec.rb
+++ b/spec/models/audio_spec.rb
@@ -1,0 +1,20 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+require 'rails_helper'
+
+RSpec.describe Audio do
+  let(:props) {OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym)}
+
+  it 'has a title' do
+    subject.title = ['foo']
+    expect(subject.title).to eq ['foo']
+  end
+
+  describe "metadata" do
+    it "has descriptive generic metadata" do
+      props.each do |prop|
+        expect(subject).to respond_to(prop)
+      end
+    end
+  end
+end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -3,7 +3,69 @@
 require 'rails_helper'
 
 RSpec.describe Image do
-  it "has tests" do
-    skip "Add your tests here"
+  let(:props) {OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym)}
+
+  it 'has a title' do
+    subject.title = ['foo']
+    expect(subject.title).to eq ['foo']
+  end
+
+  it 'has a colour_content' do
+    subject.colour_content = ['Color']
+    expect(subject.colour_content).to eq ['Color']
+  end
+
+  it 'has a color_space' do
+    subject.color_space = ['RGB']
+    expect(subject.color_space).to eq ['RGB']
+  end
+
+  it 'has a height' do
+    subject.height = '100'
+    expect(subject.height).to eq '100'
+  end
+
+  it 'has an orientation' do
+    subject.orientation = ['Horizontal']
+    expect(subject.orientation).to eq ['Horizontal']
+  end
+
+  it 'has an photograph_orientation' do
+    subject.photograph_orientation = 'west'
+    expect(subject.photograph_orientation).to eq 'west'
+  end
+
+  it 'has an photograph_orientation' do
+    subject.resolution = '72'
+    expect(subject.resolution).to eq '72'
+  end
+
+  it 'has an view' do
+    subject.view = ['exterior']
+    expect(subject.view).to eq ['exterior']
+  end
+
+  it 'has an width' do
+    subject.width = '200'
+    expect(subject.width).to eq '200'
+  end
+
+  describe "metadata" do
+    it "has descriptive image metadata" do
+      expect(subject).to respond_to(:colour_content)
+      expect(subject).to respond_to(:color_space)
+      expect(subject).to respond_to(:height)
+      expect(subject).to respond_to(:orientation)
+      expect(subject).to respond_to(:photograph_orientation)
+      expect(subject).to respond_to(:resolution)
+      expect(subject).to respond_to(:view)
+      expect(subject).to respond_to(:width)
+    end
+
+    it "has descriptive generic metadata" do
+      props.each do |prop|
+        expect(subject).to respond_to(prop)
+      end
+    end
   end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -3,7 +3,33 @@
 require 'rails_helper'
 
 RSpec.describe Video do
-  it "has tests" do
-    skip "Add your tests here"
+  let(:props) {OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym)}
+
+  it 'has a title' do
+    subject.title = ['foo']
+    expect(subject.title).to eq ['foo']
+  end
+
+  it 'has a height' do
+    subject.height = '100'
+    expect(subject.height).to eq '100'
+  end
+
+  it 'has an width' do
+    subject.width = '200'
+    expect(subject.width).to eq '200'
+  end
+
+  describe "metadata" do
+    it "has descriptive video metadata" do
+      expect(subject).to respond_to(:height)
+      expect(subject).to respond_to(:width)
+    end
+
+    it "has descriptive generic metadata" do
+      props.each do |prop|
+        expect(subject).to respond_to(prop)
+      end
+    end
   end
 end

--- a/spec/presenters/hyrax/audio_presenter_spec.rb
+++ b/spec/presenters/hyrax/audio_presenter_spec.rb
@@ -1,0 +1,27 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+require 'rails_helper'
+
+RSpec.describe Hyrax::AudioPresenter do
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:ability) { double "Ability" }
+  let(:presenter) { described_class.new(solr_document, ability) }
+
+  let(:attributes) do
+    { "id" => '888888',
+      "title_tesim" => ['foo', 'bar'],
+      "human_readable_type_tesim" => ["Generic Work"],
+      "has_model_ssim" => ["Audio"],
+      "date_created_tesim" => ['an unformatted date'],
+      "depositor_tesim" => user.user_key }
+  end
+
+  let(:core_props) {[:title, :depositor, :date_uploaded, :date_modified]}
+  let(:user) { double(user_key: 'generic person 1')}
+
+  it "delegates the method to solr document" do
+    core_props.each do |prop|
+      expect(presenter).to delegate_method(prop).to(:solr_document)
+    end
+  end
+end

--- a/spec/system/create_audio_spec.rb
+++ b/spec/system/create_audio_spec.rb
@@ -17,12 +17,7 @@ RSpec.describe 'Create a Audio', js: true, type: :system do
     end
 
     scenario do
-      visit '/dashboard'
-      click_link 'Works'
-      expect(page).to have_content 'Add new work'
-      click_link 'Add new work'
-      choose 'payload_concern', option: 'Audio', visible: false
-      click_on 'Create work'
+      visit new_hyrax_audio_path
 
       expect(page).to have_content 'Add New Audio'
       click_link 'Files' # switch tab

--- a/spec/system/create_audio_spec.rb
+++ b/spec/system/create_audio_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal:true
+
+RSpec.describe 'Create a Audio', js: true, type: :system do
+  context 'a logged in user' do
+    let(:user) { create(:user) }
+    let!(:ability) { ::Ability.new(user) }
+    let(:upload_file_path) { "#{Rails.root}/spec/fixtures/test.jpg" }
+
+    before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      allow(CharacterizeJob).to receive(:perform_later)
+      sign_in_as user
+    end
+
+    scenario do
+      visit '/dashboard'
+      click_link 'Works'
+      expect(page).to have_content 'Add new work'
+      click_link 'Add new work'
+      choose 'payload_concern', option: 'Audio', visible: false
+      click_on 'Create work'
+
+      expect(page).to have_content 'Add New Audio'
+      click_link 'Files' # switch tab
+      expect(page).to have_content 'Add files'
+      expect(page).to have_content 'Add folder'
+      within('span#addfiles') do
+        page.execute_script("$('input[type=file]').css('opacity','1')")
+        page.execute_script("$('input[type=file]').css('position','inherit')")
+        attach_file('files[]', upload_file_path)
+      end
+      click_link 'Descriptions' # switch tab
+      fill_in('Title', with: 'My Test Work')
+      fill_in('Creator', with: 'Doe, Jane')
+      fill_in('Keyword', with: 'testing')
+      # TODO: Rights statement list is missing from generic model, uncomment/resolve
+      # line below when when rights_statement list is ready
+      # select('In Copyright', from: 'Rights statement')
+      # Selenium/chrome on CircleCI requires the focus to change after the previous method
+      find('body').click
+
+      choose('audio_visibility_open')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      # Selenium/chrome on CircleCI requires the focus to change after the previous method
+      find('body').click
+
+      check('agreement')
+      # Selenium/chrome on CircleCI requires the focus to change after the previous method
+      find('body').click
+
+      click_on 'Save'
+      expect(page).to have_content('My Test Work')
+      expect(page).to have_content 'Your files are being processed by Hyrax in the background.'
+
+      # save a successful screenshot if running in CI for build artifacts
+      save_screenshot if ENV.fetch('CI', nil)
+    end
+  end
+end

--- a/spec/system/create_document_spec.rb
+++ b/spec/system/create_document_spec.rb
@@ -17,12 +17,7 @@ RSpec.describe 'Create a Document', js: true, type: :system do
     end
 
     scenario do
-      visit '/dashboard'
-      click_link 'Works'
-      expect(page).to have_content 'Add new work'
-      click_link 'Add new work'
-      choose 'payload_concern', option: 'Document', visible: false
-      click_on 'Create work'
+      visit new_hyrax_document_path
 
       expect(page).to have_content 'Add New Document'
       click_link 'Files' # switch tab

--- a/spec/system/create_generic_spec.rb
+++ b/spec/system/create_generic_spec.rb
@@ -17,12 +17,7 @@ RSpec.describe 'Create a Generic', js: true, type: :system do
     end
 
     scenario do
-      visit '/dashboard'
-      click_link 'Works'
-      expect(page).to have_content 'Add new work'
-      click_link 'Add new work'
-      choose 'payload_concern', option: 'Generic', visible: false
-      click_on 'Create work'
+      visit new_hyrax_generic_path
 
       expect(page).to have_content 'Add New Generic'
       click_link 'Files' # switch tab

--- a/spec/system/create_image_spec.rb
+++ b/spec/system/create_image_spec.rb
@@ -17,12 +17,7 @@ RSpec.describe 'Create a Image',  js: true, type: :system do
     end
 
     scenario do
-      visit '/dashboard'
-      click_link 'Works'
-      expect(page).to have_content 'Add new work'
-      click_link 'Add new work'
-      choose 'payload_concern', option: 'Image', visible: false
-      click_button 'Create work'
+      visit new_hyrax_image_path
 
       expect(page).to have_content 'Add New Image'
       click_link 'Files' # switch tab

--- a/spec/system/create_video_spec.rb
+++ b/spec/system/create_video_spec.rb
@@ -17,12 +17,7 @@ RSpec.describe 'Create a Video',  js: true, type: :system do
     end
 
     scenario do
-      visit '/dashboard'
-      click_link 'Works'
-      expect(page).to have_content 'Add new work'
-      click_link 'Add new work'
-      choose 'payload_concern', option: 'Video', visible: false
-      click_button 'Create work'
+      visit new_hyrax_video_path
 
       expect(page).to have_content 'Add New Video'
       click_link 'Files' # switch tab


### PR DESCRIPTION
fixes #109 

Customize metadata given [Metadata Application Profile](https://docs.google.com/spreadsheets/d/16xBFjmeSsaN0xQrbOpQ_jIOeFZk3ZM9kmB8CU3IhP2c/edit#gid=0)
- [x] 1. Generate Audio work type 
- [x] 2. Define model (with custom metadata if any) and model spec
- [x] 3. Set labels and help text
- [x] 4. Modify the Edit Form and add spec
- [x] 5. Define presenter and spec 
- [x] 6. Define controller and spec
- [x] 7. Modify the Show Page 
- [x] 8. Configure a property or properties to be shown in the search results for a work