### PR TITLE
Set page titles

### DIFF
--- a/app/presenters/hyrax/generic_presenter.rb
+++ b/app/presenters/hyrax/generic_presenter.rb
@@ -16,5 +16,9 @@ module Hyrax
         (presenter.image? || presenter.pdf?) && current_ability.can?(:read, presenter.id)
       end
     end
+
+    def page_title
+      "#{title.first} | #{I18n.t('hyrax.product_name')}"
+    end
   end
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -216,7 +216,7 @@ en:
     search:
       button:
         html: 'Go'
-    product_name: 'Hyrax'
+    product_name: 'Oregon Digital (Development)'
     product_twitter_handle: '@SamveraRepo'
     institution_name: 'Institution'
     institution_name_full: 'The Institution Name'

--- a/spec/system/create_audio_spec.rb
+++ b/spec/system/create_audio_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Create a Audio', js: true, type: :system, clean_repo: true do
 
       click_on 'Save'
       expect(page).to have_content('Test Title')
-      expect(page).to have_content 'Your files are being processed by Hyrax in the background.'
+      expect(page).to have_content 'Your files are being processed by Oregon Digital (Development) in the background.'
       expect(page).to be_accessible.skipping('aria-allowed-role').excluding('.label-success')
 
       # save a successful screenshot if running in CI for build artifacts

--- a/spec/system/create_document_spec.rb
+++ b/spec/system/create_document_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Create a Document', js: true, type: :system, clean_repo: true do
 
       click_on 'Save'
       expect(page).to have_content('Test Title')
-      expect(page).to have_content 'Your files are being processed by Hyrax in the background.'
+      expect(page).to have_content 'Your files are being processed by Oregon Digital (Development) in the background.'
       expect(page).to be_accessible.skipping('aria-allowed-role').excluding('.label-success')
 
       # save a successful screenshot if running in CI for build artifacts

--- a/spec/system/create_generic_spec.rb
+++ b/spec/system/create_generic_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Create a Generic', js: true, type: :system, clean_repo: true do
 
       click_on 'Save'
       expect(page).to have_content('Test Title')
-      expect(page).to have_content 'Your files are being processed by Hyrax in the background.'
+      expect(page).to have_content 'Your files are being processed by Oregon Digital (Development) in the background.'
       expect(page).to be_accessible.skipping('aria-allowed-role').excluding('.label-success')
 
       # save a successful screenshot if running in CI for build artifacts

--- a/spec/system/create_image_spec.rb
+++ b/spec/system/create_image_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Create a Image',  js: true, type: :system, clean_repo: true do
 
       click_on 'Save'
       expect(page).to have_content('Test Title')
-      expect(page).to have_content 'Your files are being processed by Hyrax in the background.'
+      expect(page).to have_content 'Your files are being processed by Oregon Digital (Development) in the background.'
       expect(page).to be_accessible.skipping('aria-allowed-role').excluding('.label-success')
 
       # save a successful screenshot if running in CI for build artifacts

--- a/spec/system/create_video_spec.rb
+++ b/spec/system/create_video_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Create a Video',  js: true, type: :system, clean_repo: true do
 
       click_on 'Save'
       expect(page).to have_content('Test Title')
-      expect(page).to have_content 'Your files are being processed by Hyrax in the background.'
+      expect(page).to have_content 'Your files are being processed by Oregon Digital (Development) in the background.'
       expect(page).to be_accessible.skipping('aria-allowed-role').excluding('.label-success')
 
       # save a successful screenshot if running in CI for build artifacts


### PR DESCRIPTION
Updates application title to 'Oregon Digital (Development)' largely everywhere. Fixes #594 
Will need to reopen this when we go prod.

Also, work show page is trimmed down to '<work title> | Oregon Digital (Development)' Fixes #602