### PR TITLE
pins to newer rack-honeycomb to keep from leaking login credentials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'omniauth-saml'
 # Honeycomb
 gem 'sequel'
 gem 'honeycomb-beeline'
+gem 'rack-honeycomb', '~> 0.5.0'
 
 group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,7 +440,7 @@ GEM
     ice_nine (0.11.2)
     iiif_manifest (0.5.0)
       activesupport (>= 4)
-    jaro_winkler (1.5.1-x86_64-darwin-17)
+    jaro_winkler (1.5.1)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -612,7 +612,7 @@ GEM
       rails (~> 5.0)
       rdf
     rack (2.0.6)
-    rack-honeycomb (0.3.0)
+    rack-honeycomb (0.5.0)
       libhoney (>= 1.5.0)
     rack-protection (2.0.3)
       rack
@@ -925,6 +925,7 @@ DEPENDENCIES
   pg
   poltergeist
   puma (~> 3.7)
+  rack-honeycomb (~> 0.5.0)
   rails (~> 5.1.6)
   rails-controller-testing
   rsolr (>= 1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,8 +17,6 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  # before_action :authenticate_user!
-
   if %w[production staging development].include? Rails.env
     def append_info_to_payload(payload)
       super(payload)


### PR DESCRIPTION
fixes #188 

Requires a `docker-compose build`