### PR TITLE
Low- and high-res download permissions

### DIFF
--- a/app/controllers/concerns/oregon_digital/download_controller_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/download_controller_behavior.rb
@@ -3,6 +3,10 @@
 module OregonDigital
   # Behavior to download data about a work
   module DownloadControllerBehavior
+    def download_low
+      send_data curation_concern.zip_files.string, filename: "#{curation_concern.id}.zip"
+    end
+
     def download
       send_data curation_concern.zip_files.string, filename: "#{curation_concern.id}.zip"
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,6 +7,7 @@ class Ability
   include OregonDigital::Ability::WorkCreateAbility
   include OregonDigital::Ability::WorkEditAbility
   include OregonDigital::Ability::WorkDeleteAbility
+  include OregonDigital::Ability::WorkDownloadAbility
   include OregonDigital::Ability::WorkShowAbility
   include OregonDigital::Ability::WorkReviewAbility
   include OregonDigital::Ability::CollectionAbility
@@ -18,6 +19,7 @@ class Ability
     work_edit_ability
     work_create_ability
     work_delete_ability
+    work_download_ability
     work_show_ability
     work_review_ability
     collection_ability

--- a/app/models/concerns/oregon_digital/ability/work_download_ability.rb
+++ b/app/models/concerns/oregon_digital/ability/work_download_ability.rb
@@ -9,7 +9,15 @@ module OregonDigital
       included do
         def work_download_ability
           can(:download, ActiveFedora::Base) if current_user.role?(manager_permission_roles)
+          can(:download, ActiveFedora::Base) do |record|
+            current_user.role?(osu_roles + uo_roles) && !uo_download_restricted?(record.admin_set)
+          end
           can(:download_low, ActiveFedora::Base)
+        end
+
+        def uo_download_restricted?(admin_set)
+          admin_sets = YAML.load_file("#{Rails.root}/config/download_restriction.yml")['uo']['admin_sets']
+          admin_sets.include?(admin_set.id)
         end
       end
     end

--- a/app/models/concerns/oregon_digital/ability/work_download_ability.rb
+++ b/app/models/concerns/oregon_digital/ability/work_download_ability.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal:true
+
+module OregonDigital
+  module Ability
+    # Sets the abilities for work editing
+    module WorkDownloadAbility
+      extend ActiveSupport::Concern
+
+      included do
+        def work_download_ability
+          can(:download, ActiveFedora::Base) if current_user.role?(manager_permission_roles)
+          can(:download_low, ActiveFedora::Base)
+        end
+      end
+    end
+  end
+end

--- a/app/views/hyrax/base/_download.html.erb
+++ b/app/views/hyrax/base/_download.html.erb
@@ -1,4 +1,4 @@
 <ul>
-  <li><%= link_to "Files + Metadata (ZIP)", main_app.send(:"download_hyrax_#{@presenter.model_name.name.downcase}_path", @presenter.id) %></li>
+  <li><%= link_to "Files + Metadata (ZIP)", ((current_user.can? :download, ActiveFedora::Base.find(@presenter.id)) ? main_app.send(:"download_hyrax_#{@presenter.model_name.name.downcase}_path", @presenter.id) : main_app.send(:"download_low_hyrax_#{@presenter.model_name.name.downcase}_path", @presenter.id)) %></li>
   <li><%= link_to "Metadata Only (CSV)", main_app.send(:"metadata_hyrax_#{@presenter.model_name.name.downcase}_path", @presenter.id) %></li>
 </ul>

--- a/app/views/hyrax/base/_download.html.erb
+++ b/app/views/hyrax/base/_download.html.erb
@@ -1,4 +1,4 @@
 <ul>
-  <li><%= link_to "Files + Metadata (ZIP)", ((current_user.can? :download, ActiveFedora::Base.find(@presenter.id)) ? main_app.send(:"download_hyrax_#{@presenter.model_name.name.downcase}_path", @presenter.id) : main_app.send(:"download_low_hyrax_#{@presenter.model_name.name.downcase}_path", @presenter.id)) %></li>
+  <li><%= link_to "Files + Metadata (ZIP)", ((current_ability.can? :download, ActiveFedora::Base.find(@presenter.id)) ? main_app.send(:"download_hyrax_#{@presenter.model_name.name.downcase}_path", @presenter.id) : main_app.send(:"download_low_hyrax_#{@presenter.model_name.name.downcase}_path", @presenter.id)) %></li>
   <li><%= link_to "Metadata Only (CSV)", main_app.send(:"metadata_hyrax_#{@presenter.model_name.name.downcase}_path", @presenter.id) %></li>
 </ul>

--- a/config/download_restriction.yml
+++ b/config/download_restriction.yml
@@ -1,0 +1,2 @@
+uo:
+  admin_sets: []

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
     concerns_to_route.each do |curation_concern_name|
       namespaced_resources curation_concern_name, only: [] do
         member do
-          get :download, :metadata
+          get :download_low, :download, :metadata
         end
       end
     end


### PR DESCRIPTION
Fixes #759 
Fixes #760 
Add a new download_low route to works to be filled in with low res download files later. Setup permissions for download and download_low routes based on matrix