### PR TITLE
URI validation for Controlled Vocabularies

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -34,6 +34,10 @@ Metrics/MethodLength:
     - 'lib/oregon_digital/triple_powered_properties/work_behavior.rb'
     - 'lib/tasks/oregon_digital/csv_ingest.rake'
 
+Naming/AccessorMethodName:
+  Exclude:
+    - 'lib/oregon_digital/controlled_vocabularies/resource.rb'
+
 RSpec/InstanceVariable:
   Exclude:
     - 'spec/controllers/users/omniauth_callbacks_controller_spec.rb'

--- a/app/models/generic.rb
+++ b/app/models/generic.rb
@@ -6,7 +6,6 @@ class Generic < ActiveFedora::Base
   include ::OregonDigital::TriplePoweredProperties::WorkBehavior
 
   before_save :resolve_oembed_errors
-  validate :terms_in_controlled_vocabulary
 
   self.indexer = GenericIndexer
   # Change this to restrict which works can be added as a child.
@@ -21,14 +20,5 @@ class Generic < ActiveFedora::Base
   def resolve_oembed_errors
     errors = OembedError.find_by(document_id: id)
     errors.delete if oembed_url_changed? && !errors.blank?
-  end
-
-  def terms_in_controlled_vocabulary
-    controlled_properties.each do |terms|
-      self.send(terms).each do |term|
-        Rails.logger.info(term)
-        errors.add(:term, "URI #{term} not in vocabulary") unless term.valid?
-      end
-    end
   end
 end

--- a/lib/oregon_digital/controlled_vocabularies/resource.rb
+++ b/lib/oregon_digital/controlled_vocabularies/resource.rb
@@ -4,6 +4,9 @@ module OregonDigital
   module ControlledVocabularies
     # Generic object for storing labels and uris
     class Resource < ActiveTriples::Resource
+      # Validate resource is in the vocabulary
+      validate :uri_in_vocab
+
       # Return a tuple of url & label
       def solrize
         return [rdf_subject.to_s] if rdf_label.first.to_s.blank? || rdf_label_uri_same?
@@ -14,6 +17,10 @@ module OregonDigital
 
       def rdf_label_uri_same?
         rdf_label.first.to_s == rdf_subject.to_s
+      end
+
+      def uri_in_vocab
+        errors.add(:uri, "URI #{id} not in vocabulary") unless self.class.respond_to?(:in_vocab?) && self.class.in_vocab?(id)
       end
     end
   end

--- a/lib/oregon_digital/controlled_vocabularies/resource.rb
+++ b/lib/oregon_digital/controlled_vocabularies/resource.rb
@@ -4,23 +4,25 @@ module OregonDigital
   module ControlledVocabularies
     # Generic object for storing labels and uris
     class Resource < ActiveTriples::Resource
-
       ##
       # Override ActiveTriples::Resource to enforce vocabulary membership
       #
       # @see ActiveTriples::Resource
       def initialize(*args, &block)
         super
-        if !node?
-          resource_uri = rdf_subject
-          @rdf_subject = nil
-          set_subject!(resource_uri)
-        end
+        # If rdf_subject wasn't set, we're done
+        return if node?
+
+        # Reset rdf_subject and set it through the proper method
+        resource_uri = @rdf_subject
+        @rdf_subject = nil
+        set_subject!(resource_uri)
       end
 
+      # Override ActiveTriples::Resource.set_subject! to throw exception if term isn't in vocab
       def set_subject!(uri_or_str)
-        raise ControlledVocabularyError,
-              "Term not in controlled vocabulary: #{uri_or_str}" unless uri_in_vocab(uri_or_str.to_s)
+        raise ControlledVocabularyError, "Term not in controlled vocabulary: #{uri_or_str}" unless
+          uri_in_vocab?(uri_or_str.to_s)
         super
       end
 
@@ -36,7 +38,7 @@ module OregonDigital
         rdf_label.first.to_s == rdf_subject.to_s
       end
 
-      def uri_in_vocab(uri)
+      def uri_in_vocab?(uri)
         self.class.respond_to?(:in_vocab?) && self.class.in_vocab?(uri)
       end
     end

--- a/spec/oregon_digital/controlled_vocabularies/resource_spec.rb
+++ b/spec/oregon_digital/controlled_vocabularies/resource_spec.rb
@@ -26,4 +26,19 @@ RSpec.describe OregonDigital::ControlledVocabularies::Resource do
       it { expect(resource.solrize).to eq ['RDF.Subject.Org'] }
     end
   end
+
+  describe '#set_subject!' do
+    context 'with a term in the vocabulary' do
+      before do
+        allow(resource).to receive(:uri_in_vocab?).and_return(true)
+      end
+      it { expect { resource.set_subject!('http://my.queryuri.com') }.not_to raise_error(OregonDigital::ControlledVocabularies::ControlledVocabularyError) }
+    end
+    context 'with a term not in the vocabulary' do
+      before do
+        allow(resource).to receive(:uri_in_vocab?).and_return(false)
+      end
+      it { expect { resource.set_subject!('http://my.queryuri.com') }.to raise_error(OregonDigital::ControlledVocabularies::ControlledVocabularyError) }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #335 

Originally 20135c0 was going to add typical validation behavior, but ActiveFedora doesn't seem to validate properties on works. Enter f1d6651 to run validation on controlled vocabulary properties, but then ActiveTriples doesn't support validation on ActiveTriples::BufferedTransaction.

I still think above is the preferable way to approach this, but d2ac188 just implements it similar to how OD1 did, w/ throwing an exception when a term is being fetched.