### PR TITLE
Increase QA redirect limit

### DIFF
--- a/lib/oregon_digital/authorities/web_service_redirect.rb
+++ b/lib/oregon_digital/authorities/web_service_redirect.rb
@@ -12,7 +12,7 @@ module OregonDigital::Authorities
     # @return [Faraday::Response]
     def response(url)
       connection = Faraday.new(url) do |b|
-        b.use FaradayMiddleware::FollowRedirects
+        b.use FaradayMiddleware::FollowRedirects, limit: 5
         b.adapter :net_http
       end
       connection.get { |req| req.headers['Accept'] = 'application/json' }

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/spar_media_type.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/spar_media_type.rb
@@ -5,7 +5,7 @@ module OregonDigital
     # Receives information pulled from the endpoint and can parse and generate queries
     class SparMediaType
       def self.expression
-        %r{^http[s]?:\/\/w3id.org\/spar\/mediatype\/.*/.*}
+        %r{^https:\/\/w3id.org\/spar\/mediatype\/.*/.*}
       end
 
       def self.label(data)


### PR DESCRIPTION
Fixes #391 

The original ticket mentions the issue occurs when the Sparonotolgy endpoint is hit with http. Turns out this breaks our term matching after the redirect limit is raised.