### PR TITLE
Add UO OSU and PD search scopes

### DIFF
--- a/app/assets/javascripts/hyrax/search.js
+++ b/app/assets/javascripts/hyrax/search.js
@@ -1,0 +1,71 @@
+(function($){
+  Hyrax.Search = function (element) {
+    this.$element = $(element);
+
+    this.init = function() {
+      this.$label = this.$element.find('[data-search-element="label"]');
+      this.$items = this.$element.find('[data-search-option]');
+      this.setDefault();
+    }
+
+    this.init();
+    this.attachEvents();
+  }
+
+
+  Hyrax.Search.prototype = {
+    attachEvents: function() {
+
+      _this = this;
+      this.$items.on('click', function(event) {
+        event.preventDefault();
+        _this.clicked($(this))
+      });
+    },
+
+    clicked: function($anchor) {
+      this.setLabel($anchor.data('search-label'));
+      this.setFormAction($anchor.data('search-option'));
+      this.setFacet($anchor.data('search-facet'), $anchor.data('search-facet-value'));
+    },
+
+    setFormAction: function(path) {
+      this.$element.attr('action', path);
+    },
+
+    getLabelForValue: function(value) {
+      selected = this.$element.find('[data-search-option="'+ value +'"]');
+      return selected.data('search-label');
+    },
+
+    setDefault: function() {
+      this.setLabel(this.getLabelForValue(this.$element.attr('action')));
+    },
+
+    setLabel: function(label) {
+      this.$label.html(label);
+    },
+
+    // OVERRIDE FROM HYRAX to add pre-search faceting
+    setFacet: function(facet, value) {
+      this.$element.find('[name ^= "f["]').remove();
+      this.$element.append('<input name="f['+facet+'][]" value="'+value+'" type="hidden">');
+    }
+
+  }
+
+  $.fn.search = function(option) {
+    return this.each(function() {
+      var $this = $(this);
+      var data  = $this.data('search');
+
+      if (!data) $this.data('search', (data = new Hyrax.Search(this)));
+    })
+  }
+
+})(jQuery);
+
+
+Blacklight.onLoad(function() {
+  $('#search-form-header').search();
+});

--- a/app/assets/stylesheets/oregon_digital/_home-page.scss
+++ b/app/assets/stylesheets/oregon_digital/_home-page.scss
@@ -33,7 +33,9 @@ td.toggle .input-group-btn:last-child > input[type=submit]:not(:last-child) {
         width: 25%;
       }
       .caret {
-        margin-left: 75%;
+        position: absolute;
+        right: 5%;
+        top: 45%;
       }
     }
   }

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -11,19 +11,30 @@
       <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
       <div class="input-group-btn">
-        <% if current_user %>
           <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
 
-            <span class="sr-only" data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
-            <span aria-hidden="true"><%= t("hyrax.search.form.option.all.label_short") %></span>
+            <span data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
             <span class="caret"></span>
           </button>
 
-          <ul class="dropdown-menu pull-right">
+          <ul class="dropdown-menu">
             <li>
               <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
                   data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
             </li>
+            <li>
+              <%= link_to t("hyrax.search.form.option.osu.label_long", application_name: application_name), "#",
+                  data: { "search-option" => main_app.search_catalog_path(f: { intitution_label_sim: ["Oregon State University"]}), "search-label" => t("hyrax.search.form.option.osu.label_short") } %>
+            </li>
+            <li>
+              <%= link_to t("hyrax.search.form.option.uo.label_long", application_name: application_name), "#",
+                  data: { "search-option" => main_app.search_catalog_path(f: { intitution_label_sim: ["University Of Oregon"]}), "search-label" => t("hyrax.search.form.option.uo.label_short") } %>
+            </li>
+            <li>
+              <%= link_to t("hyrax.search.form.option.pd.label_long", application_name: application_name), "#",
+                  data: { "search-option" => main_app.search_catalog_path(f: { license_label_sim: ["Creative Commons CC0 1.0 Universal"]}), "search-label" => t("hyrax.search.form.option.pd.label_short") } %>
+            </li>
+            <% if current_user %>
             <li>
               <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#",
                   data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
@@ -32,8 +43,8 @@
               <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
                   data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
             </li>
+            <% end %>
           </ul>
-        <% end %>
         <button type="submit" class="btn btn-primary" id="search-submit-header">
           <%= t('hyrax.search.button.html') %>
         </button>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -24,15 +24,15 @@
             </li>
             <li>
               <%= link_to t("hyrax.search.form.option.osu.label_long", application_name: application_name), "#",
-                  data: { "search-option" => main_app.search_catalog_path(f: { intitution_label_sim: ["Oregon State University"]}), "search-label" => t("hyrax.search.form.option.osu.label_short") } %>
+                  data: { "search-option" => main_app.search_catalog_path, "search-facet" => 'institution_label_sim', "search-facet-value" => 'Oregon State University', "search-label" => t("hyrax.search.form.option.osu.label_short") } %>
             </li>
             <li>
               <%= link_to t("hyrax.search.form.option.uo.label_long", application_name: application_name), "#",
-                  data: { "search-option" => main_app.search_catalog_path(f: { intitution_label_sim: ["University Of Oregon"]}), "search-label" => t("hyrax.search.form.option.uo.label_short") } %>
+                  data: { "search-option" => main_app.search_catalog_path, "search-facet" => 'institution_label_sim', "search-facet-value" => 'University Of Oregon', "search-label" => t("hyrax.search.form.option.uo.label_short") } %>
             </li>
             <li>
               <%= link_to t("hyrax.search.form.option.pd.label_long", application_name: application_name), "#",
-                  data: { "search-option" => main_app.search_catalog_path(f: { license_label_sim: ["Creative Commons CC0 1.0 Universal"]}), "search-label" => t("hyrax.search.form.option.pd.label_short") } %>
+                  data: { "search-option" => main_app.search_catalog_path, "search-facet" => 'license_label_sim', "search-facet-value" => 'Creative Commons CC0 1.0 Universal', "search-label" => t("hyrax.search.form.option.pd.label_short") } %>
             </li>
             <% if current_user %>
             <li>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -225,6 +225,17 @@ en:
       items:
         header: "Downloads"
     search:
+      form:
+        option:
+          osu:
+            label_long: OSU Content Only
+            label_short: OSU
+          uo:
+            label_long: UO Content Only
+            label_short: UO
+          pd:
+            label_long: Public Domain Content Only
+            label_short: Public Domain
       button:
         html: 'Go'
     product_name: 'Oregon Digital (Development)'


### PR DESCRIPTION
Fixes #595 
Public domain is not hooked up for union searching and only returns CC0 works. This will require [blacklight_advanced_search](https://github.com/projectblacklight/blacklight_advanced_search) gem, which I believe we will be tackling later.
Institution searches are filtered on the :institution metadata field, and respond to "University Of Oregon" and "Oregon State University" labels.

unauthed
![image](https://user-images.githubusercontent.com/11052958/61907389-349c2100-aee2-11e9-822f-94c956ee7703.png)

