### PR TITLE
First run: make sure the admin role exists

### DIFF
--- a/build/firstrun.sh
+++ b/build/firstrun.sh
@@ -1,7 +1,20 @@
 #!/bin/sh
 
+echo "Creating default admin set..."
 bundle exec rails hyrax:default_admin_set:create
+
+echo
+echo "Creating default collection types..."
 bundle exec rails hyrax:default_collection_types:create
+
+echo
+echo "Loading workflow stuff..."
 bundle exec rails hyrax:workflow:load
-bundle exec rails runner 'User.create(email: "admin@example.org", encrypted_password: "$2a$11$AzzYy9sCWJh6JCKu0qjvdeiSDp0e6DS2rdTOtDEHV2UZw/cQ0ltnG", preferred_locale: "en")'
-bundle exec rails runner 'User.last.roles << Role.find_by_name("admin")'
+
+echo
+echo "Creating the admin role"
+bundle exec rails runner "Role.create(name: 'admin')"
+
+echo
+echo "Creating a default admin user"
+bundle exec rails runner 'User.create(email: "admin@example.org", encrypted_password: "$2a$11$AzzYy9sCWJh6JCKu0qjvdeiSDp0e6DS2rdTOtDEHV2UZw/cQ0ltnG", preferred_locale: "en", roles: [Role.last])'


### PR DESCRIPTION
This fixes a problem where the first-run script just crashes because of the missing role