### PR TITLE
Stop licenses and rights statements from opening in new tabs

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -45,6 +45,7 @@ Metrics/MethodLength:
     - 'lib/oregon_digital/triple_powered_properties/inputs/triple_powered_property_input.rb'
     - 'lib/oregon_digital/triple_powered_properties/work_behavior.rb'
     - 'lib/tasks/oregon_digital/csv_ingest.rake'
+    - 'app/renderers/hyrax/renderers/rights_statement_attribute_renderer.rb'
 
 Naming/AccessorMethodName:
   Exclude:

--- a/app/renderers/hyrax/renderers/license_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/license_attribute_renderer.rb
@@ -7,22 +7,22 @@ module Hyrax
     class LicenseAttributeRenderer < AttributeRenderer
       private
 
-        ##
-        # Special treatment for license/rights.  A URL from the Hyrax gem's config/hyrax.rb is stored in the descMetadata of the
-        # curation_concern.  If that URL is valid in form, then it is used as a link.  If it is not valid, it is used as plain text.
-        def attribute_value_to_html(value)
-          begin
-            parsed_uri = URI.parse(value)
-          rescue URI::InvalidURIError
-            nil
-          end
-          if parsed_uri.nil?
-            ERB::Util.h(value)
-          else
-            # OVERRIDE FROM HYRAX to remove open-in-new-tab functionality
-            %(<a href=#{ERB::Util.h(value)}>#{Hyrax.config.license_service_class.new.label(value)}</a>)
-          end
+      ##
+      # Special treatment for license/rights.  A URL from the Hyrax gem's config/hyrax.rb is stored in the descMetadata of the
+      # curation_concern.  If that URL is valid in form, then it is used as a link.  If it is not valid, it is used as plain text.
+      def attribute_value_to_html(value)
+        begin
+          parsed_uri = URI.parse(value)
+        rescue URI::InvalidURIError
+          nil
         end
+        if parsed_uri.nil?
+          ERB::Util.h(value)
+        else
+          # OVERRIDE FROM HYRAX to remove open-in-new-tab functionality
+          %(<a href=#{ERB::Util.h(value)}>#{Hyrax.config.license_service_class.new.label(value)}</a>)
+        end
+      end
     end
   end
 end

--- a/app/renderers/hyrax/renderers/license_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/license_attribute_renderer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal:true
+
+module Hyrax
+  module Renderers
+    # This is used by PresentsAttributes to show licenses
+    #   e.g.: presenter.attribute_to_html(:license, render_as: :license)
+    class LicenseAttributeRenderer < AttributeRenderer
+      private
+
+        ##
+        # Special treatment for license/rights.  A URL from the Hyrax gem's config/hyrax.rb is stored in the descMetadata of the
+        # curation_concern.  If that URL is valid in form, then it is used as a link.  If it is not valid, it is used as plain text.
+        def attribute_value_to_html(value)
+          begin
+            parsed_uri = URI.parse(value)
+          rescue URI::InvalidURIError
+            nil
+          end
+          if parsed_uri.nil?
+            ERB::Util.h(value)
+          else
+            # OVERRIDE FROM HYRAX to remove open-in-new-tab functionality
+            %(<a href=#{ERB::Util.h(value)}>#{Hyrax.config.license_service_class.new.label(value)}</a>)
+          end
+        end
+    end
+  end
+end

--- a/app/renderers/hyrax/renderers/rights_statement_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/rights_statement_attribute_renderer.rb
@@ -7,23 +7,23 @@ module Hyrax
     class RightsStatementAttributeRenderer < AttributeRenderer
       private
 
-        ##
-        # Special treatment for license/rights.  A URL from the Hyrax gem's config/hyrax.rb is stored in the descMetadata of the
-        # curation_concern.  If that URL is valid in form, then it is used as a link.  If it is not valid, it is used as plain text.
-        def attribute_value_to_html(value)
-          begin
-            parsed_uri = URI.parse(value)
-          rescue URI::InvalidURIError
-            nil
-          end
-          if parsed_uri.nil?
-            ERB::Util.h(value)
-          else
-            label = Hyrax.config.rights_statement_service_class.new.label(value) { value }
-            # OVERRIDE FROM HYRAX to remove open-in-new-tab functionality
-            %(<a href=#{ERB::Util.h(value)}>#{label}</a>)
-          end
+      ##
+      # Special treatment for license/rights.  A URL from the Hyrax gem's config/hyrax.rb is stored in the descMetadata of the
+      # curation_concern.  If that URL is valid in form, then it is used as a link.  If it is not valid, it is used as plain text.
+      def attribute_value_to_html(value)
+        begin
+          parsed_uri = URI.parse(value)
+        rescue URI::InvalidURIError
+          nil
         end
+        if parsed_uri.nil?
+          ERB::Util.h(value)
+        else
+          label = Hyrax.config.rights_statement_service_class.new.label(value) { value }
+          # OVERRIDE FROM HYRAX to remove open-in-new-tab functionality
+          %(<a href=#{ERB::Util.h(value)}>#{label}</a>)
+        end
+      end
     end
   end
 end

--- a/app/renderers/hyrax/renderers/rights_statement_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/rights_statement_attribute_renderer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal:true
+
+module Hyrax
+  module Renderers
+    # This is used by PresentsAttributes to show licenses
+    #   e.g.: presenter.attribute_to_html(:rights_statement, render_as: :rights_statement)
+    class RightsStatementAttributeRenderer < AttributeRenderer
+      private
+
+        ##
+        # Special treatment for license/rights.  A URL from the Hyrax gem's config/hyrax.rb is stored in the descMetadata of the
+        # curation_concern.  If that URL is valid in form, then it is used as a link.  If it is not valid, it is used as plain text.
+        def attribute_value_to_html(value)
+          begin
+            parsed_uri = URI.parse(value)
+          rescue URI::InvalidURIError
+            nil
+          end
+          if parsed_uri.nil?
+            ERB::Util.h(value)
+          else
+            label = Hyrax.config.rights_statement_service_class.new.label(value) { value }
+            # OVERRIDE FROM HYRAX to remove open-in-new-tab functionality
+            %(<a href=#{ERB::Util.h(value)}>#{label}</a>)
+          end
+        end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #611 