### PR TITLE
remove linelength, autofixes offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,7 +45,7 @@ Rails/ApplicationRecord:
   Enabled: false
 
 Metrics/LineLength:
-  Max: 120
+  Enabled: false
 
 RSpec/DescribeClass:
   Exclude:

--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -1,16 +1,3 @@
-Metrics/LineLength:
-  # Ignore comment lines that may begin with spaces
-  IgnoredPatterns: ['(\A|\s)#']
-  Exclude:
-    - 'app/controllers/oregon_digital/oembeds_controller.rb'
-    - 'app/models/concerns/oregon_digital/document_metadata.rb'
-    - 'app/models/concerns/oregon_digital/generic_metadata.rb'
-    - 'app/models/concerns/oregon_digital/image_metadata.rb'
-    - 'app/models/concerns/oregon_digital/video_metadata.rb'
-    - 'spec/**/*'
-    - 'config/**/*'
-    - 'app/controllers/catalog_controller.rb'
-
 Metrics/AbcSize:
   Exclude:
     - 'app/indexers/oregon_digital/deep_indexing_service.rb'

--- a/app/controllers/hyrax/contact_form_controller.rb
+++ b/app/controllers/hyrax/contact_form_controller.rb
@@ -47,6 +47,7 @@ module Hyrax
 
     def contact_form_params
       return {} unless params.key?(:contact_form)
+
       params.require(:contact_form).permit(:contact_method, :category, :name, :email, :subject, :message)
     end
   end

--- a/lib/oregon_digital/triple_powered_properties/triplestore.rb
+++ b/lib/oregon_digital/triple_powered_properties/triplestore.rb
@@ -12,6 +12,7 @@ module OregonDigital::TriplePoweredProperties
     # @return [RDF::Graph] the graph
     def self.fetch(uri)
       return if uri.blank?
+
       begin
         @triplestore ||= TriplestoreAdapter::Triplestore.new(triplestore_client)
         @triplestore.fetch(uri, from_remote: true)

--- a/lib/oregon_digital/triple_powered_properties/work_indexer.rb
+++ b/lib/oregon_digital/triple_powered_properties/work_indexer.rb
@@ -8,6 +8,7 @@ module OregonDigital::TriplePoweredProperties
     def generate_solr_document
       super.tap do |solr_doc|
         next if object.triple_powered_properties.nil?
+
         object.triple_powered_properties.each do |p|
           labels = object.uri_labels(p).values.flatten.compact
           solr_doc[Solrizer.solr_name(p.to_s)] = labels

--- a/spec/controllers/hyrax/contact_form_controller_spec.rb
+++ b/spec/controllers/hyrax/contact_form_controller_spec.rb
@@ -22,35 +22,42 @@ RSpec.describe Hyrax::ContactFormController, type: :controller do
     before do
       controller.instance_variable_set(:@contact_form, contact_form)
     end
+
     context 'when recaptcha is enabled' do
       let(:params) { required_params }
 
       before do
         allow(controller).to receive(:recaptcha?).and_return(true)
       end
+
       context 'with and the recaptcha is not verified' do
         before do
           allow(controller).to receive(:verify_recaptcha).and_return(false)
         end
+
         it 'returns false and throws an error' do
           expect(controller.check_recaptcha).to eq(false)
         end
       end
+
       context 'with and the recaptcha is verified' do
         before do
           allow(controller).to receive(:verify_recaptcha).and_return(true)
         end
+
         it 'returns a true value' do
           expect(controller.check_recaptcha).to eq(true)
         end
       end
     end
+
     context 'when recaptcha is not enabled' do
       let(:params) { required_params }
 
       before do
         allow(controller).to receive(:recaptcha?).and_return(false)
       end
+
       it 'returns true and processes the email normally' do
         expect(controller.check_recaptcha).to eq(true)
       end

--- a/spec/controllers/oregon_digital/oembeds_controller_spec.rb
+++ b/spec/controllers/oregon_digital/oembeds_controller_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe OregonDigital::OembedsController do
         expect(flash[:alert]).to eq 'You are not authorized to access this page.'
       end
     end
+
     context 'when I have permission to edit the object' do
       it 'shows me the page' do
         expect(controller).to receive(:add_breadcrumb).with('Home', controller.root_path)

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
       allow(request).to receive(:env).and_return(merged_env)
       allow(provider).to receive(:provider).and_return('cas')
     end
+
     it 'redirects when authenticated' do
       req.env['devise.mapping'] = Devise.mappings[:user]
       get :cas
@@ -20,12 +21,14 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
       expect(response.status).to eq 302
     end
   end
+
   context 'when #saml' do
     before do
       allow(user_ob).to receive(:from_omniauth).with(anything).and_return(user)
       allow(request).to receive(:env).and_return(merged_env)
       allow(provider).to receive(:provider).and_return('cas')
     end
+
     it 'redirects when authenticated' do
       req.env['devise.mapping'] = Devise.mappings[:user]
       get :saml

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
       after(:build) do |file, _evaluator|
         file.title = ['testfile']
       end
+
       after(:create) do |file, evaluator|
         Hydra::Works::UploadFileToFileSet.call(file, evaluator.content) if evaluator.content
         create(:work, user: evaluator.user).members << file

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,24 +14,29 @@ RSpec.describe User do
         allow(access_token).to receive(:extra).and_return(extra)
         allow(extra).to receive(:osuprimarymail).and_return(email1)
       end
+
       it 'returns a user with the proper email' do
         expect(user.from_omniauth(access_token).email).to eq email1
       end
     end
+
     context 'when given a saml provider' do
       before do
         allow(access_token).to receive(:provider).and_return('saml')
         allow(access_token).to receive(:uid).and_return('myfakeuid')
       end
+
       it 'returns a user with the proper email' do
         expect(user.from_omniauth(access_token).email).to eq email2
       end
     end
+
     context 'when given anything else' do
       before do
         allow(access_token).to receive(:provider).and_return('anything else')
         allow(access_token).to receive(:uid).and_return('myfakeuid')
       end
+
       it 'returns a user with the proper email' do
         expect(user.from_omniauth(access_token).email).to eq 'myfakeuid'
       end

--- a/spec/oregon_digital/triple_powered_properties/triplestore_spec.rb
+++ b/spec/oregon_digital/triple_powered_properties/triplestore_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe OregonDigital::TriplePoweredProperties::Triplestore do
       stub_request(:get, 'http://ci-test:8080/bigdata/namespace/rw/sparql?GETSTMTS&includeInferred=false&s=%3Chttp://opaquenamespace.org/ns/blah%3E')
         .to_return(status: 200, body: '', headers: {})
     end
+
     it 'sets the triplestore as an instance of TriplestoreAdapter::Triplestore' do
       triplestore.fetch('http://opaquenamespace.org/ns/blah')
       expect(triplestore.instance_variable_get(:@triplestore)).to be_kind_of TriplestoreAdapter::Triplestore

--- a/spec/oregon_digital/triple_powered_properties/work_indexer_spec.rb
+++ b/spec/oregon_digital/triple_powered_properties/work_indexer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe OregonDigital::TriplePoweredProperties::WorkIndexer do
       allow(work).to receive(:fetch).and_return(['Blahbalh'])
       allow(work).to receive(:uri_labels).and_return(based_near: ['Blahblah'])
     end
+
     it 'appends the labels into the solr_document' do
       expect(solr_document['based_near_tesim']).to eq ['Blahblah']
     end

--- a/spec/search_builders/oregon_digital/errored_oembed_search_builder_spec.rb
+++ b/spec/search_builders/oregon_digital/errored_oembed_search_builder_spec.rb
@@ -17,11 +17,13 @@ RSpec.describe OregonDigital::ErroredOembedSearchBuilder do
     let!(:oembed_error) { create(:oembed_error) }
 
     before { search_builder.with_errored_oembed(solr_params) }
+
     it { expect(solr_params[:fq]).to eq(["id:(#{oembed_error.document_id})"]) }
   end
 
   describe 'with no errored oembeds' do
     before { search_builder.with_errored_oembed(solr_params) }
+
     it { expect(solr_params[:fq]).to eq(['-id:*']) }
   end
 end

--- a/spec/search_builders/oregon_digital/oembed_search_builder_spec.rb
+++ b/spec/search_builders/oregon_digital/oembed_search_builder_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe OregonDigital::OembedSearchBuilder do
     let(:processor_chain) { {} }
 
     before { search_builder.with_sorting(processor_chain) }
+
     it { is_expected.to eq(sort: 'system_create_dtsi desc') }
   end
 
@@ -22,6 +23,7 @@ RSpec.describe OregonDigital::OembedSearchBuilder do
     let(:processor_chain) { {} }
 
     before { search_builder.only_oembed(processor_chain) }
+
     it { is_expected.to eq(fq: ['oembed_url_tesim:*']) }
   end
 end

--- a/spec/services/oregon_digital/user_attribute_service_spec.rb
+++ b/spec/services/oregon_digital/user_attribute_service_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe OregonDigital::UserAttributeService do
   context 'when no email exists' do
     it { expect(service.email_redirect_path).to be_nil }
   end
+
   context 'when osu email' do
     let(:email) { 'blah@oregonstate.edu' }
 
     it { expect(service.email_redirect_path).to eq router.new_osu_session_path.to_s }
   end
+
   context 'when uo email' do
     let(:email) { 'blah@uoregon.edu' }
 


### PR DESCRIPTION
linelength poll suggests that we disable the cop.. 

oddly, rubocop also found a bunch of offenses that I fixed.. wonder why those were caught in CCI