### PR TITLE
add date_uploaded to indexer

### DIFF
--- a/app/forms/hyrax/generic_form.rb
+++ b/app/forms/hyrax/generic_form.rb
@@ -26,7 +26,7 @@ module Hyrax
     end
 
     def self.build_permitted_params
-      params = super - %i[date_uploaded date_modified]
+      params = super - %i[date_modified]
       Generic.controlled_property_labels.each do |prop|
         params << { prop.gsub('_label', '_attributes') => %i[id _destroy] }
       end

--- a/app/indexers/generic_indexer.rb
+++ b/app/indexers/generic_indexer.rb
@@ -22,6 +22,7 @@ class GenericIndexer < Hyrax::WorkIndexer
       index_edit_groups
       index_read_groups
       index_discover_groups
+      solr_doc['date_uploaded_dtsi'] = object.date_uploaded.to_time unless object.date_uploaded.blank?
       solr_doc['all_text_tsimv'] = object.file_sets.map { |file_set| file_set.extracted_text.content unless file_set.extracted_text.nil? }
       # Index file formats from file sets for faceting
       solr_doc[Solrizer.solr_name('file_format', :facetable)] = object.file_sets.map { |file_set| file_set.to_solr[Solrizer.solr_name('file_format', :facetable)] }


### PR DESCRIPTION
Now that https://github.com/OregonDigital/hyrax-migrator/issues/194 was addressed for date_uploaded, we can re-enable it for indexing. 