### PR TITLE
Add Blacklight facets to collections search page

### DIFF
--- a/app/views/hyrax/collections/_facets.html.erb
+++ b/app/views/hyrax/collections/_facets.html.erb
@@ -17,7 +17,7 @@
 
   <%# OVERRIDE FROM BLACKLIGHT to limit customize which facets are displayed %>
   <div id="facet-panel-collapse" class="collapse panel-group">
-    <%= render_facet_partials %>
+    <%= render_facet_partials @configured_facets %>
   </div>
 </div>
 <% end %>

--- a/app/views/hyrax/collections/_facets.html.erb
+++ b/app/views/hyrax/collections/_facets.html.erb
@@ -1,0 +1,23 @@
+<% # main container for facets/limits menu -%>
+<% if has_facet_values?  %>
+<div id="facets" class="facets sidenav">
+
+  <div class="top-panel-heading panel-heading">
+    <button type="button" class="facets-toggle" data-toggle="collapse" data-target="#facet-panel-collapse">
+      <span class="sr-only">Toggle facets</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+
+    <h2 class='facets-heading'>
+      <%= t('blacklight.search.facets.title') %>
+    </h2>
+  </div>
+
+  <%# OVERRIDE FROM BLACKLIGHT to limit customize which facets are displayed %>
+  <div id="facet-panel-collapse" class="collapse panel-group">
+    <%= render_facet_partials %>
+  </div>
+</div>
+<% end %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -1,0 +1,130 @@
+<% provide :page_title, construct_page_title(@presenter.title) %>
+<div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">
+  <div class="row hyc-header">
+    <div class="col-md-12">
+
+      <% unless @presenter.banner_file.blank? %>
+          <header class="hyc-banner" style="background-image:url(<%= @presenter.banner_file %>)">
+      <% else %>
+          <header class="hyc-generic">
+      <% end %>
+
+      <div class="hyc-title">
+        <h1><%= @presenter.title.first %></h1>
+        <%= @presenter.collection_type_badge %>
+        <%= @presenter.permission_badge %>
+      </div>
+
+      <% unless @presenter.logo_record.blank? %>
+          <div class="hyc-logos">
+            <% @presenter.logo_record.each_with_index  do |lr, i| %>
+
+                <% if lr[:linkurl].blank? %>
+                    <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" />
+                <% else %>
+                    <a href="<%= lr[:linkurl] %>">
+                      <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" />
+                    </a>
+                <% end %>
+
+            <% end %>
+          </div>
+      <% end %>
+
+      <% unless @presenter.total_viewable_items.blank? %>
+          <div class="hyc-bugs">
+            <div class="hyc-item-count">
+              <b><%= @presenter.total_viewable_items %></b>
+              <%= 'Item'.pluralize(@presenter.total_viewable_items) %></div>
+
+            <% unless @presenter.creator.blank? %>
+                <div class="hyc-created-by">Created by: <%= @presenter.creator.first %></div>
+            <% end %>
+
+            <% unless @presenter.modified_date.blank? %>
+                <div class="hyc-last-updated">Last Updated: <%= @presenter.modified_date %></div>
+            <% end %>
+          </div>
+      <% end %>
+
+      </header>
+
+    </div>
+  </div>
+
+  <div class="row hyc-body">
+    <div class="col-md-8 hyc-description">
+      <%= render 'collection_description', presenter: @presenter %>
+
+      <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
+          <div class="hyc-blacklight hyc-bl-title">
+            <h2>
+              <%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)
+            </h2>
+          </div>
+          <div class="hyc-blacklight hyc-bl-results">
+            <%= render 'show_parent_collections', presenter: @presenter %>
+          </div>
+      <% end %>
+
+    </div>
+    <div class="col-md-4 hyc-metadata">
+      <% unless has_collection_search_parameters? %>
+          <h2><%= t('hyrax.dashboard.collections.show.metadata_header') %></h2>
+          <%= render 'show_descriptions' %>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- Search results label -->
+  <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
+    <div class="hyc-blacklight hyc-bl-title">
+      <h2>
+        <% if has_collection_search_parameters? %>
+            <%= t('hyrax.dashboard.collections.show.search_results') %>
+        <% end %>
+      </h2>
+    </div>
+  <% end %>
+
+  <!-- Search bar -->
+  <div class="hyc-blacklight hyc-bl-search hyc-body row">
+    <div class="col-sm-8">
+      <%= render 'search_form', presenter: @presenter, url: hyrax.collection_path(@presenter.id) %>
+    </div>
+  </div>
+
+  <!-- Subcollections -->
+  <% if @presenter.collection_type_is_nestable? && @subcollection_count > 0 %>
+      <div class="hyc-blacklight hyc-bl-title">
+        <h4><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h4>
+      </div>
+      <div class="hyc-blacklight hyc-bl-results">
+        <%= render 'subcollection_list', collection: @subcollection_docs %>
+      </div>
+  <% end %>
+
+  <!-- Works -->
+  <% if @members_count > 0 %>
+      <div class="hyc-blacklight hyc-bl-title">
+        <h4><%= t('.works_in_collection') %> (<%= @members_count %>)</h4>
+      </div>
+
+      <div class="hyc-blacklight hyc-bl-sort">
+        <%= render 'sort_and_per_page', collection: @presenter %>
+      </div>
+
+      <%# OVERRIDE FROM HYRAX to add search sidebar from Blacklight %>
+      <div class="hyc-blacklight hyc-bl-results col-md-9 col-md-push-3 col-sm-8 col-sm-push-4">
+        <%= render_document_index @member_docs %>
+      </div>
+
+      <div class="hyc-blacklight hyc-bl-facets col-md-3 col-md-pull-9 col-sm-4 col-sm-pull-8">
+        <%= render 'search_sidebar' %>
+      </div>
+
+      <div class="hyc-blacklight hyc-bl-pager">
+        <%= render 'paginate' %>
+      </div>
+  <% end # if @members_count > 0 %>
+</div>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -119,9 +119,11 @@
         <%= render_document_index @member_docs %>
       </div>
 
+      <% unless @configured_facets.empty? %>
       <div class="hyc-blacklight hyc-bl-facets col-md-3 col-md-pull-9 col-sm-4 col-sm-pull-8">
         <%= render 'search_sidebar' %>
       </div>
+      <% end %>
 
       <div class="hyc-blacklight hyc-bl-pager">
         <%= render 'paginate' %>

--- a/config/initializers/hacks/hyrax_collections_controller_behavior.rb
+++ b/config/initializers/hacks/hyrax_collections_controller_behavior.rb
@@ -5,4 +5,9 @@ Hyrax::CollectionsControllerBehavior.module_eval do
   def single_item_search_builder
     single_item_search_builder_class.new(self).with(params.except(:f, :q, :page))
   end
+
+  # Point Blacklight searching to collection route
+  def search_action_url options = {}
+    hyrax.collection_url(options.except(:controller, :action))
+  end
 end

--- a/config/initializers/hacks/hyrax_collections_controller_behavior.rb
+++ b/config/initializers/hacks/hyrax_collections_controller_behavior.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal:true
 
 Hyrax::CollectionsControllerBehavior.module_eval do
+  # OVERRIDE FROM HYRAX
   # Remove :f (facets) from single item search to allow collection to verify user access
   def single_item_search_builder
     single_item_search_builder_class.new(self).with(params.except(:f, :q, :page))
   end
 
+  # OVERRIDE FROM HYRAX
   def show
     @curation_concern ||= ActiveFedora::Base.find(params[:id])
+    # Set list of configured facets for the view to display
     configured_facets
     presenter
     query_collection_members
@@ -15,6 +18,7 @@ Hyrax::CollectionsControllerBehavior.module_eval do
 
   private
 
+    # OVERRIDE FROM HYRAX
     # Point Blacklight searching to collection route
     def search_action_url options = {}
       hyrax.collection_url(options.except(:controller, :action))

--- a/config/initializers/hacks/hyrax_collections_controller_behavior.rb
+++ b/config/initializers/hacks/hyrax_collections_controller_behavior.rb
@@ -6,8 +6,21 @@ Hyrax::CollectionsControllerBehavior.module_eval do
     single_item_search_builder_class.new(self).with(params.except(:f, :q, :page))
   end
 
-  # Point Blacklight searching to collection route
-  def search_action_url options = {}
-    hyrax.collection_url(options.except(:controller, :action))
+  def show
+    @curation_concern ||= ActiveFedora::Base.find(params[:id])
+    configured_facets
+    presenter
+    query_collection_members
   end
+
+  private
+
+    # Point Blacklight searching to collection route
+    def search_action_url options = {}
+      hyrax.collection_url(options.except(:controller, :action))
+    end
+
+    def configured_facets
+      @configured_facets ||= []
+    end
 end


### PR DESCRIPTION
Fixes #532.
Display facets exactly as catalog search page does, from Blacklight.
`_facets.html.erb` isn't necessary yet, but will require changes once we can get a list of facets to display for the collection.

Preview of collections search page:
![image](https://user-images.githubusercontent.com/11052958/58129832-861cec80-7bcf-11e9-94b1-ca26af3d7cfe.png)
