### PR TITLE
bugfixes for hyrax-migrator

### DIFF
--- a/app/indexers/oregon_digital/deep_indexing_service.rb
+++ b/app/indexers/oregon_digital/deep_indexing_service.rb
@@ -16,7 +16,7 @@ module OregonDigital
     def fetch_value(value)
       Rails.logger.info "Fetching #{value.rdf_subject} from the authorative source. (this is slow)"
       value.fetch(headers: { 'Accept' => default_accept_header })
-    rescue IOError, SocketError, TriplestoreAdapter::TriplestoreException => e
+    rescue Net::ReadTimeout, IOError, SocketError, TriplestoreAdapter::TriplestoreException => e
       # IOError could result from a 500 error on the remote server
       # SocketError results if there is no server to connect to
       Rails.logger.error "Unable to fetch #{value.rdf_subject} from the authorative source.\n#{e.message}"

--- a/config/initializers/migrator/crosswalk.yml
+++ b/config/initializers/migrator/crosswalk.yml
@@ -424,7 +424,7 @@ crosswalk:
     multiple: true
   - property: resource_type
     predicate: http://purl.org/dc/terms/type
-    multiple: true
+    multiple: false
   - property: workType
     predicate: http://www.w3.org/1999/02/22-rdf-syntax-ns#type
     multiple: true

--- a/config/initializers/migrator/crosswalk_overrides.yml
+++ b/config/initializers/migrator/crosswalk_overrides.yml
@@ -6,6 +6,10 @@ overrides:
     function: return_nil
   - predicate: http://opaquenamespace.org/ns/full
     function: return_nil
-  - property: rightsHolder
+  - predicate: http://opaquenamespace.org/ns/primarySet
+    function: return_nil
+  - predicate: http://opaquenamespace.org/ns/set
+    function: return_nil
+  - property: rights_holder
     predicate: http://opaquenamespace.org/right/rightsHolder
     multiple: true


### PR DESCRIPTION
- Rescue `Net::ReadTimeout` for fetch_value in deep_indexing_service.rb. Occasionally, the fetch raises a timeout (that ends up causing a 500 error related to https://github.com/OregonDigital/OD2/issues/330) that breaks the migrator.
- Updates for crosswalk and crosswalk overrides