### PR TITLE
Add configurable facets to collections edit form

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require blacklight/blacklight
 
 //= require_directory .
+//= require_tree ./oregon_digital
 //= require hyrax
 
 // Required for Hyrax override in assets/javascripts/hyrax/editor/controlled_vocabulary.es6

--- a/app/assets/javascripts/oregon_digital/collections/configurable_facets.js
+++ b/app/assets/javascripts/oregon_digital/collections/configurable_facets.js
@@ -3,21 +3,58 @@ jQuery.fn.extend({
   ksortable: function (options) {
     this.sortable(options);
     $('li', this).attr('tabindex', 0).bind('keydown', function (event) {
-      if (event.which == 37 || event.which == 38) { // left or up
-        $(this).insertBefore($(this).prev());
-        $(this).focus();
+      // Quit out if focus is in a child element (form inputs)
+      if (event.currentTarget != event.target) return;
+      // Overwrite default behavior so users aren't scrolling all over the place
+      // Quit out if this isn't a key we care about
+      switch(event.which) {
+        case 32: //space
+        case 13: //enter
+        case 37: //left
+        case 38: //up
+        case 39: //right
+        case 40: //down
+        case 33: //page-up
+        case 34: //page-down
+          event.preventDefault();
+          break;
+        default:
+          return;
       }
-      if (event.which == 39 || event.which == 40) { // right or down
-        $(this).insertAfter($(this).next());
-        $(this).focus();
+
+      // Select this element, show the user, and stop spamming aria-describedby on move
+      if (event.which == 32 || event.which == 13) { // spacebar or enter
+        $(this).toggleClass('facet-selected');
+        $(this).attr('aria-describedby', function(i, attr) {
+          return attr == 'facets-instructions' ? '' : 'facets-instructions';
+        });
       }
-      if (event.which == 33) { // page-up
-        $(this).parent().prepend($(this));
+
+      // Only apply changes if the element is selected
+      if ($(this).hasClass('facet-selected')) {
+        if (event.which == 37 || event.which == 38) { // left or up
+          $(this, 'label')
+          $(this).insertBefore($(this).prev());
+        }
+        if (event.which == 39 || event.which == 40) { // right or down
+          $(this).insertAfter($(this).next());
+        }
+        if (event.which == 33) { // page-up
+          $(this).parent().prepend($(this));
+        }
+        if (event.which == 34) { // page-down
+          $(this).parent().append($(this));
+        }
         $(this).focus();
+        updateLive(this);
       }
-      if (event.which == 34) { // page-down
-        $(this).parent().append($(this));
-        $(this).focus();
+
+      // Update the aria-live element to describe the current element and it's position in the list
+      function updateLive(elem) {
+        itemLabel = $($(elem).children('label')[0]).text();
+        listCount = $(elem).parent().children('li').length;
+        listIndex = $(elem).parent().children('li').index(elem) + 1;
+        $('#facets-live').text(`${itemLabel} grabbed. Position in list: ${listIndex} of ${listCount}`);
       }
     });
   }

--- a/app/assets/javascripts/oregon_digital/collections/configurable_facets.js
+++ b/app/assets/javascripts/oregon_digital/collections/configurable_facets.js
@@ -1,5 +1,30 @@
+// Add keyboard controls to jQuery.sortable()
+jQuery.fn.extend({
+  ksortable: function (options) {
+    this.sortable(options);
+    $('li', this).attr('tabindex', 0).bind('keydown', function (event) {
+      if (event.which == 37 || event.which == 38) { // left or up
+        $(this).insertBefore($(this).prev());
+        $(this).focus();
+      }
+      if (event.which == 39 || event.which == 40) { // right or down
+        $(this).insertAfter($(this).next());
+        $(this).focus();
+      }
+      if (event.which == 33) { // page-up
+        $(this).parent().prepend($(this));
+        $(this).focus();
+      }
+      if (event.which == 34) { // page-down
+        $(this).parent().append($(this));
+        $(this).focus();
+      }
+    });
+  }
+});
+
 $('#sortable_facets').ready(function () {
-  $('#sortable_facets').sortable({
+  $('#sortable_facets').ksortable({
     revert: 100,
     axis: 'y',
     containment: '#sortable_facets',

--- a/app/assets/javascripts/oregon_digital/collections/configurable_facets.js
+++ b/app/assets/javascripts/oregon_digital/collections/configurable_facets.js
@@ -1,7 +1,9 @@
 $('#sortable_facets').ready(function () {
   $('#sortable_facets').sortable({
-    containment: '#sortable_facets',
+    revert: 100,
     axis: 'y',
+    containment: '#sortable_facets',
+    handle: '.handle',
     tolerance: 'touch',
     update: function (e, ui) {
       console.log($('#sortable_facets').sortable('serialize'));

--- a/app/assets/javascripts/oregon_digital/collections/configurable_facets.js
+++ b/app/assets/javascripts/oregon_digital/collections/configurable_facets.js
@@ -1,0 +1,16 @@
+$('#sortable_facets').ready(function () {
+  $('#sortable_facets').sortable({
+    containment: '#sortable_facets',
+    axis: 'y',
+    tolerance: 'touch',
+    update: function (e, ui) {
+      console.log($('#sortable_facets').sortable('serialize'));
+      $('#facet_configuration').val($('#sortable_facets').sortable('serialize'));
+    }
+  });
+  $('#sortable_facets').disableSelection();
+
+  $('form').submit(function () {
+    $('#facet_configuration').val($('#sortable_facets').sortable('serialize'));
+  });
+});

--- a/app/assets/stylesheets/oregon_digital/collections/configurable_facets.scss
+++ b/app/assets/stylesheets/oregon_digital/collections/configurable_facets.scss
@@ -1,0 +1,3 @@
+.handle {
+  cursor: move;
+}

--- a/app/assets/stylesheets/oregon_digital/collections/configurable_facets.scss
+++ b/app/assets/stylesheets/oregon_digital/collections/configurable_facets.scss
@@ -1,3 +1,17 @@
 .handle {
   cursor: move;
 }
+
+.facet-selected {
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  z-index: 1;
+}
+
+.screen-hidden {
+  height: 1px;
+  left: -10000px;
+  overflow: hidden;
+  position: absolute;
+  top: auto;
+  width: 1px;
+}

--- a/app/controllers/dashboard/oregon_digital/collections_controller.rb
+++ b/app/controllers/dashboard/oregon_digital/collections_controller.rb
@@ -12,6 +12,7 @@ module Dashboard
 
       private
 
+      # Turn form params into Facet objects
       def process_facets
         Rack::Utils.parse_nested_query(params[:facet_configuration])['facet'].each_with_index do |id, index|
           facet = Facet.find id

--- a/app/controllers/dashboard/oregon_digital/collections_controller.rb
+++ b/app/controllers/dashboard/oregon_digital/collections_controller.rb
@@ -11,6 +11,13 @@ module Dashboard
       private
 
         def process_facets
+          Rack::Utils.parse_nested_query(params[:facet_configuration])['facet'].each_with_index do |id,index|
+            facet = Facet.find id
+            facet.label = params["facet_label_#{id}"]
+            facet.enabled = params["facet_enabled_#{id}"]
+            facet.order = index
+            facet.save
+          end
         end
     end
   end

--- a/app/controllers/dashboard/oregon_digital/collections_controller.rb
+++ b/app/controllers/dashboard/oregon_digital/collections_controller.rb
@@ -1,0 +1,17 @@
+module Dashboard
+  module OregonDigital
+    ## Shows a list of all collections to the admins
+    class CollectionsController < Hyrax::Dashboard::CollectionsController
+
+      def update
+        process_facets
+        super
+      end
+
+      private
+
+        def process_facets
+        end
+    end
+  end
+end

--- a/app/controllers/dashboard/oregon_digital/collections_controller.rb
+++ b/app/controllers/dashboard/oregon_digital/collections_controller.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal:true
+
 module Dashboard
   module OregonDigital
     ## Shows a list of all collections to the admins
     class CollectionsController < Hyrax::Dashboard::CollectionsController
-
+      # Override update to add facet processing
       def update
         process_facets
         super
@@ -10,15 +12,15 @@ module Dashboard
 
       private
 
-        def process_facets
-          Rack::Utils.parse_nested_query(params[:facet_configuration])['facet'].each_with_index do |id,index|
-            facet = Facet.find id
-            facet.label = params["facet_label_#{id}"]
-            facet.enabled = params["facet_enabled_#{id}"]
-            facet.order = index
-            facet.save
-          end
+      def process_facets
+        Rack::Utils.parse_nested_query(params[:facet_configuration])['facet'].each_with_index do |id, index|
+          facet = Facet.find id
+          facet.label = params["facet_label_#{id}"]
+          facet.enabled = params["facet_enabled_#{id}"]
+          facet.order = index
+          facet.save
         end
+      end
     end
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -18,7 +18,12 @@ class Collection < ActiveFedora::Base
     properties = properties.merge(Image.properties)
     properties = properties.merge(Video.properties)
     properties.select { |_k, prop| prop.behaviors && prop.behaviors.include?(:facetable) }.each do |_k, prop|
-      facet = Facet.new({label: prop.term.to_s, solr_name: Solrizer.solr_name(prop.term, :facetable), collection_id: self.id, property_name: prop.term})
+      facet = Facet.new({
+        label: I18n.translate("simple_form.labels.defaults.#{prop.term}"),
+        solr_name: Solrizer.solr_name(prop.term, :facetable),
+        collection_id: self.id,
+        property_name: prop.term
+      })
       facets += [facet] if facets.select { |f| f.property_name == facet.property_name }.empty? && facet.save
     end
     facets.sort_by { |f| f.order}

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -9,8 +9,9 @@ class Collection < ActiveFedora::Base
   include Hyrax::BasicMetadata
   self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
 
-  delegate(:facet_configurable?, to: :collection_type)
+  delegate :facet_configurable?, to: :collection_type
 
+  # Identify facets available to configure
   def available_facets
     generate_default_facets
     facets = Facet.where(collection_id: id)
@@ -19,6 +20,7 @@ class Collection < ActiveFedora::Base
 
   private
 
+  # Build new Facet objects that might not exist
   def generate_default_facets
     properties_to_facet.each do |_k, prop|
       next unless Facet.where(property_name: prop.term).empty?
@@ -33,6 +35,7 @@ class Collection < ActiveFedora::Base
     end
   end
 
+  # Find properties with :facetable behavior
   def properties_to_facet
     properties = Document.properties
     properties = properties.merge(Generic.properties)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -6,4 +6,10 @@ class Collection < ActiveFedora::Base
   # You can replace these metadata if they're not suitable
   include Hyrax::BasicMetadata
   self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
+
+  delegate(:facet_configurable?, to: :collection_type)
+
+  def available_facets
+    Generic.properties.select { |_k, v| v.behaviors && v.behaviors.include?(:facetable) }
+  end
 end

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal:true
+
+class Facet < ApplicationRecord
+end

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -1,0 +1,123 @@
+<div class="panel panel-default tabs" id="collection-edit-controls">
+  <ul class="nav nav-tabs" role="tablist">
+    <li class="active">
+      <a href="#description" role="tab" data-toggle="tab"><%= t('.tabs.description') %></a>
+    </li>
+    <% if @form.persisted? %>
+      <% if @collection.brandable? %>
+      <li>
+        <a href="#branding" role="tab" data-toggle="tab"><%= t('.tabs.branding') %></a>
+      </li>
+      <% end %>
+      <% if @collection.discoverable? %>
+      <li>
+        <a href="#discovery" role="tab" data-toggle="tab"><%= t('.tabs.discovery') %></a>
+      </li>
+      <% end %>
+      <% if @collection.sharable? %>
+      <li>
+        <a href="#sharing" role="tab" data-toggle="tab"><%= t('.tabs.sharing') %></a>
+      </li>
+      <% end %>
+      <% if @collection.facet_configurable? %>
+      <li>
+        <a href="#configurable_facets" role="tab" data-toggle="tab"><%= t('.tabs.facets') %></a>
+      </li>
+      <% end %>
+    <% end %>
+  </ul>
+
+  <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor' } do |f| %>
+    <div class="tab-content">
+      <div id="description" class="tab-pane active">
+        <div class="panel panel-default labels">
+          <div class="panel-body">
+
+            <div id="base-terms">
+              <% f.object.primary_terms.each do |term| %>
+                <%= render_edit_field_partial(term, f: f) %>
+              <% end %>
+
+              <% if f.object.persisted? %>
+                <%# we're loading these values dynamically to speed page load %>
+                <%= f.input :thumbnail_id,
+                            input_html: { data: { text: f.object.thumbnail_title } } %>
+              <% end %>
+            </div>
+            <% if f.object.display_additional_fields? %>
+              <%= link_to t('hyrax.collection.form.additional_fields'),
+                      '#extended-terms',
+                      class: 'btn btn-default additional-fields',
+                      data: { toggle: 'collapse' },
+                      role: "button",
+                      'aria-expanded'=> "false",
+                      'aria-controls'=> "extended-terms" %>
+              <div id="extended-terms" class='collapse'>
+                <% f.object.secondary_terms.each do |term| %>
+                  <%= render_edit_field_partial(term, f: f) %>
+                <% end %>
+              </div>
+            <% end %>
+            <%= hidden_field_tag :type, params[:type] %>
+            <%= hidden_field_tag :stay_on_edit, true %>
+            <%= hidden_field_tag :collection_type_gid, @collection.collection_type_gid %>
+            <!-- parent_id may be passed from the nested collections controller to allow a subcollection relationship to be added as collection is created -->
+            <% if params[:parent_id].present? %>
+              <%= hidden_field_tag :parent_id, params[:parent_id] %>
+            <% end %>
+            <% if params[:batch_document_ids].present? %>
+              <% params[:batch_document_ids].each do |batch_item| %>
+                <input type="hidden" name="batch_document_ids[]" value="<%= batch_item %>" />
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      </div> <!-- end description -->
+
+      <% if @form.persisted? %>
+        <div id="branding" class="tab-pane">
+          <div class="panel panel-default labels">
+            <div class="panel-body">
+              <%= render 'form_branding', f: f %>
+            </div>
+          </div>
+        </div>
+
+        <div id="discovery" class="tab-pane">
+          <div class="panel panel-default labels">
+            <div class="panel-body">
+              <%= render 'form_discovery', f: f %>
+            </div>
+          </div>
+        </div>
+
+        <div id="sharing" class="tab-pane">
+          <div class="panel panel-default labels" id="collection_permissions" data-param-key="<%= f.object.model_name.param_key %>">
+            <div class="panel-body">
+              <%= render 'form_share', f: f %>
+            </div>
+          </div>
+        </div>
+
+        <div id="configurable_facets" class="tab-pane">
+          <div class="panel panel-default labels" id="collection_permissions" data-param-key="<%= f.object.model_name.param_key %>">
+            <div class="panel-body">
+              <%= render 'form_facets', f: f %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <div class="panel-footer">
+        <% if @collection.persisted? %>
+          <%= f.submit t(:'hyrax.collection.select_form.update'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "update_submit", name: "update_collection" %>
+          <%= link_to t(:'helpers.action.cancel'), hyrax.dashboard_collection_path(@collection), class: 'btn btn-link' %>
+        <% else %>
+          <%= f.submit t(:'hyrax.collection.select_form.create'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "create_submit", name: "create_collection" %>
+          <%= link_to t(:'helpers.action.cancel'), hyrax.my_collections_path, class: 'btn btn-link' %>
+        <% end %>
+      </div>
+    </div> <!-- end tab-content -->
+  <% end # simple_form_for %>
+
+</div> <!-- end collection-controls -->

--- a/app/views/hyrax/dashboard/collections/_form_facets.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_facets.html.erb
@@ -1,15 +1,16 @@
 <%= hidden_field_tag :facet_configuration %>
 
-<ul id='sortable_facets'>
+<ul id='sortable_facets' class="list-group col">
   <% @collection.available_facets.each_with_index do |facet,index| %>
-    <li id="facet_<%= facet.id %>">
+    <li id="facet_<%= facet.id %>" class="list-group-item" style="float:none">
+      <span class="handle"><i class="fa fa-arrows fa-lg" aria-hidden="true"></i></span>
       <%= label_tag do %>
         <%= facet.property_name %>
         <%= text_field_tag "facet_label_#{facet.id}", facet.label, class: "form-control" %>
       <% end %>
       <%= label_tag do %>
-        <%= check_box_tag "facet_enabled_#{facet.id}", nil, facet.enabled %>
         Enable
+        <%= check_box_tag "facet_enabled_#{facet.id}", nil, facet.enabled %>
       <% end %>
     </li>
   <% end %>

--- a/app/views/hyrax/dashboard/collections/_form_facets.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_facets.html.erb
@@ -1,14 +1,14 @@
 <%= hidden_field_tag :facet_configuration %>
 
 <ul id='sortable_facets'>
-  <% @collection.available_facets.each_with_index do |(key,facet),index| %>
-    <li id="facet_<%= key %>">
+  <% @collection.available_facets.each_with_index do |facet,index| %>
+    <li id="facet_<%= facet.id %>">
       <%= label_tag do %>
-        <%= key %>
-        <%= text_field_tag "facet_label_#{key}", nil, class: "form-control" %>
+        <%= facet.property_name %>
+        <%= text_field_tag "facet_label_#{facet.id}", facet.label, class: "form-control" %>
       <% end %>
       <%= label_tag do %>
-        <%= check_box_tag "facet_enabled_#{key}" %>
+        <%= check_box_tag "facet_enabled_#{facet.id}", nil, facet.enabled %>
         Enable
       <% end %>
     </li>

--- a/app/views/hyrax/dashboard/collections/_form_facets.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_facets.html.erb
@@ -3,7 +3,14 @@
 <ul id='sortable_facets'>
   <% @collection.available_facets.each_with_index do |(key,facet),index| %>
     <li id="facet_<%= key %>">
-      <%= key %>
+      <%= label_tag do %>
+        <%= key %>
+        <%= text_field_tag "facet_label_#{key}", nil, class: "form-control" %>
+      <% end %>
+      <%= label_tag do %>
+        <%= check_box_tag "facet_enabled_#{key}" %>
+        Enable
+      <% end %>
     </li>
   <% end %>
 </ul>

--- a/app/views/hyrax/dashboard/collections/_form_facets.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_facets.html.erb
@@ -1,0 +1,9 @@
+<%= hidden_field_tag :facet_configuration %>
+
+<ul id='sortable_facets'>
+  <% @collection.available_facets.each_with_index do |(key,facet),index| %>
+    <li id="facet_<%= key %>">
+      <%= key %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/hyrax/dashboard/collections/_form_facets.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_facets.html.erb
@@ -5,7 +5,7 @@
     <li id="facet_<%= facet.id %>" class="list-group-item" style="float:none">
       <span class="handle"><i class="fa fa-arrows fa-2x" aria-hidden="true"></i></span>
       <%= label_tag do %>
-        <%= facet.property_name %>
+        <%= t("simple_form.labels.defaults.#{facet.property_name}") %>
         <%= text_field_tag "facet_label_#{facet.id}", facet.label, class: "form-control" %>
       <% end %>
       <%= label_tag do %>

--- a/app/views/hyrax/dashboard/collections/_form_facets.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_facets.html.erb
@@ -1,12 +1,14 @@
-<%= hidden_field_tag :facet_configuration %>
+<div id='facets-instructions' class='screen-hidden'>Press spacebar to grab and re-order</div>
+<div id='facets-live' aria-live='assertive' class='screen-hidden'></div>
 
-<ul id='sortable_facets' class="list-group col">
+<%= hidden_field_tag :facet_configuration %>
+<ul id='sortable_facets' class='list-group col'>
   <% @collection.available_facets.each_with_index do |facet,index| %>
-    <li id="facet_<%= facet.id %>" class="list-group-item" style="float:none">
-      <span class="handle"><i class="fa fa-arrows fa-2x" aria-hidden="true"></i></span>
+    <li id='facet_<%= facet.id %>' class='list-group-item' style='float:none' draggable='true' aria-describedby='facets-instructions'>
+      <span class='handle'><i class='fa fa-arrows fa-2x' aria-hidden='true'></i></span>
       <%= label_tag do %>
         <%= t("simple_form.labels.defaults.#{facet.property_name}") %>
-        <%= text_field_tag "facet_label_#{facet.id}", facet.label, class: "form-control" %>
+        <%= text_field_tag "facet_label_#{facet.id}", facet.label, class: 'form-control' %>
       <% end %>
       <%= label_tag do %>
         Enable

--- a/app/views/hyrax/dashboard/collections/_form_facets.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_facets.html.erb
@@ -3,7 +3,7 @@
 <ul id='sortable_facets' class="list-group col">
   <% @collection.available_facets.each_with_index do |facet,index| %>
     <li id="facet_<%= facet.id %>" class="list-group-item" style="float:none">
-      <span class="handle"><i class="fa fa-arrows fa-lg" aria-hidden="true"></i></span>
+      <span class="handle"><i class="fa fa-arrows fa-2x" aria-hidden="true"></i></span>
       <%= label_tag do %>
         <%= facet.property_name %>
         <%= text_field_tag "facet_label_#{facet.id}", facet.label, class: "form-control" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,21 @@
 # frozen_string_literal:true
 
 Rails.application.routes.draw do
-  namespace :admin do 
+  namespace :admin do
     resources :collection_types, except: :show, controller: 'oregon_digital/collection_types'
+  end
+  namespace :dashboard do
+    resources :collections, controller: 'oregon_digital/collections' do # Dashboard -> All Collections and CRUD
+      member do
+        get 'page/:page', action: :index
+        get 'facet/:id', action: :facet, as: :dashboard_facet
+        get :files
+      end
+      collection do
+        put '', action: :update
+        put :remove_member
+      end
+    end
   end
   mount BrowseEverything::Engine => '/browse'
   mount Blacklight::Oembed::Engine, at: 'oembed'

--- a/db/migrate/20190529145822_create_facets.rb
+++ b/db/migrate/20190529145822_create_facets.rb
@@ -1,0 +1,14 @@
+class CreateFacets < ActiveRecord::Migration[5.1]
+  def change
+    create_table :facets do |t|
+      t.string :property_name
+      t.string :label
+      t.string :solr_name
+      t.string :collection_id
+      t.integer :order, default: 999
+      t.boolean :enabled, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190521213326) do
+ActiveRecord::Schema.define(version: 20190529145822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,6 +89,17 @@ ActiveRecord::Schema.define(version: 20190521213326) do
     t.index ["parent_id"], name: "index_curation_concerns_operations_on_parent_id"
     t.index ["rgt"], name: "index_curation_concerns_operations_on_rgt"
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
+  end
+
+  create_table "facets", force: :cascade do |t|
+    t.string "property_name"
+    t.string "label"
+    t.string "solr_name"
+    t.string "collection_id"
+    t.integer "order", default: 999
+    t.boolean "enabled", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "featured_works", id: :serial, force: :cascade do |t|

--- a/spec/controllers/dashboard/oregon_digital/collections_controller_spec.rb
+++ b/spec/controllers/dashboard/oregon_digital/collections_controller_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe Dashboard::OregonDigital::CollectionsController, type: :controller do
+  let(:valid_params) do
+    {
+      facet_configuration: 'facet[]=1&facet[]=0',
+      facet_label_0: 'label0',
+      facet_enabled_0: '1',
+      facet_label_1: 'label1',
+      facet_enabled_1: '0'
+    }
+  end
+  let(:facet0) { create(:facet, id: 0) }
+  let(:facet1) { create(:facet, id: 1) }
+
+  describe '#process_facets' do
+    before do
+      controller.params = valid_params
+      facet0.save
+      facet1.save
+      controller.send(:process_facets)
+    end
+    let(:facet) { Facet.find(0) }
+
+    it 'creates the right number of facets' do
+      expect(Facet.all.count).to eq(2)
+    end
+
+    it 'creates facet 0 with proper label' do
+      expect(facet.label).to eq('label0')
+    end
+
+    it 'creates facet 0 enabled' do
+      expect(facet.enabled).to eq(true)
+    end
+
+    it 'creates facet 0 in correct order' do
+      expect(facet.order).to eq(1)
+    end
+  end
+end

--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal:true
+
+FactoryBot.define do
+  factory :collection do
+    sequence(:title) { |n| ["title-#{n}"] }
+  end
+end

--- a/spec/factories/facets.rb
+++ b/spec/factories/facets.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :facet do
+    label { "MyString" }
+    solr_name { "MyString" }
+    collection { nil }
+  end
+end

--- a/spec/factories/facets.rb
+++ b/spec/factories/facets.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal:true
+
 FactoryBot.define do
   factory :facet do
-    label { "MyString" }
-    solr_name { "MyString" }
+    label { 'MyString' }
+    solr_name { 'MyString' }
     collection { nil }
   end
 end

--- a/spec/factories/facets.rb
+++ b/spec/factories/facets.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :facet do
     label { 'MyString' }
     solr_name { 'MyString' }
-    collection { nil }
+    collection_id { nil }
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,7 +1,45 @@
 # frozen_string_literal: true
 
 RSpec.describe Collection do
-  it 'has tests' do
-    skip 'Add your tests here'
+  subject { model }
+
+  let(:model) { build(:collection) }
+  let(:prop) { OpenStruct.new(term: 'test_prop') }
+  let(:facet) { create(:facet, collection_id: model.id, property_name: prop.term) }
+
+  describe 'available_facets' do
+    before do
+      allow(model).to receive(:generate_default_facets)
+      facet.save
+    end
+
+    it 'finds existing facets' do
+      expect(model.available_facets).to include(facet)
+    end
+
+    it 'generates default facets' do
+      expect(model).to receive(:generate_default_facets)
+      model.available_facets
+    end
+  end
+
+  describe 'generate_default_facets' do
+    before do
+      allow(model).to receive(:properties_to_facet).and_return(a: prop)
+    end
+
+    it 'adds new facets' do
+      before_count = Facet.all.count
+      model.send(:generate_default_facets)
+      expect(Facet.all.count).to eq(before_count + 1)
+    end
+  end
+
+  describe 'properties_to_facet' do
+    it 'only selects facetable properties' do
+      model.send(:properties_to_facet).each do |_key, prop|
+        expect(prop.behaviors).to include(:facetable)
+      end
+    end
   end
 end

--- a/spec/models/facet_spec.rb
+++ b/spec/models/facet_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Facet, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/facet_spec.rb
+++ b/spec/models/facet_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal:true
+
 require 'rails_helper'
 
 RSpec.describe Facet, type: :model do


### PR DESCRIPTION
Fixes #547 
This PR creates a Facet object that is used to store configuration for facets for each collection. It also adds the configurable facet tab to the collections edit form and hooks it up to that facet object. 
Draggable ordering is accessible with tab-focus and (left/up)/(right/down) keyboard navigation.

Preview:
![image](https://user-images.githubusercontent.com/11052958/58645210-bd6a5800-82b7-11e9-9294-99e4be0b7118.png)
