### PR TITLE
fix location

### DIFF
--- a/app/authorities/qa/authorities/extended_geonames.rb
+++ b/app/authorities/qa/authorities/extended_geonames.rb
@@ -13,6 +13,8 @@ module Qa::Authorities
 
     # Reformats the data received from the service
     def parse_authority_response(response)
+      Rails.logger.info "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+      Rails.logger.info response
       response['geonames'].map do |result|
         # Note: the trailing slash is meaningful.
         { 'id' => "http://sws.geonames.org/#{result['geonameId']}/",

--- a/app/authorities/qa/authorities/extended_geonames.rb
+++ b/app/authorities/qa/authorities/extended_geonames.rb
@@ -13,8 +13,6 @@ module Qa::Authorities
 
     # Reformats the data received from the service
     def parse_authority_response(response)
-      Rails.logger.info "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-      Rails.logger.info response
       response['geonames'].map do |result|
         # Note: the trailing slash is meaningful.
         { 'id' => "http://sws.geonames.org/#{result['geonameId']}/",

--- a/app/models/generic.rb
+++ b/app/models/generic.rb
@@ -6,7 +6,7 @@ class Generic < ActiveFedora::Base
   attr_writer :graph_fetch_failures
 
   # before_create :prefetch_graphs
-  before_save :resolve_oembed_errors, :prefetch_graphs
+  before_save :resolve_oembed_errors
 
   self.indexer = GenericIndexer
   # Change this to restrict which works can be added as a child.


### PR DESCRIPTION
Fixes #392 

There were some left over pieces of code, that were causing a graph to be loaded before fedora.
![location](https://user-images.githubusercontent.com/6424683/55980742-f5ef9d00-5c49-11e9-92a8-0b0efdf560c9.gif)
