### PR TITLE
Speed up download performance by skipping activefedora stream wrapper

### DIFF
--- a/app/models/concerns/oregon_digital/work_behavior.rb
+++ b/app/models/concerns/oregon_digital/work_behavior.rb
@@ -41,20 +41,24 @@ module OregonDigital
         # Add each file
         file_sets.each do |file_set|
           file = file_set.files.first
-          file_name = file.file_name.first
 
-          url = file.uri.value
-
-          zio.put_next_entry(file_name)
-          # Copy file contents directly from Fedora HTTP response
-          open(url) do |io|
-            IO.copy_stream(io, zio)
-          end
+          copy_file_to_zip(file, zio)
         end
       end
     end
 
     private
+
+    def copy_file_to_zip(file, zio)
+      file_name = file.file_name.first
+      url = file.uri.value
+
+      zio.put_next_entry(file_name)
+      # Copy file contents directly from Fedora HTTP response
+      URI.open(url) do |io|
+        IO.copy_stream(io, zio)
+      end
+    end
 
     # If the oembed_url changed all previous errors are invalid
     def resolve_oembed_errors

--- a/spec/models/generic_spec.rb
+++ b/spec/models/generic_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Generic do
   let(:user) { create(:user) }
   let(:uri) { RDF::URI.new('http://opaquenamespace.org/ns/TestVocabulary/TestTerm') }
   let(:term) { OregonDigital::ControlledVocabularies::Resource.new }
-  let(:file) { instance_double('file', stream: ["\x00"], file_name: ['name']) }
+  let(:file_uri) { 'https://uri' }
+  let(:file) { instance_double('file', stream: ["\x00"], file_name: ['name'], uri: OpenStruct.new(value: file_uri)) }
   let(:file_set) { instance_double('file_set', files: [file]) }
 
   it { is_expected.to have_attributes(title: ['foo']) }
@@ -69,6 +70,8 @@ RSpec.describe Generic do
   describe '#zip_files' do
     before do
       allow(model).to receive(:file_sets).and_return([file_set])
+      stub_request(:get, file_uri)
+        .to_return(status: 200, body: '', headers: {})
     end
 
     it 'provides a StringIO' do

--- a/spec/models/generic_spec.rb
+++ b/spec/models/generic_spec.rb
@@ -66,19 +66,6 @@ RSpec.describe Generic do
     end
   end
 
-  describe '#work_files_byte_string' do
-    before do
-      allow(model).to receive(:file_sets).and_return([file_set])
-    end
-
-    it 'provides a hash' do
-      expect(model.work_files_byte_string).to be_kind_of(Hash)
-    end
-    it 'provides correct data' do
-      expect(model.work_files_byte_string).to eq('name' => "\x00")
-    end
-  end
-
   describe '#zip_files' do
     before do
       allow(model).to receive(:file_sets).and_return([file_set])


### PR DESCRIPTION
Something about the ActiveFedora stream wrapper is SLOW. University of Michigan implemented download all as zip functionality very similarly to ours, but accessed the files body directly through fedora with `#open` and `#copy_stream`. They suggest 3G as the maximum zip size and enforce < 10G.

This may fix #1172 
Other options exist with zip_tricks and directly streaming, but this might be fast enough.