### PR TITLE
Force index strategy to be defined in metadata concerns

### DIFF
--- a/app/indexers/oregon_digital/deep_indexing_service.rb
+++ b/app/indexers/oregon_digital/deep_indexing_service.rb
@@ -6,9 +6,8 @@ module OregonDigital
   # Used to index linked data
   class DeepIndexingService < Hyrax::DeepIndexingService
     class_attribute :stored_and_facetable_fields, :stored_fields, :symbol_fields
-    self.stored_and_facetable_fields = %i[license]
-    self.stored_fields = OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym)
-    self.stored_fields -= %i[license]
+    self.stored_and_facetable_fields = %i[]
+    self.stored_fields = %i[]
     self.symbol_fields = %i[]
   end
 end

--- a/app/indexers/oregon_digital/metadata_indexer.rb
+++ b/app/indexers/oregon_digital/metadata_indexer.rb
@@ -3,10 +3,8 @@
 module OregonDigital
   # OVERRIDE FROM HYRAX TO ADD OUR OWN FIELDS
   class MetadataIndexer < Hyrax::BasicMetadataIndexer
-    class_attribute :stored_and_facetable_fields, :stored_fields, :symbol_fields
-    self.stored_and_facetable_fields = %i[license]
-    self.stored_fields = OregonDigital::GenericMetadata::PROPERTIES.map(&:to_sym)
-    self.stored_fields -= %i[license]
+    self.stored_and_facetable_fields = %i[]
+    self.stored_fields = %i[]
     self.symbol_fields = %i[]
   end
 end

--- a/app/models/concerns/oregon_digital/generic_metadata.rb
+++ b/app/models/concerns/oregon_digital/generic_metadata.rb
@@ -13,17 +13,29 @@ module OregonDigital
       property :label, predicate: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, multiple: false
       property :relative_path, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#relativePath'), multiple: false
       property :import_url, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#importUrl'), multiple: false
-      property :resource_type, predicate: ::RDF::Vocab::DC.type
-      property :creator, predicate: ::RDF::Vocab::DC11.creator
-      property :contributor, predicate: ::RDF::Vocab::DC11.contributor
-      property :date_created, predicate: ::RDF::Vocab::DC.created
+      property :resource_type, predicate: ::RDF::Vocab::DC.type do |index|
+        index.as :stored_searchable, :facetable
+      end
+      property :creator, predicate: ::RDF::Vocab::DC11.creator do |index|
+        index.as :stored_searchable, :facetable
+      end
+      property :contributor, predicate: ::RDF::Vocab::DC11.contributor do |index|
+        index.as :stored_searchable, :facetable
+      end
+      property :date_created, predicate: ::RDF::Vocab::DC.created do |index|
+        index.as :stored_searchable
+      end
 
       property :description, predicate: ::RDF::Vocab::DC.description do |index|
         index.as :stored_searchable
       end
 
-      property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
-      property :identifier, predicate: ::RDF::Vocab::DC.identifier
+      property :rights_statement, predicate: ::RDF::Vocab::EDM.rights do |index|
+        index.as :stored_searchable
+      end
+      property :identifier, predicate: ::RDF::Vocab::DC.identifier do |index|
+        index.as :stored_searchable
+      end
 
       property :alternative, predicate: ::RDF::Vocab::DC.alternative do |index|
         index.as :stored_searchable
@@ -566,7 +578,9 @@ module OregonDigital
       end
 
       # Controlled vocabulary terms
-      property :based_near, predicate: ::RDF::Vocab::FOAF.based_near, class_name: Hyrax::ControlledVocabularies::Location
+      property :based_near, predicate: ::RDF::Vocab::FOAF.based_near, class_name: Hyrax::ControlledVocabularies::Location do |index|
+        index.as :stored_searchable, :facetable
+      end
       property :ethnographic_term, predicate: ::RDF::URI.new('http://opaquenamespace.org/ns/ethnographic'),
                                    class_name: OregonDigital::ControlledVocabularies::EthnographicTerm do |index|
         index.as :stored_searchable, :facetable

--- a/app/models/concerns/oregon_digital/generic_metadata.rb
+++ b/app/models/concerns/oregon_digital/generic_metadata.rb
@@ -31,7 +31,7 @@ module OregonDigital
       end
 
       property :rights_statement, predicate: ::RDF::Vocab::EDM.rights do |index|
-        index.as :stored_searchable
+        index.as :stored_searchable, :facetable
       end
       property :identifier, predicate: ::RDF::Vocab::DC.identifier do |index|
         index.as :stored_searchable

--- a/app/search_builders/oregon_digital/oembed_search_builder.rb
+++ b/app/search_builders/oregon_digital/oembed_search_builder.rb
@@ -15,7 +15,7 @@ module OregonDigital
 
     def only_oembed(solr_params)
       solr_params[:fq] ||= []
-      solr_params[:fq] << 'oembed_url_tesim:*'
+      solr_params[:fq] << 'oembed_url_sim:*'
     end
   end
 end

--- a/spec/search_builders/oregon_digital/oembed_search_builder_spec.rb
+++ b/spec/search_builders/oregon_digital/oembed_search_builder_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe OregonDigital::OembedSearchBuilder do
 
     before { search_builder.only_oembed(processor_chain) }
 
-    it { is_expected.to eq(fq: ['oembed_url_tesim:*']) }
+    it { is_expected.to eq(fq: ['oembed_url_sim:*']) }
   end
 end


### PR DESCRIPTION
Fixes #397 by defaulting all metadata to the indexing methods defined in the metadata concerns. eg: https://github.com/OregonDigital/OD2/blob/master/app/models/concerns/oregon_digital/generic_metadata.rb#L22