### PR TITLE
Smtp configs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,14 +39,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.delivery_method = :smtp
-
-  config.action_mailer.smtp_settings = {
-    address: ENV.fetch('SMTP_ADDRESS', 'smtp.gmail.com'),
-    port: ENV.fetch('SMTP_PORT', 587),
-    user_name: ENV.fetch('SMTP_USERNAME', 'etstestmail123'),
-    password: ENV.fetch('SMTP_PASSWORD', 'etstest123')
-  }
+  # Don't actually send emails in development
+  config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,14 +38,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.delivery_method = :smtp
-
-  config.action_mailer.smtp_settings = {
-    address: ENV.fetch('SMTP_ADDRESS', 'smtp.gmail.com'),
-    port: ENV.fetch('SMTP_PORT', 587),
-    user_name: ENV.fetch('SMTP_USERNAME', 'etstestmail123'),
-    password: ENV.fetch('SMTP_PASSWORD', 'etstest123')
-  }
+  # Don't actually send emails in development
+  config.action_mailer.delivery_method = :test
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,8 +38,14 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  # Don't actually send emails in development
-  config.action_mailer.delivery_method = :test
+  config.action_mailer.delivery_method = :smtp
+
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch('SMTP_HOST', 'smtp.gmail.com'),
+    port: ENV.fetch('SMTP_PORT', 25),
+    user_name: ENV.fetch('SMTP_USER', 'bogus'),
+    password: ENV.fetch('SMTP_PASSWD', 'bogus')
+  }
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -41,10 +41,10 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = {
-    address: ENV.fetch('SMTP_ADDRESS', 'smtp.gmail.com'),
-    port: ENV.fetch('SMTP_PORT', 587),
-    user_name: ENV.fetch('SMTP_USERNAME', 'etstestmail123'),
-    password: ENV.fetch('SMTP_PASSWORD', 'etstest123')
+    address: ENV.fetch('SMTP_HOST', 'smtp.gmail.com'),
+    port: ENV.fetch('SMTP_PORT', 25),
+    user_name: ENV.fetch('SMTP_USER', 'bogus'),
+    password: ENV.fetch('SMTP_PASSWD', 'bogus')
   }
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb


### PR DESCRIPTION
Disable email functionality for development, only spool the emails to the actionmailer array.

Updates staging and production to match the ENV for deployment.