### PR TITLE
firstrun.sh: create admin with confirmation timestamp

### DIFF
--- a/build/firstrun.sh
+++ b/build/firstrun.sh
@@ -14,7 +14,13 @@ bundle exec rails hyrax:workflow:load
 
 echo
 echo "Creating a default admin user"
-bundle exec rails runner 'User.create(email: "admin@example.org", encrypted_password: "$2a$11$AzzYy9sCWJh6JCKu0qjvdeiSDp0e6DS2rdTOtDEHV2UZw/cQ0ltnG", preferred_locale: "en", roles: [Role.find_by_name("admin")])'
+bundle exec rails runner 'User.create(
+  email: "admin@example.org",
+  encrypted_password: "$2a$11$AzzYy9sCWJh6JCKu0qjvdeiSDp0e6DS2rdTOtDEHV2UZw/cQ0ltnG",
+  preferred_locale: "en",
+  roles: [Role.find_by_name("admin")],
+  confirmed_at: Time.now
+)'
 
 echo
 echo "Creating Oregon Digital admin sets"


### PR DESCRIPTION
Fixes initial setup so our admin user is actually usable - at some point we went from just needing an account to needing an account that's got a confirmation date.