### PR TITLE
Feature/jp2 encoding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
             sudo apt-get install -y clamav-freshclam clamav-daemon libclamav-dev
             sudo apt-get install -t jessie-backports -y openjdk-8-jre-headless ca-certificates-java
             sudo apt-get install -y openjdk-8-jre openjdk-8-jdk openjdk-8-jdk-headless
+            sudo apt-get install -y imagemagick graphicsmagick libopenjp2-tools
             sudo update-alternatives --config java
       - run:
           name: Fetch clamav databases

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN gem install bundler
 
 RUN apt-get update && apt-get upgrade -y && \
   apt-get install --no-install-recommends -y ca-certificates nodejs yarn \
-  build-essential libpq-dev libreoffice imagemagick unzip ghostscript vim \
-  ffmpeg qt5-default libqt5webkit5-dev xvfb xauth openjdk-8-jre --fix-missing --allow-unauthenticated
+  build-essential libpq-dev libreoffice imagemagick graphicsmagick unzip ghostscript vim \
+  ffmpeg qt5-default libqt5webkit5-dev xvfb xauth openjdk-8-jre libopenjp2-tools --fix-missing --allow-unauthenticated
 
 # install clamav for antivirus
 # fetch clamav local database
@@ -32,12 +32,6 @@ RUN mkdir -p /var/lib/clamav && \
 RUN mkdir -p /opt/fits && \
   curl -fSL -o /opt/fits-1.0.5.zip http://projects.iq.harvard.edu/files/fits/files/fits-1.0.5.zip && \
   cd /opt && unzip fits-1.0.5.zip && chmod +X fits-1.0.5/fits.sh
-
-# install Kakadu for jp2 derivatives
-RUN curl -fSL -o /opt/kakadu.zip http://kakadusoftware.com/wp-content/uploads/2014/06/KDU7A2_Demo_Apps_for_Ubuntu-x86-64_170827.zip && \
-  cd /opt && unzip kakadu.zip && mv KDU7A2_Demo_Apps_for_Ubuntu-x86-64_170827 kakadu
-ENV PATH="/opt/kakadu:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/kakadu:${LD_LIBRARY_PATH}"
 
 RUN mkdir /data
 WORKDIR /data

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+# TODO: make this a version specification once we get a new release cut
+gem 'hydra-derivatives', git: 'https://github.com/samvera/hydra-derivatives.git'
+
 gem 'browse-everything'
 gem 'coffee-rails', '~> 4.2'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,19 @@ GIT
       sparql-client
 
 GIT
+  remote: https://github.com/samvera/hydra-derivatives.git
+  revision: 8c22c5797769ea07461a8da739d5e7e996679501
+  specs:
+    hydra-derivatives (3.4.1)
+      active-fedora (>= 11.3.1, < 13)
+      active_encode (~> 0.1)
+      activesupport (>= 4.0, < 6)
+      addressable (~> 2.5)
+      deprecation
+      mime-types (> 2.0, < 4.0)
+      mini_magick (>= 3.2, < 5)
+
+GIT
   remote: https://github.com/samvera/hyrax.git
   revision: c0699505fc89d54a7545c9e5b3ff9235e1733e80
   tag: v2.4.0
@@ -410,14 +423,6 @@ GEM
     hydra-core (10.6.0)
       hydra-access-controls (= 10.6.0)
       railties (>= 4.0.0, < 6)
-    hydra-derivatives (3.4.1)
-      active-fedora (>= 11.3.1, < 13)
-      active_encode (~> 0.1)
-      activesupport (>= 4.0, < 6)
-      addressable (~> 2.5)
-      deprecation
-      mime-types (> 2.0, < 4.0)
-      mini_magick (>= 3.2, < 5)
     hydra-editor (4.0.2)
       active-fedora (>= 9.0.0)
       almond-rails (~> 0.1)
@@ -929,6 +934,7 @@ DEPENDENCIES
   factory_bot_rails
   faraday_middleware (~> 0.10.0)
   honeycomb-beeline
+  hydra-derivatives!
   hydra-role-management
   hyrax!
   jbuilder (~> 2.5)

--- a/app/services/hyrax/derivative_service.rb
+++ b/app/services/hyrax/derivative_service.rb
@@ -14,10 +14,14 @@ class Hyrax::DerivativeService
   attr_reader :valid_services
   delegate :mime_type, :uri, to: :file_set
 
+  # OVERRIDDEN again!  Forcing self.class.services to use our service first.
+  # The initializer appears to set the var for hyrax *before* these overrides
+  # are loaded, which causes us to lose the setting, which means defaulting to
+  # the wrong value....
   def initialize(file_set)
-    self.services ||= [Hyrax::FileSetDerivativesService]
+    self.class.services = [OregonDigital::FileSetDerivativesService]
     @file_set = file_set
-    @valid_services = self.services.map { |s| s.new(file_set) }.select(&:valid?)
+    @valid_services = self.class.services.map { |s| s.new(file_set) }.select(&:valid?)
     @valid_services.empty? ? self : @valid_services
   end
 

--- a/app/services/oregon_digital/file_set_derivatives_service.rb
+++ b/app/services/oregon_digital/file_set_derivatives_service.rb
@@ -1,67 +1,111 @@
 # frozen_string_literal:true
 
 module OregonDigital
-  # Helps with the generation of file set derivatives
-  class FileSetDerivativesService
-    attr_reader :file_set
-    delegate :uri, :mime_type, to: :file_set
-
-    # @param file_set [Hyrax::FileSet] At least for this class, it must have #uri and #mime_type
-    def initialize(file_set)
-      @file_set = file_set
-    end
-
-    def valid?
-      supported_mime_types.include?(mime_type)
-    end
-
+  # Overrides the Hyrax derivative generation for our JP2 setup
+  #
+  # This builds JP2 derivatives in stages.  The openjpeg tools can't convert
+  # many formats to JP2 directly, so we make sure we have a BMP, and then
+  # convert that to JP2.  It's a bit messy and definitely inelegant, but it
+  # does the job.
+  #
+  # We also have to implement graphicsmagick-based processing to deal with the
+  # intermediary image conversions.  The Hyrax code uses MiniMagick, which
+  # doesn't work with graphicsmagick when trying to flatten an image, which
+  # Hyrax does on resize operations.  We could use ImageMagick, but for some
+  # reason it's got a limit on image size.  Huge images (say 400 megapixels)
+  # just cannot be read by it.  That may not be a problem today, but it could
+  # become one eventually.
+  #
+  # We subclass from Hyrax::FileSetDerivativesService so that we can define a
+  # single derivative service - if we have two services listed, Hyrax will fire
+  # off both, not just the first one that is successful.  So we need our JP2
+  # processing to replace the standard processor, while still holding onto the
+  # built-in Hyrax processors for derivative types we don't need to customize.
+  class FileSetDerivativesService < Hyrax::FileSetDerivativesService
     def create_derivatives(filename)
+      # This is really stupid, but rubocop actually sees this alias as being
+      # significantly simpler than just having "file_set.class" in the lines
+      # below
+      fsc = file_set.class
+
       case mime_type
-      when 'image/tiff' then create_jp2_image_derivatives(filename)
-      when 'image/jp2' then create_jp2_image_derivatives(filename)
-      else
-        create_image_derivatives(filename)
+      when *fsc.pdf_mime_types             then create_pdf_derivatives(filename)
+      when *fsc.office_document_mime_types then create_office_document_derivatives(filename)
+      when *fsc.audio_mime_types           then create_audio_derivatives(filename)
+      when *fsc.video_mime_types           then create_video_derivatives(filename)
+      when *fsc.image_mime_types           then create_image_derivatives(filename)
       end
     end
 
-    def cleanup_derivatives
-      derivative_path_factory.derivatives_for_reference(file_set).each do |path|
-        FileUtils.rm_f(path)
-      end
-    end
-
-    # The destination_name parameter has to match up with the file parameter
-    # passed to the DownloadsController
-    def derivative_url(destination_name)
-      path = derivative_path_factory.derivative_path_for_reference(file_set, destination_name)
-      URI("file://#{path}").to_s
-    end
-
-    private
-
-    def supported_mime_types
-      file_set.class.image_mime_types
-    end
-
-    def create_jp2_image_derivatives(filename)
-      Hydra::Derivatives::Jpeg2kImageDerivatives.create(filename,
-                                                        outputs: [{ label: :jp2,
-                                                                    format: 'jp2',
-                                                                    recipe: '-jp2_space sRGB',
-                                                                    processor: 'jpeg2k_image',
-                                                                    url: derivative_url('jp2') }])
-    end
-
+    # Overridden: we need our image derivatives to be 100% done our way, not the Hyrax way
     def create_image_derivatives(filename)
-      Hydra::Derivatives::ImageDerivatives.create(filename,
-                                                  outputs: [{ label: :full,
-                                                              format: 'jpg',
-                                                              url: derivative_url('jpg'),
-                                                              layer: 0 }])
+      OregonDigital::Derivatives::Image::Utils.tmp_file('bmp') do |out_path|
+        preprocess_image(filename, out_path)
+        create_thumbnail(out_path)
+        create_zoomable(out_path)
+      end
     end
 
-    def derivative_path_factory
-      Hyrax::DerivativePath
+    def create_pdf_derivatives(filename)
+      OregonDigital::Derivatives::Image::GMRunner.create(filename,
+                                                         outputs: [{ label: :thumbnail,
+                                                                     size: '120x120>',
+                                                                     format: 'jpg',
+                                                                     url: derivative_url('thumbnail'),
+                                                                     layer: 0 }])
+    end
+
+    def create_thumbnail(filename)
+      OregonDigital::Derivatives::Image::GMRunner.create(filename,
+                                                         outputs: [{ label: :thumbnail,
+                                                                     size: '120x120>',
+                                                                     format: 'jpg',
+                                                                     url: derivative_url('thumbnail'),
+                                                                     layer: 0 }])
+    end
+
+    def create_zoomable(filename)
+      OregonDigital::Derivatives::Image::JP2Runner.create(filename,
+                                                          outputs: [{ label: :jp2,
+                                                                      mime_type: mime_type,
+                                                                      url: derivative_url('jp2'),
+                                                                      tile_size: '1024',
+                                                                      compression: '20',
+                                                                      layer: 0 }])
+    end
+
+    # Pre-processes the given file to generate a BMP based on its mime type:
+    #
+    # - JP2s need to be decoded and then re-encoded by opj tools:
+    #   GraphicsMagick can't read them, and opj_compress won't re-encode an
+    #   existing JP2....
+    # - BMPs don't need an intermediate step, so they don't need any
+    #   preprocessing to happen; we fake it by hard-linking the existing BMP
+    #   so the rest of the logic works consistently
+    # - All other images need to be converted to BMP via graphicsmagick
+    def preprocess_image(source_file, temp_bmp_path)
+      case mime_type
+      when 'image/jp2' then jp2_to_bmp(source_file, temp_bmp_path)
+      when 'image/bmp' then bmp_to_bmp(source_file, temp_bmp_path)
+      else                  MiniMagick::Image.open(source_file).format('bmp').write(temp_bmp_path)
+      end
+    end
+
+    def jp2_to_bmp(source, dest)
+      source = Shellwords.escape(source)
+      dest = Shellwords.escape(dest)
+      bin = jp2_processor.opj_decompress
+      jp2_processor.execute "#{bin} -i #{source} -o #{dest}"
+    end
+
+    def bmp_to_bmp(source, dest)
+      File.unlink(dest)
+      FileUtils.ln_s(source, dest)
+    end
+
+    # Returns the JP2Processor class of choice
+    def jp2_processor
+      OregonDigital::Derivatives::Image::JP2Processor
     end
   end
 end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -282,4 +282,4 @@ Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local
 Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')
 
-Hyrax::DerivativeService.services = [Hyrax::FileSetDerivativesService, OregonDigital::FileSetDerivativesService]
+Hyrax::DerivativeService.services = [OregonDigital::FileSetDerivativesService]

--- a/config/initializers/mini_magick.rb
+++ b/config/initializers/mini_magick.rb
@@ -3,5 +3,6 @@
 require 'mini_magick'
 
 MiniMagick.configure do |config|
+  config.cli = :graphicsmagick
   config.shell_api = 'posix-spawn'
 end

--- a/lib/oregon_digital/derivatives/image/gm_processor.rb
+++ b/lib/oregon_digital/derivatives/image/gm_processor.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal:true
+
+require 'mini_magick'
+
+module OregonDigital::Derivatives::Image
+  # GraphicsMagick processor for derivatives
+  class GMProcessor < Hydra::Derivatives::Processors::Processor
+    class_attribute :timeout
+
+    def process
+      timeout ? process_with_timeout : create_image
+    end
+
+    def process_with_timeout
+      Timeout.timeout(timeout) { create_image }
+    rescue Timeout::Error
+      raise Hydra::Derivatives::TimeoutError, "Unable to process image \
+        derivative\nThe command took longer than #{timeout} seconds to execute"
+    end
+
+    def create_image
+      image = load_image(source_path)
+      OregonDigital::Derivatives::Image::Utils.tmp_file(format) do |out_path|
+        convert(image, out_path)
+        output_file_service.call(File.open(out_path, 'rb'), directives)
+      end
+    end
+
+    def load_image(path)
+      selected_layers(MiniMagick::Image.open(path))
+    end
+
+    def convert(image, outfile)
+      MiniMagick::Tool::Convert.new do |cmd|
+        cmd << image.path
+        apply_convert_commands(cmd)
+        cmd << "#{format}:#{outfile}"
+      end
+    end
+
+    def apply_convert_commands(cmd)
+      if size
+        cmd.flatten
+        cmd.resize(size)
+      end
+      cmd.quality(quality.to_s) if quality
+    end
+
+    def size
+      directives.fetch(:size, nil)
+    end
+
+    def quality
+      directives.fetch(:quality, nil)
+    end
+
+    def format
+      directives.fetch(:format, 'jpg')
+    end
+
+    def selected_layers(image)
+      if image.type.match?(/pdf/i)
+        image.layers[directives.fetch(:layer, 0)]
+      elsif directives.fetch(:layer, false)
+        image.layers[directives.fetch(:layer)]
+      else
+        image
+      end
+    end
+  end
+end

--- a/lib/oregon_digital/derivatives/image/gm_runner.rb
+++ b/lib/oregon_digital/derivatives/image/gm_runner.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal:true
+
+module OregonDigital::Derivatives::Image
+  # Tells hydra which processor to use for graphicsmagick processing
+  class GMRunner < Hydra::Derivatives::Runner
+    def self.processor_class
+      GMProcessor
+    end
+  end
+end

--- a/lib/oregon_digital/derivatives/image/jp2_processor.rb
+++ b/lib/oregon_digital/derivatives/image/jp2_processor.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal:true
+
+require 'mini_magick'
+require 'tempfile'
+
+module OregonDigital::Derivatives::Image
+  # OpenJP2 processor for derivatives
+  class JP2Processor < Hydra::Derivatives::Processors::Processor
+    include Hydra::Derivatives::Processors::ShellBasedProcessor
+
+    class << self
+      attr_writer :opj_compress, :opj_decompress
+
+      def opj_compress
+        @opj_compress ||= 'opj_compress'
+      end
+
+      def opj_decompress
+        @opj_decompress ||= 'opj_decompress'
+      end
+
+      def opj_compress_recipe(args, long_dim)
+        if args[:recipe].is_a? String
+          args[:recipe]
+        else
+          calculate_recipe(args, long_dim)
+        end
+      end
+
+      def calculate_recipe(args, long_dim)
+        levels_arg = args.fetch(:levels, level_count_for_size(long_dim))
+        rates_arg = args.fetch(:compression, 10)
+        tile_size = args.fetch(:tile_size, 1024)
+        tiles_arg = "#{tile_size},#{tile_size}"
+
+        "-n #{levels_arg} -r #{rates_arg} -t #{tiles_arg}"
+      end
+
+      def level_count_for_size(long_dim)
+        Math.log2(long_dim / 96).floor
+      end
+
+      def encode(path, recipe, output_file)
+        execute "#{opj_compress} \
+          -i #{Shellwords.escape(path)} \
+          -o #{output_file} #{recipe}"
+      end
+    end
+
+    def calc_long_dim(image)
+      [image[:width], image[:height]].max
+    end
+
+    def process
+      image = MiniMagick::Image.open(source_path)
+      recipe = self.class.opj_compress_recipe(directives, calc_long_dim(image))
+
+      OregonDigital::Derivatives::Image::Utils.tmp_file('jp2') do |out_path|
+        self.class.encode(source_path, recipe, out_path)
+        output_file_service.call(File.open(out_path, 'rb'), directives)
+      end
+    end
+  end
+end

--- a/lib/oregon_digital/derivatives/image/jp2_runner.rb
+++ b/lib/oregon_digital/derivatives/image/jp2_runner.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal:true
+
+module OregonDigital::Derivatives::Image
+  # Tells hydra which processor to use for openjp2 processing
+  class JP2Runner < Hydra::Derivatives::Runner
+    def self.processor_class
+      JP2Processor
+    end
+  end
+end

--- a/lib/oregon_digital/derivatives/image/utils.rb
+++ b/lib/oregon_digital/derivatives/image/utils.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal:true
+
+module OregonDigital::Derivatives::Image
+  # Simple derivative utility functions
+  class Utils
+    class << self
+      # Generates a temporary file and passes its path to the given block.  The
+      # file is deleted at the end of execution
+      def tmp_file(ext)
+        f = Tempfile.new(['od2', ".#{ext}"], Hydra::Derivatives.temp_file_base)
+        begin
+          yield f.path
+        ensure
+          f.close
+          f.unlink
+        end
+      end
+    end
+  end
+end

--- a/spec/oregon_digital/derivatives/image/gm_runner_spec.rb
+++ b/spec/oregon_digital/derivatives/image/gm_runner_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal:true
+
+RSpec.describe OregonDigital::Derivatives::Image::GMRunner do
+  let(:source) { "#{Rails.root}/spec/fixtures/test.jpg" }
+
+  describe '#create' do
+    context 'when creating a png thumbnail' do
+      subject do
+        outfile = '/tmp/foo.png'
+        described_class.create(source,
+                               outputs: [
+                                 { label: :thumb,
+                                   size: '120x120>',
+                                   format: 'png',
+                                   url: URI("file://#{outfile}"),
+                                   layer: 0 }
+                               ])
+        MiniMagick::Image.open(outfile)
+      end
+
+      it { is_expected.to have_attributes(type: 'PNG') }
+      it { is_expected.to have_attributes(width: 120) }
+      it { is_expected.to have_attributes(height: 79) }
+    end
+  end
+end

--- a/spec/oregon_digital/derivatives/image/jp2_runner_spec.rb
+++ b/spec/oregon_digital/derivatives/image/jp2_runner_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal:true
+
+RSpec.describe OregonDigital::Derivatives::Image::JP2Runner do
+  let(:fixture) { "#{Rails.root}/spec/fixtures/test.jpg" }
+  let(:source) do
+    f = Tempfile.new(['od2-test', '.bmp'])
+    p = f.path
+    f.close
+    f.unlink
+    p
+  end
+
+  describe '#create' do
+    before do
+      # GraphicsMagick can't read the JP2.  ImageMagick can't deal with huge
+      # images, which is why we use GM by default, but in the case of this
+      # test, we don't have a huge image.
+      #
+      # Why a configure block?  #with_cli is not working.  Not sure why.
+      MiniMagick.configure do |config|
+        config.cli = :imagemagick
+      end
+
+      # Now even more fun: convert our test.jpg into a BMP because
+      # opj_decompress doesn't do jpg directly, and we don't really want to add
+      # a 500k file just for this one test
+      MiniMagick::Image.open(fixture).format('bmp').write(source)
+    end
+
+    subject do
+      outfile = '/tmp/foo.jp2'
+      described_class.create(source,
+                             outputs: [
+                               { label: :jp2,
+                                 mime_type: 'image/jpeg',
+                                 tile_size: 1024,
+                                 compression: 1,
+                                 url: URI("file://#{outfile}"),
+                                 layer: 0 }
+                             ])
+      MiniMagick::Image.open(outfile)
+    end
+
+    it { is_expected.to have_attributes(type: 'JP2') }
+    it { is_expected.to have_attributes(width: 520) }
+    it { is_expected.to have_attributes(height: 343) }
+  end
+end

--- a/spec/services/oregon_digital/file_set_derivatives_service_spec.rb
+++ b/spec/services/oregon_digital/file_set_derivatives_service_spec.rb
@@ -7,37 +7,140 @@ RSpec.describe OregonDigital::FileSetDerivativesService do
 
   let(:service) { described_class.new(valid_file_set) }
   let(:mime_type) { 'image/tiff' }
+  let(:uri) { 'http://example.org/1/2/3/foo' }
   let(:valid_file_set) do
     FileSet.new.tap do |f|
       allow(f).to receive(:mime_type).and_return(mime_type)
+      allow(f).to receive(:uri).and_return(uri)
     end
   end
 
   it_behaves_like 'a Hyrax::DerivativeService'
 
-  it 'processes a tiff into a jp2' do
-    allow(service).to receive(:create_jp2_image_derivatives).and_return true
-    expect(service).to receive(:create_jp2_image_derivatives)
-    service.create_derivatives('bogus/file_path/image.tiff')
-  end
+  describe '#create_derivatives' do
+    [
+      [FileSet.pdf_mime_types,             :create_pdf_derivatives],
+      [FileSet.office_document_mime_types, :create_office_document_derivatives],
+      [FileSet.audio_mime_types,           :create_audio_derivatives],
+      [FileSet.video_mime_types,           :create_video_derivatives],
+      [FileSet.image_mime_types,           :create_image_derivatives]
+    ].each do |mimes, callee|
+      mimes.each do |mime|
+        context "with a #{mime} source" do
+          let(:mime_type) { mime }
+          let(:callee) { callee }
 
-  context 'with a jp2' do
-    let(:mime_type) { 'image/jp2' }
-
-    it 'processes the image' do
-      allow(service).to receive(:create_jp2_image_derivatives).and_return true
-      expect(service).to receive(:create_jp2_image_derivatives)
-      service.create_derivatives('bogus/file_path/image.jp2')
+          it "runs #{callee}" do
+            allow(service).to receive(callee).and_return true
+            expect(service).to receive(callee).once
+            service.create_derivatives('bogus/file/path')
+          end
+        end
+      end
     end
   end
 
-  context 'with images other than tiff or jp2' do
-    let(:mime_type) { 'image/gif' }
+  describe '#create_image_derivatives' do
+    let(:bogus_jpg) { '/bogus/path/to/file.jpg' }
+    let(:tmp_bmp) { '/tmp/path/to/file.bmp' }
 
-    it 'processes the image' do
-      allow(service).to receive(:create_image_derivatives).and_return true
-      expect(service).to receive(:create_image_derivatives)
-      service.create_derivatives('bogus/file_path/image.gif')
+    before do
+      allow(OregonDigital::Derivatives::Image::Utils).to receive(:tmp_file).with('bmp').and_yield(tmp_bmp)
+      allow(service).to receive(:preprocess_image)
+      allow(service).to receive(:create_thumbnail)
+      allow(service).to receive(:create_zoomable)
+    end
+
+    it 'preprocesses the image' do
+      expect(service).to receive(:preprocess_image).with(bogus_jpg, tmp_bmp)
+      service.create_image_derivatives(bogus_jpg)
+    end
+
+    it 'creates a thumbnail from the bitmap' do
+      expect(service).to receive(:create_thumbnail).with(tmp_bmp)
+      service.create_image_derivatives(bogus_jpg)
+    end
+
+    it 'creates a zoomable image from the bitmap' do
+      expect(service).to receive(:create_zoomable).with(tmp_bmp)
+      service.create_image_derivatives(bogus_jpg)
+    end
+  end
+
+  describe '#preprocess_image' do
+    let(:source) { '/bogus/path/to/file.xyzzy' }
+    let(:tmp_bmp) { '/tmp/path/to/file.bmp' }
+
+    context 'with a JP2' do
+      let(:mime_type) { 'image/jp2' }
+
+      it 'runs the jp2 preprocessor to generate the bmp' do
+        expect(service).to receive(:jp2_to_bmp).with(source, tmp_bmp)
+        service.preprocess_image(source, tmp_bmp)
+      end
+    end
+
+    context 'with a BMP' do
+      let(:mime_type) { 'image/bmp' }
+
+      it 'runs the bmp preprocessor to generate the bmp' do
+        expect(service).to receive(:bmp_to_bmp).with(source, tmp_bmp)
+        service.preprocess_image(source, tmp_bmp)
+      end
+    end
+
+    (FileSet.image_mime_types - ['image/jp2', 'image/bmp']).each do |mime|
+      context "with a #{mime}" do
+        let(:mime_type) { mime }
+        let(:minimagick) { double }
+
+        before do
+          allow(MiniMagick::Image).to receive(:open).with(source).and_return(minimagick)
+          allow(minimagick).to receive(:format).with('bmp').and_return(minimagick)
+          allow(minimagick).to receive(:write).with(tmp_bmp)
+        end
+
+        it 'runs minimagick to generate a bmp' do
+          expect(minimagick).to receive(:write).with(tmp_bmp)
+          service.preprocess_image(source, tmp_bmp)
+        end
+      end
+    end
+  end
+
+  describe '#jp2_to_bmp' do
+    let(:processor) { double }
+
+    before do
+      allow(service).to receive(:jp2_processor).and_return(processor)
+      allow(processor).to receive(:opj_decompress).and_return('tool')
+    end
+
+    it "runs the processor's execute method" do
+      expect(processor).to receive(:execute).with('tool -i foo.jp2 -o bar.bmp')
+      service.jp2_to_bmp('foo.jp2', 'bar.bmp')
+    end
+
+    it 'escapes shell-dangerous source and destinations' do
+      expect(processor).to receive(:execute).with('tool -i foo\"bar -o baz\ \|\|\ exit\ 1')
+      service.jp2_to_bmp('foo"bar', 'baz || exit 1')
+    end
+  end
+
+  describe '#bmp_to_bmp' do
+    before do
+      allow(File).to receive(:unlink).with('tmp.bmp')
+      allow(FileUtils).to receive(:ln_s).with('orig.bmp', 'tmp.bmp')
+    end
+
+    it 'removes the temp file' do
+      expect(File).to receive(:unlink).with('tmp.bmp')
+      service.bmp_to_bmp('orig.bmp', 'tmp.bmp')
+    end
+
+    it 'symlinks the source bmp' do
+      expect(FileUtils).to receive(:ln_s).with('orig.bmp', 'tmp.bmp')
+      service.bmp_to_bmp('orig.bmp', 'tmp.bmp')
     end
   end
 end


### PR DESCRIPTION
Addresses part of #145.  All image sources give us zoomable JP2 images without kakadu.  This breaks the PDF processor, however, because that's still trying to go through the Hyrax layer.  The Hyrax layer uses minimagick with assumptions that the base process will be ImageMagick.  We have to use GraphicsMagick because (at the moment) ImageMagick crashes on huge files.

<s>I request that, on merge, the commits stay as-is, not be squashed.  There is some value in the three minor commits not being smashed into the big bomb.</s>

This is flagged as "draft" because I still want to see if I can get PDFs to a state where they at least don't crash.  I'm not sure about getting them fully implemented with our custom logic (at least not as soon as I'd like), but I would like to get them to not crash.