### PR TITLE
Update to add callback to updating a member

### DIFF
--- a/config/initializers/hacks/hyrax_collections_controller_behavior.rb
+++ b/config/initializers/hacks/hyrax_collections_controller_behavior.rb
@@ -25,7 +25,6 @@ Hyrax::CollectionsControllerBehavior.module_eval do
       else
         member.member_of_collections << self
         member.save!
-        run_fetch_callback(member)
       end
       member
     end
@@ -44,9 +43,5 @@ Hyrax::CollectionsControllerBehavior.module_eval do
       @configured_facets.each do |facet|
         blacklight_config.facet_configuration_for_field(facet.solr_name).label = facet.label
       end
-    end
-
-    def run_fetch_callback(member)
-      true
     end
 end

--- a/config/initializers/hacks/hyrax_collections_controller_behavior.rb
+++ b/config/initializers/hacks/hyrax_collections_controller_behavior.rb
@@ -25,7 +25,7 @@ Hyrax::CollectionsControllerBehavior.module_eval do
       else
         member.member_of_collections << self
         member.save!
-        run_callbacks(:after_update_metadata, member)
+        run_fetch_callback(member)
       end
       member
     end
@@ -46,8 +46,8 @@ Hyrax::CollectionsControllerBehavior.module_eval do
       end
     end
 
-    def run_callbacks(hook, member)
-      Hyrax.config.callback.run(hook, member, current_user, warn: false)
+    def run_fetch_callback(member)
+      Hyrax.config.callback.run(:after_update_metadata, member, current_user, warn: false)
       true
     end
 end

--- a/config/initializers/hacks/hyrax_collections_controller_behavior.rb
+++ b/config/initializers/hacks/hyrax_collections_controller_behavior.rb
@@ -16,20 +16,6 @@ Hyrax::CollectionsControllerBehavior.module_eval do
     configured_facets
   end
 
-  def add_member_objects(new_member_ids)
-    Array(new_member_ids).collect do |member_id|
-      member = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: member_id, use_valkyrie: false)
-      message = Hyrax::MultipleMembershipChecker.new(item: member).check(collection_ids: id, include_current_members: true)
-      if message
-        member.errors.add(:collections, message)
-      else
-        member.member_of_collections << self
-        member.save!
-      end
-      member
-    end
-  end
-
   private
 
     # OVERRIDE FROM HYRAX

--- a/config/initializers/hacks/hyrax_collections_controller_behavior.rb
+++ b/config/initializers/hacks/hyrax_collections_controller_behavior.rb
@@ -47,7 +47,6 @@ Hyrax::CollectionsControllerBehavior.module_eval do
     end
 
     def run_fetch_callback(member)
-      Hyrax.config.callback.run(:after_update_metadata, member, current_user, warn: false)
       true
     end
 end

--- a/config/initializers/hacks/hyrax_collections_members_controller.rb
+++ b/config/initializers/hacks/hyrax_collections_members_controller.rb
@@ -15,4 +15,23 @@ Hyrax::Dashboard::CollectionMembersController.class_eval do
       format.json { render json: @collection, status: :updated, location: dashboard_collection_path(@collection) }
     end
   end
+
+  def update_members
+    err_msg = validate
+    after_update_error(err_msg) if err_msg.present?
+    return if err_msg.present?
+
+    collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
+    members = collection.add_member_objects batch_ids
+    messages = members.collect { |member| member.errors.full_messages }.flatten
+    if messages.size == members.size
+      after_update_error(messages.uniq.join(', '))
+    elsif messages.present?
+      flash[:error] = messages.uniq.join(', ')
+      after_update
+    else
+      members.each { |member| Hyrax.config.callback.run(:after_update_metadata, member, current_user, warn: false) }
+      after_update
+    end
+  end
 end


### PR DESCRIPTION
Here is an initial proposal to fixing the metadata disappearing after a work is added to a collection. One thing to note here is there is a reindex that happens when a work is added to a collection. this means that metadata (specifically controlled vocabularies) may not be available instantly after a work is added to a collection. 

This has been noted previously when a work is created. But this needs to be extended to "anytime a work is saved" which may not just be on create/update. 

Therefore we have to be mindful of the state of an application after someone adds a work to a collection.