### PR TITLE
Stub out low-res download method and control flow

### DIFF
--- a/app/controllers/concerns/oregon_digital/download_controller_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/download_controller_behavior.rb
@@ -8,7 +8,7 @@ module OregonDigital
     end
 
     def download
-      send_data curation_concern.zip_files.string, filename: "#{curation_concern.id}.zip"
+      send_data curation_concern.zip_files_low.string, filename: "#{curation_concern.id}.zip"
     end
 
     def metadata

--- a/app/models/concerns/oregon_digital/collection_behavior.rb
+++ b/app/models/concerns/oregon_digital/collection_behavior.rb
@@ -34,11 +34,9 @@ module OregonDigital
 
     def copy_works_to_zip(works, current_ability, zio)
       works.each do |work|
-        # Skip adding works that the user can't download
-        next unless current_ability.can? :download, work
-
         zio.put_next_entry("#{work.id}.zip")
-        zio.write work.zip_files.string
+        # Add high- or low-res zips depending on which user can download
+        zio.write current_ability.can?(:download, work) ? work.zip_files.string : work.zip_files_low.string
       end
     end
 

--- a/app/models/concerns/oregon_digital/work_behavior.rb
+++ b/app/models/concerns/oregon_digital/work_behavior.rb
@@ -47,6 +47,11 @@ module OregonDigital
       end
     end
 
+    # TODO: Implement low resolution download
+    def zip_files_low
+      zip_files
+    end
+
     private
 
     def copy_file_to_zip(file, zio)


### PR DESCRIPTION
Fixes downloads not working for non-institutional affiliate users. Work and collection downloads will degrade to low-res downloads once that method is implemented.