### PR TITLE
Adds print and license sections to work show page

### DIFF
--- a/app/assets/stylesheets/oregon_digital/_files-sets.scss
+++ b/app/assets/stylesheets/oregon_digital/_files-sets.scss
@@ -4,4 +4,11 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+
+  .thumbnail.file_set.attributes {
+
+      text-overflow: ellipsis;
+      overflow-x: hidden;
+
+  }
 }

--- a/app/views/hyrax/base/_license.html.erb
+++ b/app/views/hyrax/base/_license.html.erb
@@ -1,0 +1,8 @@
+<div class="license">
+  <h2><%= t('.header') %></h2>
+  <% if license=@presenter.attribute_to_html(:license, render_as: :license, html_dl: true) %>
+    <%= license %>
+  <% else %>
+    <%= @presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
+  <% end %>
+</div>

--- a/app/views/hyrax/base/_license.html.erb
+++ b/app/views/hyrax/base/_license.html.erb
@@ -1,9 +1,9 @@
 <div class="license">
   <h2><%= t('.header') %></h2>
-  <% license=@presenter.attribute_to_html(:license, render_as: :license, html_dl: true) %>
+  <% license=@presenter.attribute_to_html(:license, render_as: :license) %>
   <% unless license.blank? %>
     <%= license %>
   <% else %>
-    <%= @presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
+    <%= @presenter.attribute_to_html(:rights_statement, render_as: :rights_statement) %>
   <% end %>
 </div>

--- a/app/views/hyrax/base/_license.html.erb
+++ b/app/views/hyrax/base/_license.html.erb
@@ -1,6 +1,7 @@
 <div class="license">
   <h2><%= t('.header') %></h2>
-  <% if license=@presenter.attribute_to_html(:license, render_as: :license, html_dl: true) %>
+  <% license=@presenter.attribute_to_html(:license, render_as: :license, html_dl: true) %>
+  <% unless license.blank? %>
     <%= license %>
   <% else %>
     <%= @presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>

--- a/app/views/hyrax/base/_print.html.erb
+++ b/app/views/hyrax/base/_print.html.erb
@@ -1,0 +1,4 @@
+<div class="citations">
+  <h2><%= t('.header') %></h2>
+  <%= link_to 'Print this resource', '#', :onclick => 'window.print();return false;'%>
+</div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -28,6 +28,7 @@
             <%= render 'relationships', presenter: @presenter %>
             <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? %>
             <%# OVERRIDE FROM HYRAX remove work citations %>
+            <%= render 'print' %>
             <%= render 'social_media' %>
             <%= render 'items', presenter: @presenter %>
           </div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -28,6 +28,7 @@
             <%= render 'relationships', presenter: @presenter %>
             <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? %>
             <%# OVERRIDE FROM HYRAX remove work citations %>
+            <%= render 'license' %>
             <%= render 'print' %>
             <%= render 'social_media' %>
             <%= render 'items', presenter: @presenter %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -220,6 +220,8 @@ en:
         header: 'MLA Citation'
       print:
         header: 'Print'
+      license:
+        header: 'Can I use it?'
     search:
       button:
         html: 'Go'

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -218,6 +218,8 @@ en:
         header: 'Collection Information'
       citations:
         header: 'MLA Citation'
+      print:
+        header: 'Print'
     search:
       button:
         html: 'Go'


### PR DESCRIPTION
Fixes #612 
Fixes #611 
Fixes #628 
We don't have access to font-awesome v5, so we can't add any of the CC or licensing icons.
![image](https://user-images.githubusercontent.com/11052958/61746991-ce809400-ad51-11e9-8295-cfe8d96b7ae3.png)
