### PR TITLE
fix FeatureClassUriToLabel to display missing class label

### DIFF
--- a/lib/oregon_digital/feature_class_uri_to_label.rb
+++ b/lib/oregon_digital/feature_class_uri_to_label.rb
@@ -4,15 +4,15 @@ module OregonDigital
   # Translate feature class
   class FeatureClassUriToLabel
     def uri_to_label(uri)
-      { 'http://www.geonames.org/ontology#A' => 'Administrative Boundary',
-        'http://www.geonames.org/ontology#H' => 'Hydrographic',
-        'http://www.geonames.org/ontology#L' => 'Area',
-        'http://www.geonames.org/ontology#P' => 'Populated Place',
-        'http://www.geonames.org/ontology#R' => 'Road / Railroad',
-        'http://www.geonames.org/ontology#S' => 'Spot',
-        'http://www.geonames.org/ontology#T' => 'Hypsographic',
-        'http://www.geonames.org/ontology#U' => 'Undersea',
-        'http://www.geonames.org/ontology#V' => 'Vegetation' }[uri]
+      { 'https://www.geonames.org/ontology#A' => 'Administrative Boundary',
+        'https://www.geonames.org/ontology#H' => 'Hydrographic',
+        'https://www.geonames.org/ontology#L' => 'Area',
+        'https://www.geonames.org/ontology#P' => 'Populated Place',
+        'https://www.geonames.org/ontology#R' => 'Road / Railroad',
+        'https://www.geonames.org/ontology#S' => 'Spot',
+        'https://www.geonames.org/ontology#T' => 'Hypsographic',
+        'https://www.geonames.org/ontology#U' => 'Undersea',
+        'https://www.geonames.org/ontology#V' => 'Vegetation' }[uri]
     end
   end
 end

--- a/spec/hyrax/controlled_vocabularies/location_spec.rb
+++ b/spec/hyrax/controlled_vocabularies/location_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Hyrax::ControlledVocabularies::Location do
         allow(location).to receive(:valid_label_without_parent).and_return(false)
         allow(location).to receive(:label_or_blank).and_return('Parent Label')
         allow(location).to receive(:top_level_parent).with('Parent Label').and_return(false)
-        allow(location).to receive(:featureClass).and_return([described_class.new('http://www.geonames.org/ontology#A')])
+        allow(location).to receive(:featureClass).and_return([described_class.new('https://www.geonames.org/ontology#A')])
       end
 
       it { expect(location.rdf_label).to eq ['http://dbpedia.org/resource/Oregon_State_University , Parent Label, (Administrative Boundary) '] }

--- a/spec/oregon_digital/feature_class_uri_to_label_spec.rb
+++ b/spec/oregon_digital/feature_class_uri_to_label_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe OregonDigital::FeatureClassUriToLabel do
   let(:converter) { described_class.new }
-  let(:uri) { 'http://www.geonames.org/ontology#A' }
+  let(:uri) { 'https://www.geonames.org/ontology#A' }
 
   it { expect(converter.uri_to_label(uri)).to eq 'Administrative Boundary' }
 end


### PR DESCRIPTION
fixes https://github.com/OregonDigital/OD2/issues/943 

This additional fix addresses a mismatch issue when building the label for location. It should display the feature class in parenthesis, i.e. "(Administrative Boundary)".