### PR TITLE
Feature/update to fetch location on edit

### DIFF
--- a/app/workers/fetch_graph_worker.rb
+++ b/app/workers/fetch_graph_worker.rb
@@ -22,6 +22,7 @@ class FetchGraphWorker
     # Iterate over Controller Props values
     work.controlled_properties.each do |controlled_prop|
       work.attributes[controlled_prop.to_s].each do |val|
+        val = Hyrax::ControlledVocabularies::Location.new(val) if val.include? 'sws.geonames.org'
         # Fetch labels
         if val.respond_to?(:fetch)
           begin


### PR DESCRIPTION
This makes it so on Edit, locations are fetched properly. Locations that havent been updated come in as string and need to be cast to ControlledVocabularies objects.
Fixes #1014 