### PR TITLE
posts markers to honeycomb during staging/production boot

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -13,5 +13,7 @@ fi
 
 # Precompile assets for production or staging
 if [ "${RAILS_ENV}" = 'production' ] || [ "${RAILS_ENV}" = 'staging' ]; then
+  curl https://api.honeycomb.io/1/markers/od2-rails-${RAILS_ENV} -X POST -H "X-Honeycomb-Team: ${HONEYCOMB_WRITEKEY}" -d "{\"message\":\"${RAILS_ENV} - ${DEPLOYED_VERSION} - compiling assets\", \"type\":\"deploy\"}"
   bundle exec rails assets:precompile
+  curl https://api.honeycomb.io/1/markers/od2-rails-${RAILS_ENV} -X POST -H "X-Honeycomb-Team: ${HONEYCOMB_WRITEKEY}" -d "{\"message\":\"${RAILS_ENV} - ${DEPLOYED_VERSION} - booting\", \"type\":\"deploy\"}"
 fi


### PR DESCRIPTION
these markers add context to honeycomb for the boot process during deployment

fixes #175 