### PR TITLE
update migrator and rights_statement to use attributes_replaces_data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/OregonDigital/hyrax-migrator.git
-  revision: de45f680964d7b75105431f269bd688861d71d5b
+  revision: 75ab66ce89cafe6796207ae9168ddfdcda171a47
   branch: master
   specs:
     hyrax-migrator (0.1.0)
@@ -174,8 +174,8 @@ GEM
     awesome_nested_set (3.1.4)
       activerecord (>= 4.0.0, < 5.3)
     aws-eventstream (1.0.3)
-    aws-partitions (1.220.0)
-    aws-sdk-core (3.68.0)
+    aws-partitions (1.221.0)
+    aws-sdk-core (3.68.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -474,7 +474,7 @@ GEM
       hydra-derivatives (~> 3.0)
       hydra-file_characterization (~> 1.0)
       hydra-pcdm (>= 0.9)
-    i18n (1.6.0)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     iiif_manifest (0.5.0)
@@ -680,8 +680,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.2.0)
-      loofah (~> 2.2, >= 2.2.2)
+    rails-html-sanitizer (1.3.0)
+      loofah (~> 2.3)
     rails_autolink (1.1.6)
       rails (> 3.1)
     railties (5.1.7)
@@ -849,7 +849,7 @@ GEM
       rdf-xsd (>= 2.2, < 4.0)
       sparql (>= 2.2, < 4.0)
       sxp (~> 1.0)
-    sidekiq (6.0.0)
+    sidekiq (6.0.1)
       connection_pool (>= 2.2.2)
       rack (>= 2.0.0)
       rack-protection (>= 2.0.0)

--- a/config/initializers/migrator/crosswalk_overrides.yml
+++ b/config/initializers/migrator/crosswalk_overrides.yml
@@ -34,9 +34,10 @@ overrides:
     predicate: http://purl.org/dc/terms/subject
     multiple: true
     function: attributes_data
-  - property: license
+  - property: rights_statement
     predicate: http://purl.org/dc/terms/rights
     multiple: false
+    function: attributes_replaces_data
   - property: language
     predicate: http://purl.org/dc/terms/language
     multiple: true


### PR DESCRIPTION
- update hyrax-migrator to include patch https://github.com/OregonDigital/hyrax-migrator/pull/151
- override `rights_statement` to point to predicate `http://purl.org/dc/terms/rights` and use new `attributes_replaces_data` to temporarily replace `http://opaquenamespace.org/ns/rights/rr-f` with `http://rightsstatements.org/vocab/InC/1.0/`
