### PR TITLE
Set Mailboxer from address via env

### DIFF
--- a/config/initializers/mailboxer.rb
+++ b/config/initializers/mailboxer.rb
@@ -5,7 +5,7 @@ Mailboxer.setup do |config|
   config.uses_emails = true
 
   # Configures the default from for emails sent for Messages and Notifications
-  config.default_from = 'no-reply@mailboxer.com'
+  config.default_from = ENV.fetch('SYSTEM_EMAIL_ADDRESS', 'noreply@oregondigital.org')
 
   # Configures the methods needed by mailboxer
   config.email_method = :mailboxer_email


### PR DESCRIPTION
Sets Mailboxer from address from env var. Should fix #297, but we'll see if this is the issue.

fixes #297 