### PR TITLE
Apply more groups to Blacklight permissions

### DIFF
--- a/app/indexers/generic_indexer.rb
+++ b/app/indexers/generic_indexer.rb
@@ -45,8 +45,10 @@ class GenericIndexer < Hyrax::WorkIndexer
   end
 
   def index_blacklight_permissions
-    object.edit_groups = object.edit_groups + %w[admin collection_curator]
-    object.read_groups = object.read_groups + %w[admin collection_curator depositor]
-    object.discover_groups = object.discover_groups + %w[admin collection_curator depositor]
+    object.edit_groups = (object.edit_groups + %w[admin collection_curator]).uniq
+    # Edit implies read
+    object.read_groups = (object.edit_groups + object.read_groups + %w[admin collection_curator depositor]).uniq
+    # Edit and Read implies discover
+    object.discover_groups = (object.edit_groups + object.read_groups + object.discover_groups + %w[admin collection_curator depositor]).uniq
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -36,10 +36,10 @@ class Ability
   end
 
   def osu_roles
-    %w[osu_affiliate osu_user]
+    %w[osu_affiliate osu_user community_affiliate]
   end
 
   def uo_roles
-    %w[uo_affiliate uo_user]
+    %w[uo_affiliate uo_user community_affiliate]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,8 +23,8 @@ class User < ApplicationRecord
   # https://github.com/samvera/hydra-head/blob/v10.6.2/hydra-access-controls/lib/hydra/user.rb
   def groups
     groups = super
-    groups << 'osu' unless (groups & %w[osu_affiliate osu_user]).empty?
-    groups << 'uo' unless (groups & %w[uo_affiliate uo_user]).empty?
+    groups << 'osu' unless (groups & %w[osu_affiliate osu_user community_affiliate]).empty?
+    groups << 'uo' unless (groups & %w[uo_affiliate uo_user community_affiliate]).empty?
     groups
   end
   # END OVERRIDE

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,16 @@ class User < ApplicationRecord
     !(roles.map(&:name) & Array(role)).empty?
   end
 
+  # OVERRIDE FROM HYRAX: to map osu and uo roles to group & visibility
+  # https://github.com/samvera/hydra-head/blob/v10.6.2/hydra-access-controls/lib/hydra/user.rb
+  def groups
+    groups = super
+    groups << 'osu' unless (groups & %w[osu_affiliate osu_user]).empty?
+    groups << 'uo' unless (groups & %w[uo_affiliate uo_user]).empty?
+    groups
+  end
+  # END OVERRIDE
+
   # method needed for messaging
   def mailboxer_email(_obj = nil)
     email


### PR DESCRIPTION
Fixes #755 
Fixes #756 

This makes sure the solrized groups and the groups the User object returns lines up with what Blacklight expects to restrict discover, read, and access permissions.