### PR TITLE
Remove save button and checkboxes from collections

### DIFF
--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,9 +1,11 @@
 <!-- OVERRIDE FROM HYRAX TO ADD CHECKBOX INPUT TO HOOK UP SAVE FUNCTIONALITY -->
 <li id="document_<%= document.to_param %>" class="document <%= render_document_class document %>" itemscope itemtype="<%= document.itemtype %>">
   <div class="row search-result-wrapper">
-    <p class="pull-left">
-    <input type="checkbox" name="batch_document_ids[]" id=<%="batch_document_#{document.id}"%> value=<%= document.id %> class="batch_document_selector">
-    </p>
+    <% unless document.collection? %>
+      <p class="pull-left">
+        <input type="checkbox" name="batch_document_ids[]" id=<%="batch_document_#{document.id}"%> value=<%= document.id %> class="batch_document_selector">
+      </p>
+    <% end %>
     <%= render_document_partials document, blacklight_config.view_config(document_index_view_type).partials, document_counter: document_counter %>
   </div>
 </li>

--- a/app/views/catalog/_index_gallery_default.html.erb
+++ b/app/views/catalog/_index_gallery_default.html.erb
@@ -15,9 +15,11 @@
 <%= doc_presenter.field_value index_fields(document)['type_label_tesim'] %>
 <p>
 <!-- OVERRIDE FROM HYRAX TO ADD SAVE BUTTON AND MODAL -->
-<%= button_tag t('hyrax.dashboard.my.action.save'),
-                  class: 'btn btn-default submits-batches submits-batches-add pull-right',
-                  data: { toggle: "modal", target: "#collection-list-container" } %>
+<% unless document.collection? %>
+  <%= button_tag t('hyrax.dashboard.my.action.save'),
+                    class: 'btn btn-default submits-batches submits-batches-add pull-right',
+                    data: { toggle: "modal", target: "#collection-list-container" } %>
+<% end %>
 </p>
 <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>
 <%= render 'oregon_digital/dashboard/collections/form_for_create_collection' %>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -40,10 +40,12 @@
     </div>
   <% end %>
   <!-- OVERRIDE FROM HYRAX TO ADD SAVE BUTTON AND MODAL -->
-  <%= button_tag t('hyrax.dashboard.my.action.save'),
-                  class: 'btn btn-default submits-batches submits-batches-add pull-right',
-                  data: { toggle: "modal", target: "#collection-list-container", id: document.id },
-                  :onclick => "javascript:updateSaveCheckboxes(this)" %>
+  <% unless document.collection? %>
+    <%= button_tag t('hyrax.dashboard.my.action.save'),
+                    class: 'btn btn-default submits-batches submits-batches-add pull-right',
+                    data: { toggle: "modal", target: "#collection-list-container", id: document.id },
+                    :onclick => "javascript:updateSaveCheckboxes(this)" %>
+  <% end %>
 </div>
 
 <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>


### PR DESCRIPTION
Prevents users from adding collections to user collections as sub-collections.
Nested indexing is still not async and indexes all children works of the collection being added. This can easily cause timeouts.