### PR TITLE
Enable facets on collections search

### DIFF
--- a/config/initializers/hacks/hyrax_collections_controller_behavior.rb
+++ b/config/initializers/hacks/hyrax_collections_controller_behavior.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal:true
+
+Hyrax::CollectionsControllerBehavior.module_eval do
+  # Remove :f (facets) from single item search to allow collection to verify user access
+  def single_item_search_builder
+    single_item_search_builder_class.new(self).with(params.except(:f, :q, :page))
+  end
+end


### PR DESCRIPTION
Fixes #531 
Facets work similar to catalog controller, but may need to be altered further once we figure out how to display facets on the search page. In particular, https://github.com/samvera/hyrax/blob/master/app/controllers/concerns/hyrax/collections_controller_behavior.rb#L105 may need to include merging a new facets query string