### PR TITLE
Configure search results metadata

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -53,10 +53,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false, highlight: true
     config.add_index_field solr_name('creator_label', :stored_searchable), itemprop: 'creator', link_to_search: solr_name('creator', :facetable), max_values: 3, max_values_label: 'others'
-    config.add_index_field solr_name('photographer_label', :stored_searchable), itemprop: 'photographer', link_to_search: solr_name('photographer', :facetable), max_values: 3, max_values_label: 'others'
     config.add_index_field solr_name('date', :stored_searchable), itemprop: 'date'
-    config.add_index_field solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
-    config.add_index_field solr_name('location_label', :stored_searchable), itemprop: 'location'
     config.add_index_field solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link_with_highlight, truncate: { list: 20, gallery: 10 }, max_values: 1, highlight: true, if: lambda { |_context, _field_config, document|
       # Only display description if a highlight is hit
       document.response['highlighting'][document.id].keys.include?(solr_name('description', :stored_searchable))

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -58,9 +58,17 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('date_modified', :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
     config.add_index_field solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
     config.add_index_field solr_name('location_label', :stored_searchable), itemprop: 'location'
-    config.add_index_field solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link, truncate: { list: 20, gallery: 10 }, max_values: 1, highlight: true, include_in_request: true
-    config.add_index_field solr_name('keyword', :stored_searchable), itemprop: 'keyword', helper_method: :iconify_auto_link, truncate: { list: 20, gallery: 10 }, max_values: 1, highlight: true, include_in_request: true
+    # TODO: Replace keyword with full text once full text extraction is in place.
+    config.add_index_field solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link, truncate: { list: 20, gallery: 10 }, max_values: 1, highlight: true, if: lambda { |_context, _field_config, document|
+      document.response['highlighting'][document.id].keys.include?(solr_name('description', :stored_searchable))
+    }
+    config.add_index_field solr_name('keyword', :stored_searchable), itemprop: 'keyword', truncate: { list: 20, gallery: 10 }, max_values: 1, highlight: true, unless: lambda { |_context, _field_config, document|
+      document.response['highlighting'][document.id].keys.include?(solr_name('description', :stored_searchable))
+    }, if:  lambda { |_context, _field_config, document|
+      document.response['highlighting'][document.id].keys.include?(solr_name('keyword', :stored_searchable))
+    }
     config.add_index_field solr_name('type_label', :stored_searchable), label: 'Resource Type', link_to_search: solr_name('type_label', :facetable), if: false
+    config.add_field_configuration_to_solr_request!
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -58,7 +58,8 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('date_modified', :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
     config.add_index_field solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
     config.add_index_field solr_name('location_label', :stored_searchable), itemprop: 'location'
-    config.add_index_field solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link, truncate: { list: 20, gallery: 10 }, max_values: 1
+    config.add_index_field solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link, truncate: { list: 20, gallery: 10 }, max_values: 1, highlight: true, include_in_request: true
+    config.add_index_field solr_name('keyword', :stored_searchable), itemprop: 'keyword', helper_method: :iconify_auto_link, truncate: { list: 20, gallery: 10 }, max_values: 1, highlight: true, include_in_request: true
     config.add_index_field solr_name('type_label', :stored_searchable), label: 'Resource Type', link_to_search: solr_name('type_label', :facetable), if: false
 
     # solr fields to be displayed in the show (single result) view

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -58,11 +58,14 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
     config.add_index_field solr_name('location_label', :stored_searchable), itemprop: 'location'
     config.add_index_field solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link_with_highlight, truncate: { list: 20, gallery: 10 }, max_values: 1, highlight: true, if: lambda { |_context, _field_config, document|
+      # Only display description if a highlight is hit
       document.response['highlighting'][document.id].keys.include?(solr_name('description', :stored_searchable))
     }
     config.add_index_field 'all_text_tsimv', itemprop: 'keyword', truncate: { list: 20, gallery: 10 }, max_values: 1, highlight: true, unless: lambda { |_context, _field_config, document|
+      # Don't display full text if description has a highlight hit
       document.response['highlighting'][document.id].keys.include?(solr_name('description', :stored_searchable))
     }, if:  lambda { |_context, _field_config, document|
+      # Only try to display full text if a highlight is hit
       document.response['highlighting'][document.id].keys.include?('all_text_tsimv')
     }
     config.add_index_field solr_name('type_label', :stored_searchable), label: 'Resource Type', link_to_search: solr_name('type_label', :facetable), if: false

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -54,8 +54,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false
     config.add_index_field solr_name('creator_label', :stored_searchable), itemprop: 'creator', link_to_search: solr_name('creator', :facetable), max_values: 3, max_values_label: 'others'
     config.add_index_field solr_name('photographer_label', :stored_searchable), itemprop: 'photographer', link_to_search: solr_name('photographer', :facetable), max_values: 3, max_values_label: 'others'
-    config.add_index_field solr_name('date_uploaded', :stored_sortable, type: :date), itemprop: 'datePublished', helper_method: :human_readable_date
-    config.add_index_field solr_name('date_modified', :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
+    config.add_index_field solr_name('date', :stored_searchable), itemprop: 'date'
     config.add_index_field solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
     config.add_index_field solr_name('location_label', :stored_searchable), itemprop: 'location'
     # TODO: Replace keyword with full text once full text extraction is in place.

--- a/app/indexers/generic_indexer.rb
+++ b/app/indexers/generic_indexer.rb
@@ -20,7 +20,7 @@ class GenericIndexer < Hyrax::WorkIndexer
       index_topic_combined_label(solr_doc, object.keyword)
       index_date_combined_label(solr_doc)
       solr_doc['date_uploaded_dtsi'] = object.date_uploaded.to_time unless object.date_uploaded.blank?
-      solr_doc['all_text_tsimv'] = object.file_sets.map { |file_set| file_set.extracted_text.content }
+      solr_doc['all_text_tsimv'] = object.file_sets.map { |file_set| file_set.extracted_text.content unless file_set.extracted_text.nil? }
       index_edit_groups
       index_read_groups
       index_discover_groups

--- a/app/indexers/generic_indexer.rb
+++ b/app/indexers/generic_indexer.rb
@@ -20,6 +20,7 @@ class GenericIndexer < Hyrax::WorkIndexer
       index_topic_combined_label(solr_doc, object.keyword)
       index_date_combined_label(solr_doc)
       solr_doc['date_uploaded_dtsi'] = object.date_uploaded.to_time unless object.date_uploaded.blank?
+      solr_doc['all_text_tsimv'] = object.file_sets.map { |file_set| file_set.extracted_text.content }
       index_edit_groups
       index_read_groups
       index_discover_groups

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -75,6 +75,7 @@ en:
           military_branch_label_sim: Military Branch
           subject_label_sim: Subject
         index:
+          all_text_tsimv: Full Text
           based_near_label_tesim: Location
           contributor_tesim: Contributor
           creator_tesim: Creator

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -78,6 +78,7 @@ en:
           based_near_label_tesim: Location
           contributor_tesim: Contributor
           creator_tesim: Creator
+          date_tesim: Date
           date_created_tesim: Date Created
           date_modified_dtsi: Date Modified
           date_uploaded_dtsi: Date Uploaded


### PR DESCRIPTION
This better aligns the search results metadata with #850.
It's not perfect and still needs to display full text. A TODO is added to describe where full text can be put swapped for keyword.