### PR TITLE
Remove community_affiliate role and permissions

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -41,15 +41,11 @@ class Ability
     admin_permission_roles << 'depositor'
   end
 
-  def community_roles
-    %w[community_affiliate]
-  end
-
   def osu_roles
-    %w[osu_affiliate osu_user community_affiliate]
+    %w[osu_affiliate osu_user]
   end
 
   def uo_roles
-    %w[uo_affiliate uo_user community_affiliate]
+    %w[uo_affiliate uo_user]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,8 +23,8 @@ class User < ApplicationRecord
   # https://github.com/samvera/hydra-head/blob/v10.6.2/hydra-access-controls/lib/hydra/user.rb
   def groups
     groups = super
-    groups << 'osu' unless (groups & %w[osu_affiliate osu_user community_affiliate]).empty?
-    groups << 'uo' unless (groups & %w[uo_affiliate uo_user community_affiliate]).empty?
+    groups << 'osu' unless (groups & %w[osu_affiliate osu_user]).empty?
+    groups << 'uo' unless (groups & %w[uo_affiliate uo_user]).empty?
     groups
   end
   # END OVERRIDE

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -6,4 +6,3 @@ roles:
   - osu_user
   - uo_affiliate
   - uo_user
-  - community_affiliate


### PR DESCRIPTION
Fixes #756 

community_affiliate role does not have any special permissions. A community_affiliate should be affiliated with one or both universities and should have the exact same permissions as a [university]_user role. [university]_affiliate roles takes care of this and slightly simplifies our QA and permissions matrix.