### PR TITLE
Display file sets and child works again

### DIFF
--- a/app/assets/stylesheets/oregon_digital/_files-sets.scss
+++ b/app/assets/stylesheets/oregon_digital/_files-sets.scss
@@ -1,0 +1,16 @@
+.file-sets {
+    height: auto;
+    overflow-x: visible;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+
+    .thumbnail-block {
+        width: 140px;
+        img {
+            height: 70px;
+        }
+        text-overflow: ellipsis;
+        overflow-x: hidden;
+    }
+}

--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -3,7 +3,19 @@
 <%  array_of_ids = presenter.list_of_item_ids_to_display %>
 <%  members = presenter.member_presenters_for(array_of_ids) %>
 <% if members.present? %>
-  <div class="related-files"><%= render partial: 'download' %></div>
+  <div class="related-files">
+    <%= render partial: 'download' %>
+  </div>
+  <%# Temporary FileSets and Child Work section %>
+  <h2>Items</h2>
+  <div class="row file-sets">
+    <%= render partial: 'member', collection: members %>
+    <% if presenter.total_pages > 1 %>
+        <div class="row record-padding col-md-9">
+          <%= paginate array_of_ids, outer_window: 2, theme: 'blacklight', param_name: :page, route_set: main_app %>
+        </div><!-- /pager -->
+    <% end %>
+  </div>
 <% elsif can? :edit, presenter.id %>
     <div class="alert alert-warning" role="alert"><%= t('.empty', type: presenter.human_readable_type) %></div>
 <% else %>

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -1,11 +1,10 @@
 <%# OVERRIDE FROM HYRAX change item table to flexbox %>
 <div class="thumbnail <%= dom_class(member) %> attributes">
-  <%= render_thumbnail_tag member %>
-  <%= link_to(member.link_name, contextual_path(member, @presenter)) %>
+  <div class="thumbnail-block"
+    <%= render_thumbnail_tag member %>
+    <br>
+    <%= link_to(member.link_name, contextual_path(member, @presenter)) %>
+  </div>
   <br>
-  <ul>
-    <li><%= link_to "Download Image", download_path(member.id) %></li>
-    <li>High Resolution</li>
-    <li>Metadata Only (CSV)</li>
-  </ul>
+  <%= render 'actions', member: member %>
 </div>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -116,13 +116,13 @@
 
       <%# OVERRIDE FROM HYRAX to add search sidebar from Blacklight %>
       <%# and swap facet and results render order %>
-      <% unless @configured_facets.empty? %>
+      <% unless @configured_facets.nil? || @configured_facets.empty? %>
       <div class="hyc-blacklight hyc-bl-facets col-md-3 col-sm-4">
         <%= render 'search_sidebar' %>
       </div>
       <% end %>
 
-      <div class="hyc-blacklight hyc-bl-results <%= 'col-md-9 col-sm-8' unless @configured_facets.empty? %>">
+      <div class="hyc-blacklight hyc-bl-results <%= 'col-md-9 col-sm-8' unless @configured_facets.nil? || @configured_facets.empty? %>">
         <%= render_document_index @member_docs %>
       </div>
 


### PR DESCRIPTION
Fixes #1024 
![image](https://user-images.githubusercontent.com/11052958/77477428-8d0d2080-6dd9-11ea-9acc-ee3ffb009fc5.png)
Not the prettiest display, but so far it is supposed to be temporary for debugging and working in staging. Madison Avenue and PMOP will decide its fate.