### PR TITLE
UO SAML fixes

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,6 +2,8 @@
 
 # This handles the omniauth callback to grab a user and sign them in
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_before_action :verify_authenticity_token, only: [:saml, :failure]
+
   def cas
     find_user_and_redirect
   end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,7 +2,7 @@
 
 # This handles the omniauth callback to grab a user and sign them in
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  skip_before_action :verify_authenticity_token, only: [:saml, :failure]
+  skip_before_action :verify_authenticity_token, only: %i[saml failure]
 
   def cas
     find_user_and_redirect

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -257,7 +257,7 @@ Devise.setup do |config|
   config.omniauth :saml,
                   idp_cert: ENV.fetch('SAML_IDP_CERT', 'cert'),
                   idp_sso_target_url: ENV.fetch('SAML_URL', 'https://shibboleth-test.uoregon.edu/idp/profile/SAML2/Redirect/SSO'),
-                  issuer: ENV.fetch('SAML_ISSUER', 'http://od2-staging.library.oregonstate.edu/users/auth/saml'),
+                  issuer: ENV.fetch('SAML_ISSUER', 'http://od2-staging.library.oregonstate.edu/users/auth/saml?locale=en'),
                   private_key: ENV.fetch('SAML_PRIVATE_KEY', 'key'),
                   certificate: ENV.fetch('SAML_CERT', nil),
                   uid_attribute: 'urn:oid:0.9.2342.19200300.100.1.1'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -259,7 +259,8 @@ Devise.setup do |config|
                   idp_sso_target_url: ENV.fetch('SAML_URL', 'https://shibboleth-test.uoregon.edu/idp/profile/SAML2/Redirect/SSO'),
                   issuer: ENV.fetch('SAML_ISSUER', 'http://od2-staging.library.oregonstate.edu/users/auth/saml'),
                   private_key: ENV.fetch('SAML_PRIVATE_KEY', 'key'),
-                  certificate: ENV.fetch('SAML_CERT', nil)
+                  certificate: ENV.fetch('SAML_CERT', nil),
+                  uid_attribute: 'urn:oid:0.9.2342.19200300.100.1.1'
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.


### PR DESCRIPTION
This PR updates devise/omniauth config to correctly grab UO uids and match the entityID with the url most users will initiate SAML auth from.
It also disables CSRF checks for the SAML callback as the devise, omniauth, omniauth-saml stack does not implement CSRF challenges for that endpoint.