### PR TITLE
Use POST method to query solr

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -25,6 +25,7 @@ class CatalogController < ApplicationController
     config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
     config.show.partials.insert(1, :openseadragon)
     config.search_builder_class = Hyrax::CatalogSearchBuilder
+    config.http_method = :post
 
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {


### PR DESCRIPTION
Fixes #463 
We use FAR too much metadata to query via GET.
https://github.com/rsolr/rsolr#using-post-for-search-queries Here's some docs about the underlying Rsolr details.
https://github.com/projectblacklight/blacklight/blob/master/lib/generators/blacklight/templates/catalog_controller.rb And the config in Blacklight this changes.