### PR TITLE
Override show page partial

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,3 +1,4 @@
+<%= presenter.attribute_to_html(:description, html_dl: true, label: t("simple_form.labels.defaults.description")) %>
 <% (Generic.generic_properties.map(&:to_sym)).reject{ |attr| [:description, :language, :license, :oembed_url, :resource_type, :rights_statement].include? attr }.each do |attr| %>
   <%= presenter.attribute_to_html(attr, html_dl: true, label: t("simple_form.labels.defaults.#{attr}")) %>
 <% end %>

--- a/app/views/hyrax/base/_work_title.html.erb
+++ b/app/views/hyrax/base/_work_title.html.erb
@@ -1,0 +1,18 @@
+<% presenter.title.each_with_index do |title, index| %>
+  <div class="row">
+    <div class="col-sm-8">
+      <% if index == 0 %>
+        <h1><%= title %>
+          <small class="text-muted"><%= presenter.permission_badge %> <%= presenter.workflow.badge %></small>
+        </h1>
+      <% else %>
+        <h1><%= title %></h1>
+      <% end %>
+    </div>
+    <div class="col-sm-4 text-right">
+      <% if index == 0 %>
+        <%= render "show_actions", presenter: presenter %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,0 +1,41 @@
+<% provide :page_title, @presenter.page_title %>
+
+<%= render 'shared/citations' %>
+
+<div class="row work-type">
+  <%# OVERRIDE FROM HYRAX remove work type heading %>
+  <div class="col-xs-12">&nbsp;</div>
+  <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <%= render 'work_title', presenter: @presenter %>
+      </div>
+      <div class="panel-body">
+        <div class="row">
+          <%= render 'workflow_actions_widget', presenter: @presenter %>
+          <% if @presenter.iiif_viewer? %>
+            <div class="col-sm-12">
+              <%= render 'representative_media', presenter: @presenter, viewer: true %>
+            </div>
+          <% end %>
+          <div class="col-sm-3 text-center">
+            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? %>
+            <%= render 'citations', presenter: @presenter %>
+            <%= render 'social_media' %>
+          </div>
+          <div class="col-sm-9">
+            <%= render 'work_description', presenter: @presenter %>
+            <%= render 'metadata', presenter: @presenter %>
+          </div>
+          <div class="col-sm-12">
+            <%= render 'relationships', presenter: @presenter %>
+            <%= render 'items', presenter: @presenter %>
+            <%# TODO: we may consider adding these partials in the future %>
+            <%# = render 'sharing_with', presenter: @presenter %>
+            <%# = render 'user_activity', presenter: @presenter %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -24,7 +24,7 @@
             <%= render 'social_media' %>
           </div>
           <div class="col-sm-9">
-            <%= render 'work_description', presenter: @presenter %>
+            <%# OVERRIDE FROM HYRAX remove work description %>
             <%= render 'metadata', presenter: @presenter %>
           </div>
           <div class="col-sm-12">

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -20,7 +20,7 @@
           <% end %>
           <div class="col-sm-3 text-center">
             <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? %>
-            <%= render 'citations', presenter: @presenter %>
+            <%# OVERRIDE FROM HYRAX remove work citations %>
             <%= render 'social_media' %>
           </div>
           <div class="col-sm-9">

--- a/config/initializers/_i18n.rb
+++ b/config/initializers/_i18n.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal:true
 
 # Load application custom translations in order to use them in other initializers
-I18n.load_path += Dir[Rails.root.join('config', 'locales', '*.{rb,yml}').to_s]
 I18n.load_path += Dir[Hyrax::Engine.root.join('config', 'locales', '*.{rb,yml}').to_s]
+I18n.load_path += Dir[Rails.root.join('config', 'locales', '*.{rb,yml}').to_s]


### PR DESCRIPTION
Fixes #605 
Fixes #606 
Fixes #608 

- Removes work type heading from work show page
- Changes work title to h1
- Remove citation dropdown from work show page
- Removes work description and sets it as the first attribute row, giving it a label