### PR TITLE
First pass to generalize external link fields

### DIFF
--- a/app/renderers/search_and_external_link_attribute_renderer.rb
+++ b/app/renderers/search_and_external_link_attribute_renderer.rb
@@ -11,4 +11,36 @@ class SearchAndExternalLinkAttributeRenderer < Hyrax::Renderers::LinkedAttribute
     links << link_to('<span class="glyphicon glyphicon-new-window"></span>'.html_safe, external_link, 'aria-label' => 'Open link in new window', class: 'btn', target: '_blank') unless external_link.nil?
     links.join('')
   end
+
+  def search_field
+    search_link_field = :blank
+    if creator_fields.include? field.to_sym
+      search_link_field = :creator_combined_label
+    elsif scientific_fields.include? field.to_sym 
+      search_link_field = :scientific_combined_label
+    elsif topic_fields.include? field.to_sym 
+      search_link_field = :topic_combined_label
+    elsif location_fields.include? field.to_sym 
+      search_link_field = :location_combined_label
+    else
+      search_link_field = options.fetch(:search_field, field)
+    end
+    search_link_field
+  end
+
+  def creator_fields
+    %i[arranger_label artist_label author_label cartographer_label collector_label composer_label creator_label contributor_label dedicatee_label donor_label designer_label editor_label illustrator_label interviewee_label interviewer_label lyricist_label owner_label patron_label photographer_label print_maker_label recipient_label transcriber_label translator_label]
+  end
+
+  def topic_fields
+    %i[keyword_label subject_label]
+  end
+
+  def location_fields
+    %i[ranger_district_label water_basin_label location_label] 
+  end
+
+  def scientific_fields
+    %i[taxon_class_label family_label genus_label order_label species_label phylum_or_division_label]
+  end
 end

--- a/app/renderers/search_and_external_link_attribute_renderer.rb
+++ b/app/renderers/search_and_external_link_attribute_renderer.rb
@@ -14,17 +14,17 @@ class SearchAndExternalLinkAttributeRenderer < Hyrax::Renderers::LinkedAttribute
 
   def search_field
     search_link_field = :blank
-    if creator_fields.include? field.to_sym
-      search_link_field = :creator_combined_label
-    elsif scientific_fields.include? field.to_sym 
-      search_link_field = :scientific_combined_label
-    elsif topic_fields.include? field.to_sym 
-      search_link_field = :topic_combined_label
-    elsif location_fields.include? field.to_sym 
-      search_link_field = :location_combined_label
-    else
-      search_link_field = options.fetch(:search_field, field)
-    end
+    search_link_field = if creator_fields.include? field.to_sym
+                          :creator_combined_label
+                        elsif scientific_fields.include? field.to_sym 
+                          :scientific_combined_label
+                        elsif topic_fields.include? field.to_sym 
+                          :topic_combined_label
+                        elsif location_fields.include? field.to_sym 
+                          :location_combined_label
+                        else
+                          options.fetch(:search_field, field)
+                        end
     search_link_field
   end
 

--- a/app/renderers/search_and_external_link_attribute_renderer.rb
+++ b/app/renderers/search_and_external_link_attribute_renderer.rb
@@ -24,7 +24,6 @@ class SearchAndExternalLinkAttributeRenderer < Hyrax::Renderers::LinkedAttribute
                         else
                           options.fetch(:search_field, field)
                         end
-    search_link_field
   end
 
   def creator_fields
@@ -36,7 +35,7 @@ class SearchAndExternalLinkAttributeRenderer < Hyrax::Renderers::LinkedAttribute
   end
 
   def location_fields
-    %i[ranger_district_label water_basin_label location_label] 
+    %i[ranger_district_label water_basin_label location_label]
   end
 
   def scientific_fields

--- a/app/renderers/search_and_external_link_attribute_renderer.rb
+++ b/app/renderers/search_and_external_link_attribute_renderer.rb
@@ -15,11 +15,11 @@ class SearchAndExternalLinkAttributeRenderer < Hyrax::Renderers::LinkedAttribute
   def search_field
     search_link_field = if creator_fields.include? field.to_sym
                           :creator_combined_label
-                        elsif scientific_fields.include? field.to_sym 
+                        elsif scientific_fields.include? field.to_sym
                           :scientific_combined_label
-                        elsif topic_fields.include? field.to_sym 
+                        elsif topic_fields.include? field.to_sym
                           :topic_combined_label
-                        elsif location_fields.include? field.to_sym 
+                        elsif location_fields.include? field.to_sym
                           :location_combined_label
                         else
                           options.fetch(:search_field, field)

--- a/app/renderers/search_and_external_link_attribute_renderer.rb
+++ b/app/renderers/search_and_external_link_attribute_renderer.rb
@@ -12,19 +12,23 @@ class SearchAndExternalLinkAttributeRenderer < Hyrax::Renderers::LinkedAttribute
     links.join('')
   end
 
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def search_field
-    search_link_field = if creator_fields.include? field.to_sym
-                          :creator_combined_label
-                        elsif scientific_fields.include? field.to_sym
-                          :scientific_combined_label
-                        elsif topic_fields.include? field.to_sym
-                          :topic_combined_label
-                        elsif location_fields.include? field.to_sym
-                          :location_combined_label
-                        else
-                          options.fetch(:search_field, field)
-                        end
+    if creator_fields.include? field.to_sym
+      :creator_combined_label
+    elsif scientific_fields.include? field.to_sym
+      :scientific_combined_label
+    elsif topic_fields.include? field.to_sym
+      :topic_combined_label
+    elsif location_fields.include? field.to_sym
+      :location_combined_label
+    else
+      options.fetch(:search_field, field)
+    end
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   def creator_fields
     %i[arranger_label artist_label author_label cartographer_label collector_label composer_label creator_label contributor_label dedicatee_label donor_label designer_label editor_label illustrator_label interviewee_label interviewer_label lyricist_label owner_label patron_label photographer_label print_maker_label recipient_label transcriber_label translator_label]

--- a/app/renderers/search_and_external_link_attribute_renderer.rb
+++ b/app/renderers/search_and_external_link_attribute_renderer.rb
@@ -13,7 +13,6 @@ class SearchAndExternalLinkAttributeRenderer < Hyrax::Renderers::LinkedAttribute
   end
 
   def search_field
-    search_link_field = :blank
     search_link_field = if creator_fields.include? field.to_sym
                           :creator_combined_label
                         elsif scientific_fields.include? field.to_sym 


### PR DESCRIPTION
Fixes #1006 

This abstracts and generates combined label searches for the configured fields. Since its only the controlled vocabularies, its only pieces that would search using the _label method. 