### PR TITLE
More closely match form spec to form-model relationship

### DIFF
--- a/spec/forms/hyrax/audio_form_spec.rb
+++ b/spec/forms/hyrax/audio_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hyrax::AudioForm do
 
   it 'responds to terms with the proper list of terms' do
     props.each do |prop|
-      expect(described_class.terms).to include(prop)
+      expect(terms).to include(prop)
     end
   end
 

--- a/spec/forms/hyrax/audio_form_spec.rb
+++ b/spec/forms/hyrax/audio_form_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Hyrax::AudioForm do
   let(:user) { create(:user) }
   let(:ability) { instance_double('Ability') }
   let(:props) { OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym) }
+  let(:terms) { new_form.primary_terms + new_form.secondary_terms }
+  let(:model) { create(:audio) }
 
   before do
     allow(new_form).to receive(:current_ability).and_return(ability)
@@ -14,6 +16,12 @@ RSpec.describe Hyrax::AudioForm do
   it 'responds to terms with the proper list of terms' do
     props.each do |prop|
       expect(described_class.terms).to include(prop)
+    end
+  end
+
+  it 'matches terms to model properties' do
+    terms.each do |term|
+      expect(model).to respond_to(term)
     end
   end
 end

--- a/spec/forms/hyrax/document_form_spec.rb
+++ b/spec/forms/hyrax/document_form_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Hyrax::DocumentForm do
   let(:user) { create(:user) }
   let(:ability) { instance_double('Ability') }
   let(:props) { OregonDigital::DocumentMetadata::PROPERTIES.map(&:to_sym) }
+  let(:terms) { new_form.primary_terms + new_form.secondary_terms }
+  let(:model) { create(:document) }
 
   before do
     allow(new_form).to receive(:current_ability).and_return(ability)
@@ -14,6 +16,12 @@ RSpec.describe Hyrax::DocumentForm do
   it 'responds to terms with the proper list of terms' do
     props.each do |prop|
       expect(described_class.terms).to include(prop)
+    end
+  end
+
+  it 'matches terms to model properties' do
+    terms.each do |term|
+      expect(model).to respond_to(term)
     end
   end
 end

--- a/spec/forms/hyrax/document_form_spec.rb
+++ b/spec/forms/hyrax/document_form_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe Hyrax::DocumentForm do
   let(:new_form) { described_class.new(Document.new, nil, instance_double('Controller')) }
   let(:user) { create(:user) }
   let(:ability) { instance_double('Ability') }
-  let(:props) { OregonDigital::DocumentMetadata::PROPERTIES.map(&:to_sym) }
+  let(:props) do
+    OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym) +
+      OregonDigital::DocumentMetadata::PROPERTIES.map(&:to_sym)
+  end
   let(:terms) { new_form.primary_terms + new_form.secondary_terms }
   let(:model) { create(:document) }
 
@@ -15,7 +18,7 @@ RSpec.describe Hyrax::DocumentForm do
 
   it 'responds to terms with the proper list of terms' do
     props.each do |prop|
-      expect(described_class.terms).to include(prop)
+      expect(terms).to include(prop)
     end
   end
 

--- a/spec/forms/hyrax/generic_form_spec.rb
+++ b/spec/forms/hyrax/generic_form_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Hyrax::GenericForm do
   let(:user) { create(:user) }
   let(:ability) { instance_double('Ability') }
   let(:props) { OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym) }
+  let(:terms) { new_form.primary_terms + new_form.secondary_terms }
+  let(:model) { create(:generic) }
 
   before do
     allow(new_form).to receive(:current_ability).and_return(ability)
@@ -14,6 +16,12 @@ RSpec.describe Hyrax::GenericForm do
   it 'responds to terms with the proper list of terms' do
     props.each do |t|
       expect(described_class.terms).to include(t)
+    end
+  end
+
+  it 'matches terms to model properties' do
+    terms.each do |term|
+      expect(model).to respond_to(term)
     end
   end
 end

--- a/spec/forms/hyrax/generic_form_spec.rb
+++ b/spec/forms/hyrax/generic_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hyrax::GenericForm do
 
   it 'responds to terms with the proper list of terms' do
     props.each do |t|
-      expect(described_class.terms).to include(t)
+      expect(terms).to include(t)
     end
   end
 

--- a/spec/forms/hyrax/image_form_spec.rb
+++ b/spec/forms/hyrax/image_form_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe Hyrax::ImageForm do
   let(:new_form) { described_class.new(Image.new, nil, instance_double('Controller')) }
   let(:user) { create(:user) }
   let(:ability) { instance_double('Ability') }
-  let(:props) { OregonDigital::ImageMetadata::PROPERTIES.map(&:to_sym) }
+  let(:props) do
+    OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym) +
+      OregonDigital::ImageMetadata::PROPERTIES.map(&:to_sym)
+  end
   let(:terms) { new_form.primary_terms + new_form.secondary_terms }
   let(:model) { create(:image) }
 
@@ -15,7 +18,7 @@ RSpec.describe Hyrax::ImageForm do
 
   it 'responds to terms with the proper list of terms' do
     props.each do |t|
-      expect(described_class.terms).to include(t)
+      expect(terms).to include(t)
     end
   end
 

--- a/spec/forms/hyrax/image_form_spec.rb
+++ b/spec/forms/hyrax/image_form_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Hyrax::ImageForm do
   let(:user) { create(:user) }
   let(:ability) { instance_double('Ability') }
   let(:props) { OregonDigital::ImageMetadata::PROPERTIES.map(&:to_sym) }
+  let(:terms) { new_form.primary_terms + new_form.secondary_terms }
+  let(:model) { create(:image) }
 
   before do
     allow(new_form).to receive(:current_ability).and_return(ability)
@@ -14,6 +16,12 @@ RSpec.describe Hyrax::ImageForm do
   it 'responds to terms with the proper list of terms' do
     props.each do |t|
       expect(described_class.terms).to include(t)
+    end
+  end
+
+  it 'matches terms to model properties' do
+    terms.each do |term|
+      expect(model).to respond_to(term)
     end
   end
 end

--- a/spec/forms/hyrax/video_form_spec.rb
+++ b/spec/forms/hyrax/video_form_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Hyrax::VideoForm do
   let(:user) { create(:user) }
   let(:ability) { instance_double('Ability') }
   let(:props) { OregonDigital::VideoMetadata::PROPERTIES.map(&:to_sym) }
+  let(:terms) { new_form.primary_terms + new_form.secondary_terms }
+  let(:model) { create(:video) }
 
   before do
     allow(new_form).to receive(:current_ability).and_return(ability)
@@ -14,6 +16,12 @@ RSpec.describe Hyrax::VideoForm do
   it 'responds to terms with the proper list of terms' do
     props.each do |t|
       expect(described_class.terms).to include(t)
+    end
+  end
+
+  it 'matches terms to model properties' do
+    terms.each do |term|
+      expect(model).to respond_to(term)
     end
   end
 end

--- a/spec/forms/hyrax/video_form_spec.rb
+++ b/spec/forms/hyrax/video_form_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe Hyrax::VideoForm do
   let(:new_form) { described_class.new(Video.new, nil, instance_double('Controller')) }
   let(:user) { create(:user) }
   let(:ability) { instance_double('Ability') }
-  let(:props) { OregonDigital::VideoMetadata::PROPERTIES.map(&:to_sym) }
+  let(:props) do
+    OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym) +
+      OregonDigital::VideoMetadata::PROPERTIES.map(&:to_sym)
+  end
   let(:terms) { new_form.primary_terms + new_form.secondary_terms }
   let(:model) { create(:video) }
 
@@ -15,7 +18,7 @@ RSpec.describe Hyrax::VideoForm do
 
   it 'responds to terms with the proper list of terms' do
     props.each do |t|
-      expect(described_class.terms).to include(t)
+      expect(terms).to include(t)
     end
   end
 


### PR DESCRIPTION
Fixes #308, increases amount of metadata covered, and narrows terms searched to only those that actually appear on the form.