### PR TITLE
initializes honeycomb proper, disables integration for development/test env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ jobs:
         environment:
           CAPYBARA_APP_HOST: http://test:3001
           FEDORA_URL: http://localhost:8080/fcrepo/rest
+          HONEYCOMB_DATASET: od2-rails-test
+          HONEYCOMB_DEBUG: 'true'
+          HONEYCOMB_WRITEKEY: buzzzzzzzzzzzzzzzz
+          HONEYCOMB_SERVICE: od2
           RAILS_ENV: test
           RDS_DB_NAME: test
           RDS_HOSTNAME: localhost

--- a/Gemfile
+++ b/Gemfile
@@ -29,10 +29,8 @@ gem 'loofah', '>= 2.2.3'
 gem 'rubyzip', '>= 1.2.2'
 
 # Honeycomb
-group :production, :staging do
-  gem 'sequel'
-  gem 'honeycomb-beeline'
-end
+gem 'sequel'
+gem 'honeycomb-beeline'
 
 group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  if %w[production staging].include? Rails.env
+  if %w[production staging development].include? Rails.env
     def append_info_to_payload(payload)
       super(payload)
       Rack::Honeycomb.add_field(request.env, 'version', ENV.fetch('DEPLOYED_VERSION', OregonDigital::VERSION))

--- a/config.ru
+++ b/config.ru
@@ -1,11 +1,8 @@
-# This file is used by Rack-based servers to start the application.
-
-require_relative 'config/environment'
+# frozen_string_literal:true
 
 # Initialize Honeycomb before everything else
-if %w[production staging].include? Rails.env
-  require 'honeycomb-beeline'
-  Honeycomb.init
-end
+require 'honeycomb-beeline'
+Honeycomb.init
 
+require_relative 'config/environment'
 run Rails.application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,10 @@ services:
       - ACTIVE_JOB_QUEUE_ADAPTER=sidekiq
       - FEDORA_URL=http://fcrepo-dev:8080/fcrepo/rest
       - FITS_PATH=/opt/fits-1.0.5/fits.sh
+      - HONEYCOMB_DATASET=od2-rails
+      - HONEYCOMB_DEBUG=true
+      - HONEYCOMB_WRITEKEY=buzzzzzzzzzzzzzzzz
+      - HONEYCOMB_SERVICE=od2
       - IIIF_SERVER_BASE_URL=http://localhost:8080/iiif
       - RAILS_CACHE_STORE_URL=memcache
       - RAILS_ENV=development
@@ -53,9 +57,6 @@ services:
       - SOLR_URL=http://solr-dev:8983/solr/development
       - TRIPLESTORE_ADAPTER_TYPE=blazegraph
       - TRIPLESTORE_ADAPTER_URL=http://blazegraph-dev:8080/bigdata/namespace/rw/sparql
-      - HONEYCOMB_DATASET=od2-rails
-      - HONEYCOMB_WRITEKEY=buzzzzzzzzzzzzzzzz
-      - HONEYCOMB_SERVICE=od2
     depends_on:
       - db-dev
       - blazegraph-dev
@@ -93,6 +94,10 @@ services:
       - CAPYBARA_APP_HOST=http://test:3001
       - FEDORA_URL=http://fcrepo-test:8080/fcrepo/rest
       - FITS_PATH=/opt/fits-1.0.5/fits.sh
+      - HONEYCOMB_DATASET=od2-rails
+      - HONEYCOMB_DEBUG=true
+      - HONEYCOMB_WRITEKEY=buzzzzzzzzzzzzzzzz
+      - HONEYCOMB_SERVICE=od2
       - IIIF_SERVER_BASE_URL=http://localhost:8080/iiif
       - RAILS_CACHE_STORE_URL=memcache
       - RAILS_ENV=test


### PR DESCRIPTION
Honeycomb.init has to be called before the Rails environment, but the HONEYCOMB_DEBUG environment variable existence will disable it from sending traces and redirects that output to STDERR. 

This PR gives us the ability to enable it for development, if needed, but defaults both development and test to disabling it.. while enabling and initializing it for production/staging.