### PR TITLE
Remove query string from SAML callback url

### DIFF
--- a/config/initializers/hacks/omniauth_strategies_saml.rb
+++ b/config/initializers/hacks/omniauth_strategies_saml.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal:true
+
+OmniAuth::Strategies::SAML.class_eval do
+  def callback_url
+    # Remove query_string to keep omniauth-saml from append query_string to SAML metadata
+    full_host + script_name + callback_path
+  end
+end


### PR DESCRIPTION
Fully fixes #173

Removing query_string from the SAML callback URL forces `AssertionConsumerService` in the SAML metadata to always match `AssertionConsumerServiceURL` in the request to the IDP.