### PR TITLE
manages smtp to be enabled by env

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,11 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.delivery_method = :smtp
+  if ENV.fetch('SMTP_ENABLED', '0').to_i > 0
+    config.action_mailer.delivery_method = :smtp
+  else
+    config.action_mailer.delivery_method = :test
+  end
 
   config.action_mailer.smtp_settings = {
     authentication: :login,

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -38,7 +38,11 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.delivery_method = :smtp
+  if ENV.fetch('SMTP_ENABLED', '0').to_i > 0
+    config.action_mailer.delivery_method = :smtp
+  else
+    config.action_mailer.delivery_method = :test
+  end
 
   config.action_mailer.smtp_settings = {
     authentication: :login,
@@ -80,11 +84,6 @@ Rails.application.configure do
   config.active_job.queue_adapter = ENV.fetch('ACTIVE_JOB_QUEUE_ADAPTER', 'inline').to_sym
   # config.active_job.queue_name_prefix = "OD2_#{Rails.env}"
   config.action_mailer.perform_caching = false
-
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
fixes #213 

Staging had a configuration to force emails to not send because of the configuration `:test`.. This update puts the smtp enable as an ENV to allow for configurability for production and staging.