### PR TITLE
fixes empty tmp/pids bug and makes entrypoint a single script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,10 @@
 pg_upgrade_*.log
 
 # Ignore all logfiles and tempfiles.
+/tmp/pids/*
 /log/*
 /tmp/*
+!/tmp/pids/.keep
 !/log/.keep
 !/tmp/.keep
 

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+rm -f tmp/pids/puma.pid
+./build/install_gems.sh
+./build/create_solr_index.sh
+./build/validate_migrated.sh

--- a/build/install_gems.sh
+++ b/build/install_gems.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "${RAILS_ENV}" = 'production' ] || [ "${RAILS_ENV}" = 'staging' ]; then
+  echo "Cannot auto-install gems in ${RAILS_ENV}, exiting"
+  exit 1
+fi
+
+bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,8 +64,7 @@ services:
   server:
     <<: *dev
     command: >
-      bash -c "./build/create_solr_index.sh &&
-      ./build/validate_migrated.sh &&
+      bash -c "./build/entrypoint.sh &&
       bundle exec puma -C config/puma/development.rb --dir /data --pidfile /data/tmp/pids/puma.pid -b tcp://0.0.0.0:3000 &&
       tail -f log/development.log"
   workers:
@@ -116,8 +115,7 @@ services:
       - .:/data # mount current directory into the image
       - ./tmp:/tmp
     command: >
-      bash -c "./build/create_solr_index.sh &&
-      ./build/validate_migrated.sh &&
+      bash -c "./build/entrypoint.sh &&
       puma -b tcp://0.0.0.0:3001 -e test -d &&
       tail -f log/test.log"
     expose:


### PR DESCRIPTION
Fixes a bug that @decimalator ran into where a fresh repo didn't include the tmp/pids directory and caused docker to fail startup. 

Creates a single entrypoint script to run any bootstrap needs for development and test environments