### PR TITLE
bring over admin_set crosswalk file to OD2

### DIFF
--- a/config/initializers/hyrax_migrator.rb
+++ b/config/initializers/hyrax_migrator.rb
@@ -43,6 +43,9 @@ Hyrax::Migrator.config do |config|
   # The crosswalk overrides metadata file for properties and predicates that need special handling
   config.crosswalk_overrides_file = File.join(Rails.root, 'config/initializers/migrator/crosswalk_overrides.yml')
 
+  # The crosswalk file for associating primary sets in OD1 with admin sets in OD2
+  config.crosswalk_admin_sets_file = File.join(Rails.root, 'config/initializers/migrator/crosswalk_admin_sets.yml')
+
   config.upload_storage_service = :aws_s3
 
   # The service used to upload files ready for migration. It defaults to file_system for test and development. On production, it defaults to aws_s3

--- a/config/initializers/migrator/crosswalk_admin_sets.yml
+++ b/config/initializers/migrator/crosswalk_admin_sets.yml
@@ -1,0 +1,207 @@
+crosswalk:
+  - primary_set: aa-images
+    admin_set_id: uo
+  - primary_set: african-ephemera
+    admin_set_id: uo
+  - primary_set: alice-b-sheldon
+    admin_set_id: uo
+  - primary_set: angelus-studio
+    admin_set_id: uo
+  - primary_set: annual-cruise
+    admin_set_id: osu-scarc-admin
+  - primary_set: arch-entourage
+    admin_set_id: uo
+  - primary_set: artists-books
+    admin_set_id: uo
+  - primary_set: braceros
+    admin_set_id: osu-scarc-admin
+  - primary_set: building-or
+    admin_set_id: uo
+  - primary_set: chinavine
+    admin_set_id: uo
+  - primary_set: clarence-andrews
+    admin_set_id: uo
+  - primary_set: columbia-gorge
+    admin_set_id: osu
+  - primary_set: colver-family
+    admin_set_id: uo
+  - primary_set: corvallis-flood
+    admin_set_id: osu-scarc-admin
+  - primary_set: corvallis-images
+    admin_set_id: osu-scarc-admin
+  - primary_set: cw-furlong
+    admin_set_id: uo
+  - primary_set: daily-barometer
+    admin_set_id: osu-scarc-admin
+  - primary_set: daily-emerald
+    admin_set_id: uo
+  - primary_set: dan-powell
+    admin_set_id: uo
+  - primary_set: dissociation
+    admin_set_id: uo
+  - primary_set: doris-ulmann
+    admin_set_id: uo
+  - primary_set: electric-studio
+    admin_set_id: uo
+  - primary_set: ellis-fuller-lawrence
+    admin_set_id: uo
+  - primary_set: ellmaker-family
+    admin_set_id: uo
+  - primary_set: fairbanks
+    admin_set_id: osu
+  - primary_set: finley-bohlman
+    admin_set_id: osu-scarc-admin
+  - primary_set: florence-hartshorn
+    admin_set_id: uo
+  - primary_set: frazier-boutelle
+    admin_set_id: uo
+  - primary_set: gb-warner
+    admin_set_id: uo
+  - primary_set: gb-warner-nosatsu
+    admin_set_id: uo
+  - primary_set: gb-warner-papers-ua022
+    admin_set_id: uo
+  - primary_set: gbwarnerpapers
+    admin_set_id: uo
+  - primary_set: general-catalogs
+    admin_set_id: osu-scarc-admin
+  - primary_set: gifford
+    admin_set_id: osu-scarc-admin
+  - primary_set: grayson-mathews
+    admin_set_id: uo
+  - primary_set: gwilliams
+    admin_set_id: osu-scarc-admin
+  - primary_set: herbarium
+    admin_set_id: osu
+  - primary_set: illustrated-booklets
+    admin_set_id: osu-scarc-admin
+  - primary_set: james-cloutier
+    admin_set_id: uo
+  - primary_set: jasr
+    admin_set_id: uo
+  - primary_set: joanna-russ
+    admin_set_id: uo
+  - primary_set: joel-palmer
+    admin_set_id: uo
+  - primary_set: john-bauguess
+    admin_set_id: uo
+  - primary_set: johnyeonarchdrawings
+    admin_set_id: uo
+  - primary_set: ken-gray
+    admin_set_id: osu-scarc-admin
+  - primary_set: lchsa
+    admin_set_id: osu
+  - primary_set: lee-drake
+    admin_set_id: uo
+  - primary_set: lee-moorhouse
+    admin_set_id: uo
+  - primary_set: lichens-pnw
+    admin_set_id: osu
+  - primary_set: lowenstam
+    admin_set_id: uo
+  - primary_set: maic
+    admin_set_id: uo
+  - primary_set: mayo-methot-bogart
+    admin_set_id: uo
+  - primary_set: middle-east-water
+    admin_set_id: osu
+  - primary_set: mountaingrove
+    admin_set_id: uo
+  - primary_set: mss-rb
+    admin_set_id: uo
+  - primary_set: ncu
+    admin_set_id: uo
+  - primary_set: nw-folklife
+    admin_set_id: uo
+  - primary_set: ocfrp
+    admin_set_id: osu-scarc-admin
+  - primary_set: ohba
+    admin_set_id: osu-scarc-admin
+  - primary_set: oimb
+    admin_set_id: uo
+  - primary_set: opal-whiteley
+    admin_set_id: uo
+  - primary_set: or-chinese-disinterment
+    admin_set_id: osu-scarc-admin
+  - primary_set: or-latino-herit
+    admin_set_id: uo
+  - primary_set: orange-owl
+    admin_set_id: osu-scarc-admin
+  - primary_set: oregon-multicultural-archives
+    admin_set_id: osu-scarc-admin
+  - primary_set: oregon-state-yank
+    admin_set_id: osu-scarc-admin
+  - primary_set: oregons-agricultural-progress
+    admin_set_id: osu-scarc-admin
+  - primary_set: ormaps
+    admin_set_id: uo
+  - primary_set: osu-alumni-magazine
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-athletics
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-baseball
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-commencement-programs
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-department-histories
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-fact-book
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-historical-images
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-historical-maps
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-historical-publications
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-scarc-admin
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-sports-media-guides
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-student-protest-underground-pubs
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-wwii-japanese-american-students
+    admin_set_id: osu-scarc-admin
+  - primary_set: osu-yearbooks
+    admin_set_id: osu-scarc-admin
+  - primary_set: percent-for-art
+    admin_set_id: uo
+  - primary_set: petrarch
+    admin_set_id: uo
+  - primary_set: quincy-scott
+    admin_set_id: uo
+  - primary_set: rockyshore93
+    admin_set_id: osu
+  - primary_set: roy-c-andrews
+    admin_set_id: uo
+  - primary_set: rv-mills
+    admin_set_id: uo
+  - primary_set: schnitzer-nitrate
+    admin_set_id: uo
+  - primary_set: sheetmusic
+    admin_set_id: uo
+  - primary_set: siuslaw
+    admin_set_id: osu
+  - primary_set: streamsurvey
+    admin_set_id: osu
+  - primary_set: textile-and-apparel
+    admin_set_id: osu
+  - primary_set: texts-data
+    admin_set_id: uo
+  - primary_set: the-manuscript
+    admin_set_id: osu-scarc-admin
+  - primary_set: uo-arch-photos
+    admin_set_id: uo
+  - primary_set: uo-athletics
+    admin_set_id: uo
+  - primary_set: uo-president
+    admin_set_id: uo
+  - primary_set: uo-stock-photos
+    admin_set_id: uo
+  - primary_set: uo-veterans
+    admin_set_id: uo
+  - primary_set: walter-bowman
+    admin_set_id: uo
+  - primary_set: western-waters
+    admin_set_id: uo
+  - primary_set: willis-dunagan
+    admin_set_id: uo

--- a/config/initializers/migrator/crosswalk_admin_sets.yml
+++ b/config/initializers/migrator/crosswalk_admin_sets.yml
@@ -153,7 +153,7 @@ crosswalk:
     admin_set_id: osu-scarc-admin
   - primary_set: osu-historical-publications
     admin_set_id: osu-scarc-admin
-  - primary_set: osu-scarc-admin
+  - primary_set: osu-scarc
     admin_set_id: osu-scarc-admin
   - primary_set: osu-sports-media-guides
     admin_set_id: osu-scarc-admin


### PR DESCRIPTION
This brings over admin set crosswalk file from the migrator to live in OD2 configs with the other .yml files so the service can find it. Modified the id of osu-scarc (see comment on #562)