### PR TITLE
[WIP] System tests for work permissions

### DIFF
--- a/spec/system/permissions/work_create_spec.rb
+++ b/spec/system/permissions/work_create_spec.rb
@@ -1,0 +1,306 @@
+# frozen_string_literal:true
+
+RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
+  let(:user) { create(:user) }
+  let!(:ability) { ::Ability.new(user) }
+  let(:upload_file_path) { "#{Rails.root}/spec/fixtures/test.jpg" }
+
+  context 'Without any roles' do
+    before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      allow(CharacterizeJob).to receive(:perform_later)
+      sign_in_as user
+    end
+
+    it 'Blocks work creation' do
+      visit new_hyrax_generic_path
+
+      expect(page).to have_content 'You are not authorized'
+
+      # save a successful screenshot if running in CI for build artifacts
+      # rubocop:disable Lint/Debugger
+      save_screenshot if ENV.fetch('CI', nil)
+      # rubocop:enable Lint/Debugger
+    end
+  end
+
+  context 'With community affiliate role' do
+    let(:role) { Role.new(name: 'community_affiliate') }
+
+    before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      allow(CharacterizeJob).to receive(:perform_later)
+
+      user.roles = [ role ]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Blocks work creation' do
+      visit new_hyrax_generic_path
+
+      expect(page).to have_content 'You are not authorized'
+
+      # save a successful screenshot if running in CI for build artifacts
+      # rubocop:disable Lint/Debugger
+      save_screenshot if ENV.fetch('CI', nil)
+      # rubocop:enable Lint/Debugger
+    end
+  end
+
+  context 'With osu role' do
+    let(:role) { Role.new(name: 'osu_user') }
+
+    before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      allow(CharacterizeJob).to receive(:perform_later)
+
+      user.roles = [ role ]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Blocks work creation' do
+      visit new_hyrax_generic_path
+
+      expect(page).to have_content 'You are not authorized'
+
+      # save a successful screenshot if running in CI for build artifacts
+      # rubocop:disable Lint/Debugger
+      save_screenshot if ENV.fetch('CI', nil)
+      # rubocop:enable Lint/Debugger
+    end
+  end
+
+  context 'With uo role' do
+    let(:role) { Role.new(name: 'uo_user') }
+
+    before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      allow(CharacterizeJob).to receive(:perform_later)
+
+      user.roles = [ role ]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Blocks work creation' do
+      visit new_hyrax_generic_path
+
+      expect(page).to have_content 'You are not authorized'
+
+      # save a successful screenshot if running in CI for build artifacts
+      # rubocop:disable Lint/Debugger
+      save_screenshot if ENV.fetch('CI', nil)
+      # rubocop:enable Lint/Debugger
+    end
+  end
+
+  context 'With depositor role' do
+    let(:role) { Role.new(name: 'depositor') }
+
+    before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      allow(CharacterizeJob).to receive(:perform_later)
+
+      user.roles = [ role ]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Allows work creation' do
+      visit new_hyrax_generic_path
+
+      expect(page).to have_content 'Add New Generic'
+      click_link 'Files' # switch tab
+      expect(page).to have_content 'Add files'
+      expect(page).to have_content 'Add folder'
+      within('span#addfiles') do
+        page.execute_script("$('input[type=file]').css('opacity','1')")
+        page.execute_script("$('input[type=file]').css('position','inherit')")
+        attach_file('files[]', upload_file_path)
+      end
+      click_link 'Descriptions' # switch tab
+      within('div.generic_title') do
+        fill_in('Title', with: 'Test Title')
+      end
+      within('div.generic_identifier') do
+        fill_in('Identifier', with: 'Test ID')
+      end
+      within('div.generic_resource_type') do
+        select('Dataset', from: 'Type')
+      end
+      select('In Copyright', from: 'Rights')
+
+      # Selenium/chrome on CircleCI requires the focus to change after the previous method
+      find('body').click
+
+      choose('generic_visibility_open')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      # Selenium/chrome on CircleCI requires the focus to change after the previous method
+      find('body').click
+
+      check('agreement', visible: false)
+      # Selenium/chrome on CircleCI requires the focus to change after the previous method
+      find('body').click
+
+      click_on 'Save'
+      expect(page).to have_content('Test Title')
+      expect(page).to have_content 'Your files are being processed by Oregon Digital (Development) in the background.'
+      expect(page).to be_accessible.skipping('aria-allowed-role').excluding('.label-success')
+
+      # save a successful screenshot if running in CI for build artifacts
+      # rubocop:disable Lint/Debugger
+      save_screenshot if ENV.fetch('CI', nil)
+      # rubocop:enable Lint/Debugger
+    end
+  end
+
+  context 'With curation curator role' do
+    let(:role) { Role.new(name: 'collection_curator') }
+
+    before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      allow(CharacterizeJob).to receive(:perform_later)
+
+      user.roles = [ role ]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Allows work creation' do
+      visit new_hyrax_generic_path
+
+      expect(page).to have_content 'Add New Generic'
+      click_link 'Files' # switch tab
+      expect(page).to have_content 'Add files'
+      expect(page).to have_content 'Add folder'
+      within('span#addfiles') do
+        page.execute_script("$('input[type=file]').css('opacity','1')")
+        page.execute_script("$('input[type=file]').css('position','inherit')")
+        attach_file('files[]', upload_file_path)
+      end
+      click_link 'Descriptions' # switch tab
+      within('div.generic_title') do
+        fill_in('Title', with: 'Test Title')
+      end
+      within('div.generic_identifier') do
+        fill_in('Identifier', with: 'Test ID')
+      end
+      within('div.generic_resource_type') do
+        select('Dataset', from: 'Type')
+      end
+      select('In Copyright', from: 'Rights')
+
+      # Selenium/chrome on CircleCI requires the focus to change after the previous method
+      find('body').click
+
+      choose('generic_visibility_open')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      # Selenium/chrome on CircleCI requires the focus to change after the previous method
+      find('body').click
+
+      check('agreement', visible: false)
+      # Selenium/chrome on CircleCI requires the focus to change after the previous method
+      find('body').click
+
+      click_on 'Save'
+      expect(page).to have_content('Test Title')
+      expect(page).to have_content 'Your files are being processed by Oregon Digital (Development) in the background.'
+      expect(page).to be_accessible.skipping('aria-allowed-role').excluding('.label-success')
+
+      # save a successful screenshot if running in CI for build artifacts
+      # rubocop:disable Lint/Debugger
+      save_screenshot if ENV.fetch('CI', nil)
+      # rubocop:enable Lint/Debugger
+    end
+  end
+
+  context 'With admin role' do
+    let(:role) { Role.new(name: 'admin') }
+
+    before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      allow(CharacterizeJob).to receive(:perform_later)
+
+      user.roles = [ role ]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Allows work creation' do
+      visit new_hyrax_generic_path
+
+      expect(page).to have_content 'Add New Generic'
+      click_link 'Files' # switch tab
+      expect(page).to have_content 'Add files'
+      expect(page).to have_content 'Add folder'
+      within('span#addfiles') do
+        page.execute_script("$('input[type=file]').css('opacity','1')")
+        page.execute_script("$('input[type=file]').css('position','inherit')")
+        attach_file('files[]', upload_file_path)
+      end
+      click_link 'Descriptions' # switch tab
+      within('div.generic_title') do
+        fill_in('Title', with: 'Test Title')
+      end
+      within('div.generic_identifier') do
+        fill_in('Identifier', with: 'Test ID')
+      end
+      within('div.generic_resource_type') do
+        select('Dataset', from: 'Type')
+      end
+      select('In Copyright', from: 'Rights')
+
+      # Selenium/chrome on CircleCI requires the focus to change after the previous method
+      find('body').click
+
+      choose('generic_visibility_open')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      # Selenium/chrome on CircleCI requires the focus to change after the previous method
+      find('body').click
+
+      check('agreement', visible: false)
+      # Selenium/chrome on CircleCI requires the focus to change after the previous method
+      find('body').click
+
+      click_on 'Save'
+      expect(page).to have_content('Test Title')
+      expect(page).to have_content 'Your files are being processed by Oregon Digital (Development) in the background.'
+      expect(page).to be_accessible.skipping('aria-allowed-role').excluding('.label-success')
+
+      # save a successful screenshot if running in CI for build artifacts
+      # rubocop:disable Lint/Debugger
+      save_screenshot if ENV.fetch('CI', nil)
+      # rubocop:enable Lint/Debugger
+    end
+  end
+end

--- a/spec/system/permissions/work_create_spec.rb
+++ b/spec/system/permissions/work_create_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
   let!(:ability) { ::Ability.new(user) }
   let(:upload_file_path) { "#{Rails.root}/spec/fixtures/test.jpg" }
 
-  context 'Without any roles' do
+  context 'without any roles' do
     before do
       create(:permission_template_access,
              :deposit,
@@ -28,7 +28,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
     end
   end
 
-  context 'With community affiliate role' do
+  context 'with community affiliate role' do
     let(:role) { Role.new(name: 'community_affiliate') }
 
     before do
@@ -39,7 +39,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
              agent_id: user.user_key)
       allow(CharacterizeJob).to receive(:perform_later)
 
-      user.roles = [ role ]
+      user.roles = [role]
       user.save
       sign_in_as user
     end
@@ -56,7 +56,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
     end
   end
 
-  context 'With osu role' do
+  context 'with osu role' do
     let(:role) { Role.new(name: 'osu_user') }
 
     before do
@@ -67,7 +67,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
              agent_id: user.user_key)
       allow(CharacterizeJob).to receive(:perform_later)
 
-      user.roles = [ role ]
+      user.roles = [role]
       user.save
       sign_in_as user
     end
@@ -84,7 +84,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
     end
   end
 
-  context 'With uo role' do
+  context 'with uo role' do
     let(:role) { Role.new(name: 'uo_user') }
 
     before do
@@ -95,7 +95,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
              agent_id: user.user_key)
       allow(CharacterizeJob).to receive(:perform_later)
 
-      user.roles = [ role ]
+      user.roles = [role]
       user.save
       sign_in_as user
     end
@@ -112,7 +112,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
     end
   end
 
-  context 'With depositor role' do
+  context 'with depositor role' do
     let(:role) { Role.new(name: 'depositor') }
 
     before do
@@ -123,7 +123,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
              agent_id: user.user_key)
       allow(CharacterizeJob).to receive(:perform_later)
 
-      user.roles = [ role ]
+      user.roles = [role]
       user.save
       sign_in_as user
     end
@@ -176,7 +176,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
     end
   end
 
-  context 'With curation curator role' do
+  context 'with curation curator role' do
     let(:role) { Role.new(name: 'collection_curator') }
 
     before do
@@ -187,7 +187,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
              agent_id: user.user_key)
       allow(CharacterizeJob).to receive(:perform_later)
 
-      user.roles = [ role ]
+      user.roles = [role]
       user.save
       sign_in_as user
     end
@@ -240,7 +240,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
     end
   end
 
-  context 'With admin role' do
+  context 'with admin role' do
     let(:role) { Role.new(name: 'admin') }
 
     before do
@@ -251,7 +251,7 @@ RSpec.describe 'Create a work', js: true, type: :system, clean_repo: true do
              agent_id: user.user_key)
       allow(CharacterizeJob).to receive(:perform_later)
 
-      user.roles = [ role ]
+      user.roles = [role]
       user.save
       sign_in_as user
     end

--- a/spec/system/permissions/work_edit_spec.rb
+++ b/spec/system/permissions/work_edit_spec.rb
@@ -1,0 +1,310 @@
+# frozen_string_literal:true
+
+RSpec.describe 'Edit various works', js: true, type: :system, clean_repo: true do
+  let(:public_reviewed) { create(:work, title: ['public_reviewed'], depositor: 'foo@bar.baz', id: 1, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, state: Vocab::FedoraResourceStatus.active) }
+  let(:public_unreviewed) { create(:work, title: ['public_unreviewed'], depositor: 'foo@bar.baz', id: 2, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, state: Vocab::FedoraResourceStatus.inactive) }
+  let(:osu_reviewed) { create(:work, title: ['osu_reviewed'], depositor: 'foo@bar.baz', id: 3, visibility: 'osu', state: Vocab::FedoraResourceStatus.active) }
+  let(:osu_unreviewed) { create(:work, title: ['osu_unreviewed'], depositor: 'foo@bar.baz', id: 4, visibility: 'osu', state: Vocab::FedoraResourceStatus.inactive) }
+  let(:uo_reviewed) { create(:work, title: ['uo_reviewed'], depositor: 'foo@bar.baz', id: 5, visibility: 'uo', state: Vocab::FedoraResourceStatus.active) }
+  let(:uo_unreviewed) { create(:work, title: ['uo_unreviewed'], depositor: 'foo@bar.baz', id: 6, visibility: 'uo', state: Vocab::FedoraResourceStatus.inactive) }
+  let(:private_reviewed) { create(:work, title: ['private_reviewed'], depositor: 'foo@bar.baz', id: 7, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, state: Vocab::FedoraResourceStatus.active) }
+  let(:private_unreviewed) { create(:work, title: ['private_unreviewed'], depositor: 'foo@bar.baz', id: 8, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, state: Vocab::FedoraResourceStatus.inactive) }
+  let(:user) { create(:user) }
+  let!(:ability) { ::Ability.new(user) }
+
+  before do
+    public_reviewed.save!
+    public_unreviewed.save!
+    osu_reviewed.save!
+    osu_unreviewed.save!
+    uo_reviewed.save!
+    uo_unreviewed.save!
+    private_reviewed.save!
+    private_unreviewed.save!
+  end
+
+  context 'with an unauthenticated user' do
+    it 'Blocks all works' do
+      visit edit_hyrax_generic_path public_reviewed.id
+      expect(page).to have_content 'not authorized'
+
+      visit edit_hyrax_generic_path public_unreviewed.id
+      expect(page).to have_content 'not authorized'
+
+      visit edit_hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'not authorized'
+
+      visit edit_hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'not authorized'
+
+      visit edit_hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'not authorized'
+
+      visit edit_hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'not authorized'
+
+      visit edit_hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'not authorized'
+
+      visit edit_hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'not authorized'
+    end
+  end
+
+  context 'without any roles' do
+    before do
+      sign_in_as user
+    end
+
+    it 'Blocks all works' do
+      visit edit_hyrax_generic_path public_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path public_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+  end
+
+  context 'with community affiliate role' do
+    let(:role) { Role.new(name: 'community_affiliate') }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Blocks all works' do
+      visit edit_hyrax_generic_path public_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path public_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+  end
+
+  context 'with osu role' do
+    let(:role) { Role.new(name: 'osu_user') }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Blocks all works' do
+      visit edit_hyrax_generic_path public_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path public_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+  end
+
+  context 'with uo role' do
+    let(:role) { Role.new(name: 'uo_user') }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Blocks all works' do
+      visit edit_hyrax_generic_path public_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path public_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+  end
+
+  context 'with depositor role' do
+    let(:role) { Role.new(name: 'depositor') }
+    let(:deposited) { create(:work, title: ['deposited'], id: 9, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, state: Vocab::FedoraResourceStatus.active) }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+
+      deposited.depositor = user.email
+      deposited.save
+    end
+
+    it 'Allows self deposited works' do
+      visit edit_hyrax_generic_path deposited.id
+      expect(page).to have_content 'deposited'
+    end
+
+    it 'Blocks non-deposited works' do
+      visit edit_hyrax_generic_path public_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path public_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit edit_hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+  end
+
+  context 'with collection curator role' do
+    let(:role) { Role.new(name: 'collection_curator') }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Allows all works' do
+      visit edit_hyrax_generic_path public_reviewed.id
+      expect(page).to have_content 'public_reviewed'
+
+      visit edit_hyrax_generic_path public_unreviewed.id
+      expect(page).to have_content 'public_unreviewed'
+
+      visit edit_hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'osu_reviewed'
+
+      visit edit_hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'osu_unreviewed'
+
+      visit edit_hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'uo_reviewed'
+
+      visit edit_hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'uo_unreviewed'
+
+      visit edit_hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'private_reviewed'
+
+      visit edit_hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'private_unreviewed'
+    end
+  end
+
+  context 'with admin role' do
+    let(:role) { Role.new(name: 'admin') }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Allows all works' do
+      visit edit_hyrax_generic_path public_reviewed.id
+      expect(page).to have_content 'public_reviewed'
+
+      visit edit_hyrax_generic_path public_unreviewed.id
+      expect(page).to have_content 'public_unreviewed'
+
+      visit edit_hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'osu_reviewed'
+
+      visit edit_hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'osu_unreviewed'
+
+      visit edit_hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'uo_reviewed'
+
+      visit edit_hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'uo_unreviewed'
+
+      visit edit_hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'private_reviewed'
+
+      visit edit_hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'private_unreviewed'
+    end
+  end
+end

--- a/spec/system/permissions/work_search_spec.rb
+++ b/spec/system/permissions/work_search_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal:true
+
+RSpec.describe 'Search various works', js: true, type: :system, clean_repo: true do
+  let(:public_reviewed) { create(:work, title: ['public_reviewed'], depositor: 'foo@bar.baz', id: 1, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, state: Vocab::FedoraResourceStatus.active) }
+  let(:public_unreviewed) { create(:work, title: ['public_unreviewed'], depositor: 'foo@bar.baz', id: 2, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, state: Vocab::FedoraResourceStatus.inactive) }
+  let(:osu_reviewed) { create(:work, title: ['osu_reviewed'], depositor: 'foo@bar.baz', id: 3, visibility: 'osu', state: Vocab::FedoraResourceStatus.active) }
+  let(:osu_unreviewed) { create(:work, title: ['osu_unreviewed'], depositor: 'foo@bar.baz', id: 4, visibility: 'osu', state: Vocab::FedoraResourceStatus.inactive) }
+  let(:uo_reviewed) { create(:work, title: ['uo_reviewed'], depositor: 'foo@bar.baz', id: 5, visibility: 'uo', state: Vocab::FedoraResourceStatus.active) }
+  let(:uo_unreviewed) { create(:work, title: ['uo_unreviewed'], depositor: 'foo@bar.baz', id: 6, visibility: 'uo', state: Vocab::FedoraResourceStatus.inactive) }
+  let(:private_reviewed) { create(:work, title: ['private_reviewed'], depositor: 'foo@bar.baz', id: 7, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, state: Vocab::FedoraResourceStatus.active) }
+  let(:private_unreviewed) { create(:work, title: ['private_unreviewed'], depositor: 'foo@bar.baz', id: 8, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, state: Vocab::FedoraResourceStatus.inactive) }
+  let(:out_adminset) { create(:work, title: ['out_adminset'], depositor: 'foo@bar.baz', id: 9, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, state: Vocab::FedoraResourceStatus.inactive, admin_set_id: out_set.id) }
+  let(:in_adminset) { create(:work, title: ['in_adminset'], depositor: 'foo@bar.baz', id: 10, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, state: Vocab::FedoraResourceStatus.inactive, admin_set_id: in_set.id) }
+  let(:user) { create(:user) }
+  let!(:ability) { ::Ability.new(user) }
+  let(:out_set) { create(:admin_set) }
+  let(:in_set) { create(:admin_set) }
+
+  before do
+    public_reviewed.save!
+    public_unreviewed.save!
+    osu_reviewed.save!
+    osu_unreviewed.save!
+    uo_reviewed.save!
+    uo_unreviewed.save!
+    private_reviewed.save!
+    private_unreviewed.save!
+    out_adminset.save!
+    in_adminset.save!
+    create(:permission_template_access,
+           :manage,
+           permission_template: create(:permission_template, with_admin_set: true, source_id: out_set.id, with_active_workflow: true),
+           agent_type: 'user')
+    create(:permission_template_access,
+           :manage,
+           permission_template: create(:permission_template, with_admin_set: true, source_id: in_set.id, with_active_workflow: true),
+           agent_type: 'user')
+  end
+
+  context 'with an unauthenticated user' do
+    it 'Searches reviewed public works' do
+      visit search_catalog_path
+      expect(page).to have_content 'public_reviewed'
+    end
+
+    it 'Does not search unreviewed public works' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'public_unreviewed'
+      expect(page).not_to have_content 'osu_unreviewed'
+      expect(page).not_to have_content 'uo_unreviewed'
+      expect(page).not_to have_content 'private_unreviewed'
+    end
+
+    it 'Does not search non-public works' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'osu_reviewed'
+      expect(page).not_to have_content 'uo_reviewed'
+      expect(page).not_to have_content 'private_reviewed'
+    end
+  end
+
+  context 'without any roles' do
+    before do
+      sign_in_as user
+    end
+
+    it 'Searches reviewed public works' do
+      visit search_catalog_path
+      expect(page).to have_content 'public_reviewed'
+    end
+
+    it 'Does not search unreviewed public works' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'public_unreviewed'
+      expect(page).not_to have_content 'osu_unreviewed'
+      expect(page).not_to have_content 'uo_unreviewed'
+      expect(page).not_to have_content 'private_unreviewed'
+    end
+
+    it 'Does not search non-public works' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'osu_reviewed'
+      expect(page).not_to have_content 'uo_reviewed'
+      expect(page).not_to have_content 'private_reviewed'
+    end
+  end
+
+  context 'with community affiliate role' do
+    let(:role) { Role.new(name: 'community_affiliate') }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Searches reviewed public works' do
+      visit search_catalog_path
+      expect(page).to have_content 'public_reviewed'
+    end
+
+    it 'Searches reviewed OSU and UO works' do
+      visit search_catalog_path
+      expect(page).to have_content 'osu_reviewed'
+      expect(page).to have_content 'uo_reviewed'
+    end
+
+    it 'Does not search unreviewed works' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'public_unreviewed'
+      expect(page).not_to have_content 'osu_unreviewed'
+      expect(page).not_to have_content 'uo_unreviewed'
+      expect(page).not_to have_content 'private_unreviewed'
+    end
+
+    it 'Does not search private works' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'private_reviewed'
+    end
+  end
+
+  context 'with osu role' do
+    let(:role) { Role.new(name: 'osu_user') }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Searches reviewed public works' do
+      visit search_catalog_path
+      expect(page).to have_content 'public_reviewed'
+    end
+
+    it 'Searches reviewed OSU works' do
+      visit search_catalog_path
+      expect(page).to have_content 'osu_reviewed'
+    end
+
+    it 'Does not search UO works' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'uo_reviewed'
+    end
+
+    it 'Does not search unreviewed works' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'public_unreviewed'
+      expect(page).not_to have_content 'osu_unreviewed'
+      expect(page).not_to have_content 'uo_unreviewed'
+      expect(page).not_to have_content 'private_unreviewed'
+    end
+
+    it 'Does not search private works' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'private_reviewed'
+    end
+  end
+
+  context 'with uo role' do
+    let(:role) { Role.new(name: 'uo_user') }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Searches reviewed public works' do
+      visit search_catalog_path
+      expect(page).to have_content 'public_reviewed'
+    end
+
+    it 'Searches reviewed UO works' do
+      visit search_catalog_path
+      expect(page).to have_content 'uo_reviewed'
+    end
+
+    it 'Does not search OSU works' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'osu_unreviewed'
+    end
+
+    it 'Does not search unreviewed works' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'public_unreviewed'
+      expect(page).not_to have_content 'osu_unreviewed'
+      expect(page).not_to have_content 'uo_unreviewed'
+      expect(page).not_to have_content 'private_unreviewed'
+    end
+
+    it 'Does not search private works' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'private_reviewed'
+    end
+  end
+
+  context 'with depositor role' do
+    let(:role) { Role.new(name: 'depositor') }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Searches reviewed works' do
+      visit search_catalog_path
+      expect(page).to have_content 'public_reviewed'
+      expect(page).to have_content 'osu_reviewed'
+      expect(page).to have_content 'uo_reviewed'
+      expect(page).to have_content 'private_reviewed'
+    end
+
+    it 'Searches unreviewed works I can deposit into' do
+      visit search_catalog_path
+      expect(page).to have_content 'in_adminset'
+    end
+
+    it 'Does not search unreviewed works I cannot deposit into' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'out_adminset'
+    end
+  end
+
+  context 'with curation curator role' do
+    let(:role) { Role.new(name: 'depositor') }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Searches reviewed works' do
+      visit search_catalog_path
+      expect(page).to have_content 'public_reviewed'
+      expect(page).to have_content 'osu_reviewed'
+      expect(page).to have_content 'uo_reviewed'
+      expect(page).to have_content 'private_reviewed'
+    end
+
+    it 'Searches unreviewed works I can manage' do
+      visit search_catalog_path
+      expect(page).to have_content 'in_adminset'
+    end
+
+    it 'Does not search unreviewed works I cannot manage' do
+      visit search_catalog_path
+      expect(page).not_to have_content 'out_adminset'
+    end
+  end
+end

--- a/spec/system/permissions/work_search_spec.rb
+++ b/spec/system/permissions/work_search_spec.rb
@@ -27,14 +27,6 @@ RSpec.describe 'Search various works', js: true, type: :system, clean_repo: true
     private_unreviewed.save!
     out_adminset.save!
     in_adminset.save!
-    create(:permission_template_access,
-           :manage,
-           permission_template: create(:permission_template, with_admin_set: true, source_id: out_set.id, with_active_workflow: true),
-           agent_type: 'user')
-    create(:permission_template_access,
-           :manage,
-           permission_template: create(:permission_template, with_admin_set: true, source_id: in_set.id, with_active_workflow: true),
-           agent_type: 'user')
   end
 
   context 'with an unauthenticated user' do
@@ -199,6 +191,14 @@ RSpec.describe 'Search various works', js: true, type: :system, clean_repo: true
     let(:role) { Role.new(name: 'depositor') }
 
     before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, with_admin_set: true, source_id: out_set.id, with_active_workflow: true),
+             agent_type: 'user')
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, with_admin_set: true, source_id: in_set.id, with_active_workflow: true),
+             agent_type: 'user')
       user.roles = [role]
       user.save
       sign_in_as user
@@ -223,10 +223,18 @@ RSpec.describe 'Search various works', js: true, type: :system, clean_repo: true
     end
   end
 
-  context 'with curation curator role' do
-    let(:role) { Role.new(name: 'depositor') }
+  context 'with collection curator role' do
+    let(:role) { Role.new(name: 'collection') }
 
     before do
+      create(:permission_template_access,
+             :manage,
+             permission_template: create(:permission_template, with_admin_set: true, source_id: out_set.id, with_active_workflow: true),
+             agent_type: 'user')
+      create(:permission_template_access,
+             :manage,
+             permission_template: create(:permission_template, with_admin_set: true, source_id: in_set.id, with_active_workflow: true),
+             agent_type: 'user')
       user.roles = [role]
       user.save
       sign_in_as user
@@ -248,6 +256,30 @@ RSpec.describe 'Search various works', js: true, type: :system, clean_repo: true
     it 'Does not search unreviewed works I cannot manage' do
       visit search_catalog_path
       expect(page).not_to have_content 'out_adminset'
+    end
+  end
+
+  context 'with admin role' do
+    let(:role) { Role.new(name: 'admin') }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Searches all works' do
+      visit search_catalog_path
+      expect(page).to have_content 'public_reviewed'
+      expect(page).to have_content 'public_unreviewed'
+      expect(page).to have_content 'osu_reviewed'
+      expect(page).to have_content 'osu_unreviewed'
+      expect(page).to have_content 'uo_reviewed'
+      expect(page).to have_content 'uo_unreviewed'
+      expect(page).to have_content 'private_reviewed'
+      expect(page).to have_content 'private_unreviewed'
+      expect(page).to have_content 'in_adminset'
+      expect(page).to have_content 'out_adminset'
     end
   end
 end

--- a/spec/system/permissions/work_view_spec.rb
+++ b/spec/system/permissions/work_view_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
   let(:uo_unreviewed) { create(:work, title: ['uo_unreviewed'], depositor: 'foo@bar.baz', id: 6, visibility: 'uo', state: Vocab::FedoraResourceStatus.inactive) }
   let(:private_reviewed) { create(:work, title: ['private_reviewed'], depositor: 'foo@bar.baz', id: 7, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, state: Vocab::FedoraResourceStatus.active) }
   let(:private_unreviewed) { create(:work, title: ['private_unreviewed'], depositor: 'foo@bar.baz', id: 8, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, state: Vocab::FedoraResourceStatus.inactive) }
-  let(:out_adminset) { create(:work, title: ['out_adminset'], depositor: 'foo@bar.baz', id: 9, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, state: Vocab::FedoraResourceStatus.inactive, admin_set_id: out_set.id) }
-  let(:in_adminset) { create(:work, title: ['in_adminset'], depositor: 'foo@bar.baz', id: 9, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, state: Vocab::FedoraResourceStatus.inactive, admin_set_id: in_set.id) }
+  let(:out_adminset) { create(:work, title: ['out_adminset'], depositor: 'foo@bar.baz', id: 9, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, state: Vocab::FedoraResourceStatus.inactive, admin_set_id: out_set.id) }
+  let(:in_adminset) { create(:work, title: ['in_adminset'], depositor: 'foo@bar.baz', id: 10, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, state: Vocab::FedoraResourceStatus.inactive, admin_set_id: in_set.id) }
   let(:user) { create(:user) }
   let!(:ability) { ::Ability.new(user) }
   let(:out_set) { create(:admin_set) }
@@ -25,6 +25,8 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     uo_unreviewed.save!
     private_reviewed.save!
     private_unreviewed.save!
+    out_adminset.save!
+    in_adminset.save!
     create(:permission_template_access,
            :manage,
            permission_template: create(:permission_template, with_admin_set: true, source_id: out_set.id, with_active_workflow: true),

--- a/spec/system/permissions/work_view_spec.rb
+++ b/spec/system/permissions/work_view_spec.rb
@@ -1,0 +1,315 @@
+# frozen_string_literal:true
+
+RSpec.describe 'View various works', js: true, type: :system, clean_repo: true do
+  let(:public_reviewed) { create(:work, title: ['public_reviewed'], depositor: 'foo@bar.baz', id: 1, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, state: Vocab::FedoraResourceStatus.active) }
+  let(:public_unreviewed) { create(:work, title: ['public_unreviewed'], depositor: 'foo@bar.baz', id: 2, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, state: Vocab::FedoraResourceStatus.inactive) }
+  let(:osu_reviewed) { create(:work, title: ['osu_reviewed'], depositor: 'foo@bar.baz', id: 3, visibility: 'osu', state: Vocab::FedoraResourceStatus.active) }
+  let(:osu_unreviewed) { create(:work, title: ['osu_unreviewed'], depositor: 'foo@bar.baz', id: 4, visibility: 'osu', state: Vocab::FedoraResourceStatus.inactive) }
+  let(:uo_reviewed) { create(:work, title: ['uo_reviewed'], depositor: 'foo@bar.baz', id: 5, visibility: 'uo', state: Vocab::FedoraResourceStatus.active) }
+  let(:uo_unreviewed) { create(:work, title: ['uo_unreviewed'], depositor: 'foo@bar.baz', id: 6, visibility: 'uo', state: Vocab::FedoraResourceStatus.inactive) }
+  let(:private_reviewed) { create(:work, title: ['private_reviewed'], depositor: 'foo@bar.baz', id: 7, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, state: Vocab::FedoraResourceStatus.active) }
+  let(:private_unreviewed) { create(:work, title: ['private_unreviewed'], depositor: 'foo@bar.baz', id: 8, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, state: Vocab::FedoraResourceStatus.inactive) }
+  let(:out_adminset) { create(:work, title: ['out_adminset'], depositor: 'foo@bar.baz', id: 9, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, state: Vocab::FedoraResourceStatus.inactive, admin_set_id: out_set.id) }
+  let(:in_adminset) { create(:work, title: ['in_adminset'], depositor: 'foo@bar.baz', id: 9, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, state: Vocab::FedoraResourceStatus.inactive, admin_set_id: in_set.id) }
+  let(:user) { create(:user) }
+  let!(:ability) { ::Ability.new(user) }
+  let(:out_set) { create(:admin_set) }
+  let(:in_set) { create(:admin_set) }
+  let(:out_permission_template_access) { create(:permission_template_access,
+                                                :manage,
+                                                permission_template: create(:permission_template, with_admin_set: true, source_id: out_set.id, with_active_workflow: true),
+                                                agent_type: 'user') }
+  let(:in_permission_template_access) { create(:permission_template_access,
+                                               :manage,
+                                               permission_template: create(:permission_template, with_admin_set: true, source_id: in_set.id, with_active_workflow: true),
+                                               agent_type: 'user') }
+
+  before do
+    public_reviewed.save!
+    public_unreviewed.save!
+    osu_reviewed.save!
+    osu_unreviewed.save!
+    uo_reviewed.save!
+    uo_unreviewed.save!
+    private_reviewed.save!
+    private_unreviewed.save!
+  end
+
+  context 'As an unauthenticated user' do
+    it 'Shows reviewed public works' do
+      visit hyrax_generic_path public_reviewed.id
+
+      expect(page).to have_content 'public_reviewed'
+    end
+
+    it 'Blocks unreviewed public works' do
+      visit hyrax_generic_path public_unreviewed.id
+
+      expect(page).to have_content 'not currently available'
+    end
+
+    it 'Blocks non-public works' do
+      visit hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'not authorized'
+
+      visit hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'not authorized'
+
+      visit hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'not authorized'
+
+      visit hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'not authorized'
+
+      visit hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'not authorized'
+
+      visit hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'not authorized'
+    end
+  end
+
+  context 'Without any roles' do
+    before do
+      sign_in_as user
+    end
+
+    it 'Shows reviewed public works' do
+      visit hyrax_generic_path public_reviewed.id
+
+      expect(page).to have_content 'public_reviewed'
+    end
+
+    it 'blocks unreviewed public works' do
+      visit hyrax_generic_path public_unreviewed.id
+
+      expect(page).to have_content 'not currently available'
+    end
+
+    it 'Blocks non-public works' do
+      visit hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+  end
+
+  context 'With community affiliate role' do
+    let(:role) { Role.new(name: 'community_affiliate') }
+
+    before do
+      user.roles = [ role ]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Shows reviewed public works' do
+      visit hyrax_generic_path public_reviewed.id
+
+      expect(page).to have_content 'public_reviewed'
+    end
+
+    it 'blocks unreviewed public works' do
+      visit hyrax_generic_path public_unreviewed.id
+
+      expect(page).to have_content 'not currently available'
+    end
+
+    it 'Shows reviewed OSU and UO works' do
+      visit hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'osu_reviewed'
+
+      visit hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'uo_reviewed'
+    end
+
+    it 'Blocks unreviewed works' do
+      visit hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'not currently available'
+
+      visit hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'not currently available'
+
+      visit hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+
+    it 'Blocks private works' do
+      visit hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+  end
+
+  context 'With osu role' do
+    let(:role) { Role.new(name: 'osu_user') }
+
+    before do
+      user.roles = [ role ]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Shows reviewed public works' do
+      visit hyrax_generic_path public_reviewed.id
+
+      expect(page).to have_content 'public_reviewed'
+    end
+
+    it 'blocks unreviewed public works' do
+      visit hyrax_generic_path public_unreviewed.id
+
+      expect(page).to have_content 'not currently available'
+    end
+
+    it 'Shows reviewed OSU works' do
+      visit hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'osu_reviewed'
+    end
+
+    it 'Blocks UO works' do
+      visit hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+
+    it 'Blocks unreviewed works' do
+      visit hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'not currently available'
+
+      visit hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+
+    it 'Blocks private works' do
+      visit hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+  end
+
+  context 'With uo role' do
+    let(:role) { Role.new(name: 'uo_user') }
+
+    before do
+      user.roles = [ role ]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Shows reviewed public works' do
+      visit hyrax_generic_path public_reviewed.id
+
+      expect(page).to have_content 'public_reviewed'
+    end
+
+    it 'blocks unreviewed public works' do
+      visit hyrax_generic_path public_unreviewed.id
+
+      expect(page).to have_content 'not currently available'
+    end
+
+    it 'Shows reviewed UO works' do
+      visit hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'uo_reviewed'
+    end
+
+    it 'Blocks OSU works' do
+      visit hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+
+      visit hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+
+    it 'Blocks unreviewed works' do
+      visit hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'not currently available'
+
+      visit hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+
+    it 'Blocks private works' do
+      visit hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'Unauthorized'
+    end
+  end
+
+  context 'With depositor role' do
+    let(:role) { Role.new(name: 'depositor') }
+
+    before do
+      user.roles = [ role ]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Shows reviewed works' do
+      visit hyrax_generic_path public_reviewed.id
+      expect(page).to have_content 'public_reviewed'
+
+      visit hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'osu_reviewed'
+
+      visit hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'uo_reviewed'
+
+      visit hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'private_reviewed'
+    end
+
+    it 'Shows unreviewed works I can deposit into' do
+      visit hyrax_generic_path in_adminset.id
+      expect(page).to have_content 'in_adminset'
+    end
+
+    it 'Blocks unreviewed works I cannot deposit into' do
+      visit hyrax_generic_path out_adminset.id
+      expect(page).to have_content 'not currently available'
+    end
+  end
+
+  context 'With curation curator role' do
+    let(:role) { Role.new(name: 'depositor') }
+
+    before do
+      user.roles = [ role ]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Shows reviewed works' do
+      visit hyrax_generic_path public_reviewed.id
+      expect(page).to have_content 'public_reviewed'
+
+      visit hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'osu_reviewed'
+
+      visit hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'uo_reviewed'
+
+      visit hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'private_reviewed'
+    end
+
+    it 'Shows unreviewed works I can manage' do
+    end
+
+    it 'Blocks unreviewed works I cannot manage' do
+    end
+  end
+end

--- a/spec/system/permissions/work_view_spec.rb
+++ b/spec/system/permissions/work_view_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     it 'Shows reviewed public works' do
       visit hyrax_generic_path public_reviewed.id
 
-      expect(page).to have_content 'public_reviewed'
+      expect(page).to have_content 'MLA Citation'
     end
 
     it 'Blocks unreviewed public works' do
@@ -71,7 +71,7 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     it 'Shows reviewed public works' do
       visit hyrax_generic_path public_reviewed.id
 
-      expect(page).to have_content 'public_reviewed'
+      expect(page).to have_content 'MLA Citation'
     end
 
     it 'blocks unreviewed public works' do
@@ -113,7 +113,7 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     it 'Shows reviewed public works' do
       visit hyrax_generic_path public_reviewed.id
 
-      expect(page).to have_content 'public_reviewed'
+      expect(page).to have_content 'MLA Citation'
     end
 
     it 'blocks unreviewed public works' do
@@ -124,10 +124,10 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
 
     it 'Shows reviewed OSU and UO works' do
       visit hyrax_generic_path osu_reviewed.id
-      expect(page).to have_content 'osu_reviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path uo_reviewed.id
-      expect(page).to have_content 'uo_reviewed'
+      expect(page).to have_content 'MLA Citation'
     end
 
     it 'Blocks unreviewed works' do
@@ -159,7 +159,7 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     it 'Shows reviewed public works' do
       visit hyrax_generic_path public_reviewed.id
 
-      expect(page).to have_content 'public_reviewed'
+      expect(page).to have_content 'MLA Citation'
     end
 
     it 'blocks unreviewed public works' do
@@ -170,7 +170,7 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
 
     it 'Shows reviewed OSU works' do
       visit hyrax_generic_path osu_reviewed.id
-      expect(page).to have_content 'osu_reviewed'
+      expect(page).to have_content 'MLA Citation'
     end
 
     it 'Blocks UO works' do
@@ -207,7 +207,7 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     it 'Shows reviewed public works' do
       visit hyrax_generic_path public_reviewed.id
 
-      expect(page).to have_content 'public_reviewed'
+      expect(page).to have_content 'MLA Citation'
     end
 
     it 'blocks unreviewed public works' do
@@ -218,7 +218,7 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
 
     it 'Shows reviewed UO works' do
       visit hyrax_generic_path uo_reviewed.id
-      expect(page).to have_content 'uo_reviewed'
+      expect(page).to have_content 'MLA Citation'
     end
 
     it 'Blocks OSU works' do
@@ -262,21 +262,21 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
 
     it 'Shows reviewed works' do
       visit hyrax_generic_path public_reviewed.id
-      expect(page).to have_content 'public_reviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path osu_reviewed.id
-      expect(page).to have_content 'osu_reviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path uo_reviewed.id
-      expect(page).to have_content 'uo_reviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path private_reviewed.id
-      expect(page).to have_content 'private_reviewed'
+      expect(page).to have_content 'MLA Citation'
     end
 
     it 'Shows unreviewed works I can deposit into' do
       visit hyrax_generic_path in_adminset.id
-      expect(page).to have_content 'in_adminset'
+      expect(page).to have_content 'MLA Citation'
     end
 
     it 'Blocks unreviewed works I cannot deposit into' do
@@ -304,21 +304,21 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
 
     it 'Shows reviewed works' do
       visit hyrax_generic_path public_reviewed.id
-      expect(page).to have_content 'public_reviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path osu_reviewed.id
-      expect(page).to have_content 'osu_reviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path uo_reviewed.id
-      expect(page).to have_content 'uo_reviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path private_reviewed.id
-      expect(page).to have_content 'private_reviewed'
+      expect(page).to have_content 'MLA Citation'
     end
 
     it 'Shows unreviewed works I can manage' do
       visit hyrax_generic_path in_adminset.id
-      expect(page).to have_content 'in_adminset'
+      expect(page).to have_content 'MLA Citation'
     end
 
     it 'Blocks unreviewed works I cannot manage' do
@@ -338,28 +338,28 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
 
     it 'Shows all works' do
       visit hyrax_generic_path public_reviewed.id
-      expect(page).to have_content 'public_reviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path public_unreviewed.id
-      expect(page).to have_content 'public_unreviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path osu_reviewed.id
-      expect(page).to have_content 'osu_reviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path osu_unreviewed.id
-      expect(page).to have_content 'osu_unreviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path uo_reviewed.id
-      expect(page).to have_content 'uo_reviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path uo_unreviewed.id
-      expect(page).to have_content 'uo_unreviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path private_reviewed.id
-      expect(page).to have_content 'private_reviewed'
+      expect(page).to have_content 'MLA Citation'
 
       visit hyrax_generic_path private_unreviewed.id
-      expect(page).to have_content 'private_unreviewed'
+      expect(page).to have_content 'MLA Citation'
     end
   end
 end

--- a/spec/system/permissions/work_view_spec.rb
+++ b/spec/system/permissions/work_view_spec.rb
@@ -15,14 +15,6 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
   let!(:ability) { ::Ability.new(user) }
   let(:out_set) { create(:admin_set) }
   let(:in_set) { create(:admin_set) }
-  let(:out_permission_template_access) { create(:permission_template_access,
-                                                :manage,
-                                                permission_template: create(:permission_template, with_admin_set: true, source_id: out_set.id, with_active_workflow: true),
-                                                agent_type: 'user') }
-  let(:in_permission_template_access) { create(:permission_template_access,
-                                               :manage,
-                                               permission_template: create(:permission_template, with_admin_set: true, source_id: in_set.id, with_active_workflow: true),
-                                               agent_type: 'user') }
 
   before do
     public_reviewed.save!
@@ -33,9 +25,17 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     uo_unreviewed.save!
     private_reviewed.save!
     private_unreviewed.save!
+    create(:permission_template_access,
+           :manage,
+           permission_template: create(:permission_template, with_admin_set: true, source_id: out_set.id, with_active_workflow: true),
+           agent_type: 'user')
+    create(:permission_template_access,
+           :manage,
+           permission_template: create(:permission_template, with_admin_set: true, source_id: in_set.id, with_active_workflow: true),
+           agent_type: 'user')
   end
 
-  context 'As an unauthenticated user' do
+  context 'with an unauthenticated user' do
     it 'Shows reviewed public works' do
       visit hyrax_generic_path public_reviewed.id
 
@@ -69,7 +69,7 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     end
   end
 
-  context 'Without any roles' do
+  context 'without any roles' do
     before do
       sign_in_as user
     end
@@ -107,11 +107,11 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     end
   end
 
-  context 'With community affiliate role' do
+  context 'with community affiliate role' do
     let(:role) { Role.new(name: 'community_affiliate') }
 
     before do
-      user.roles = [ role ]
+      user.roles = [role]
       user.save
       sign_in_as user
     end
@@ -153,11 +153,11 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     end
   end
 
-  context 'With osu role' do
+  context 'with osu role' do
     let(:role) { Role.new(name: 'osu_user') }
 
     before do
-      user.roles = [ role ]
+      user.roles = [role]
       user.save
       sign_in_as user
     end
@@ -201,11 +201,11 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     end
   end
 
-  context 'With uo role' do
+  context 'with uo role' do
     let(:role) { Role.new(name: 'uo_user') }
 
     before do
-      user.roles = [ role ]
+      user.roles = [role]
       user.save
       sign_in_as user
     end
@@ -249,11 +249,11 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     end
   end
 
-  context 'With depositor role' do
+  context 'with depositor role' do
     let(:role) { Role.new(name: 'depositor') }
 
     before do
-      user.roles = [ role ]
+      user.roles = [role]
       user.save
       sign_in_as user
     end
@@ -283,11 +283,11 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     end
   end
 
-  context 'With curation curator role' do
+  context 'with curation curator role' do
     let(:role) { Role.new(name: 'depositor') }
 
     before do
-      user.roles = [ role ]
+      user.roles = [role]
       user.save
       sign_in_as user
     end
@@ -307,9 +307,13 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     end
 
     it 'Shows unreviewed works I can manage' do
+      visit hyrax_generic_path in_adminset.id
+      expect(page).to have_content 'in_adminset'
     end
 
     it 'Blocks unreviewed works I cannot manage' do
+      visit hyrax_generic_path out_adminset.id
+      expect(page).to have_content 'not currently available'
     end
   end
 end

--- a/spec/system/permissions/work_view_spec.rb
+++ b/spec/system/permissions/work_view_spec.rb
@@ -27,14 +27,6 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     private_unreviewed.save!
     out_adminset.save!
     in_adminset.save!
-    create(:permission_template_access,
-           :manage,
-           permission_template: create(:permission_template, with_admin_set: true, source_id: out_set.id, with_active_workflow: true),
-           agent_type: 'user')
-    create(:permission_template_access,
-           :manage,
-           permission_template: create(:permission_template, with_admin_set: true, source_id: in_set.id, with_active_workflow: true),
-           agent_type: 'user')
   end
 
   context 'with an unauthenticated user' do
@@ -255,6 +247,14 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     let(:role) { Role.new(name: 'depositor') }
 
     before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, with_admin_set: true, source_id: out_set.id, with_active_workflow: true),
+             agent_type: 'user')
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, with_admin_set: true, source_id: in_set.id, with_active_workflow: true),
+             agent_type: 'user')
       user.roles = [role]
       user.save
       sign_in_as user
@@ -285,10 +285,18 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     end
   end
 
-  context 'with curation curator role' do
-    let(:role) { Role.new(name: 'depositor') }
+  context 'with collection curator role' do
+    let(:role) { Role.new(name: 'collection_curator') }
 
     before do
+      create(:permission_template_access,
+             :manage,
+             permission_template: create(:permission_template, with_admin_set: true, source_id: out_set.id, with_active_workflow: true),
+             agent_type: 'user')
+      create(:permission_template_access,
+             :manage,
+             permission_template: create(:permission_template, with_admin_set: true, source_id: in_set.id, with_active_workflow: true),
+             agent_type: 'user')
       user.roles = [role]
       user.save
       sign_in_as user
@@ -316,6 +324,42 @@ RSpec.describe 'View various works', js: true, type: :system, clean_repo: true d
     it 'Blocks unreviewed works I cannot manage' do
       visit hyrax_generic_path out_adminset.id
       expect(page).to have_content 'not currently available'
+    end
+  end
+
+  context 'with admin role' do
+    let(:role) { Role.new(name: 'admin') }
+
+    before do
+      user.roles = [role]
+      user.save
+      sign_in_as user
+    end
+
+    it 'Shows all works' do
+      visit hyrax_generic_path public_reviewed.id
+      expect(page).to have_content 'public_reviewed'
+
+      visit hyrax_generic_path public_unreviewed.id
+      expect(page).to have_content 'public_unreviewed'
+
+      visit hyrax_generic_path osu_reviewed.id
+      expect(page).to have_content 'osu_reviewed'
+
+      visit hyrax_generic_path osu_unreviewed.id
+      expect(page).to have_content 'osu_unreviewed'
+
+      visit hyrax_generic_path uo_reviewed.id
+      expect(page).to have_content 'uo_reviewed'
+
+      visit hyrax_generic_path uo_unreviewed.id
+      expect(page).to have_content 'uo_unreviewed'
+
+      visit hyrax_generic_path private_reviewed.id
+      expect(page).to have_content 'private_reviewed'
+
+      visit hyrax_generic_path private_unreviewed.id
+      expect(page).to have_content 'private_unreviewed'
     end
   end
 end


### PR DESCRIPTION
Beginning work on #804
Accomplishes permission tests for Creating, Viewing, and Searching works.

Changes behavior of search a little. Unreviewed works are difficult and impractical to display on catalog search while making restrictions based on collection/admin set. Depositor and Collection Curator roles have had their permissions backed off to not be able to search the catalog for unreviewed works, and apparently admins couldn't do this already anyways. Unreviewed works can still be found at the managed works page.