### PR TITLE
makes entrypoint more dynamic and allows for production or staging builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM ruby:2.5.1
+
+ARG RAILS_ENV
+
 # Necessary for bundler to operate properly
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
@@ -30,5 +33,4 @@ ADD . /data
 # COPY package.json yarn.lock /data/
 # RUN yarn install
 
-# bundle gem dependencies
-RUN bundle install -j $(nproc)
+RUN ./build/install_gems.sh

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
+
+echo "Building ${RAILS_ENV}"
+
 rm -f tmp/pids/puma.pid
 ./build/install_gems.sh
-./build/create_solr_index.sh
-./build/validate_migrated.sh
+
+# Do not auto-create SOLR or Migrations for production or staging environments
+if [ "${RAILS_ENV}" != 'production' ] && [ "${RAILS_ENV}" != 'staging' ]; then
+  ./build/create_solr_index.sh
+  ./build/validate_migrated.sh
+fi
+
+# Precompile assets for production or staging
+if [ "${RAILS_ENV}" = 'production' ] || [ "${RAILS_ENV}" = 'staging' ]; then
+  bundle exec rails assets:precompile
+fi

--- a/build/install_gems.sh
+++ b/build/install_gems.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 if [ "${RAILS_ENV}" = 'production' ] || [ "${RAILS_ENV}" = 'staging' ]; then
-  echo "Cannot auto-install gems in ${RAILS_ENV}, exiting"
-  exit 1
+  echo "Bundle install without development or test gems."
+  bundle install --without development test -j $(nproc)
+else
+  bundle install -j $(nproc)
 fi
-
-bundle install


### PR DESCRIPTION
This gives the build server the ability to generate Docker images for staging and production environments (without dev/test gems which can cause problems, like having `spring` in the mix).

`.env` automatically sets the RAILS_ENV to development locally, otherwise to build production (`docker build --build-arg RAILS_ENV=production .`)