### PR TITLE
checks cache during blocking and indexes if in cache

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: https://github.com/osulp/triplestore-adapter
-  revision: 5b05379d91ca18c405e29513c27bb110365e4af2
+  revision: ae58b56a6d0ca35a0c6feec2a5b70f0c554b0689
   specs:
     triplestore-adapter (0.1.1)
       json-ld
@@ -226,7 +226,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     connection_pool (2.2.3)
     coveralls (0.8.23)
       json (>= 1.8, < 3)

--- a/app/indexers/oregon_digital/deep_indexing_service.rb
+++ b/app/indexers/oregon_digital/deep_indexing_service.rb
@@ -13,12 +13,14 @@ module OregonDigital
     private
 
     # OVERRIDEN FROM HYRAX TO BYPASS THE FETCHING OF CONTROLLED VOCABULARIES
-    def fetch_value(value)
+    def fetch_external
       object.controlled_properties.each do |property|
         object[property].each do |value|
           resource = value.respond_to?(:resource) ? value.resource : value
           next unless resource.is_a?(ActiveTriples::Resource)
+
           next if value.is_a?(ActiveFedora::Base)
+
           # Fetch if the vocab is cached since this is fast and can be displayed quicker.
           fetch_with_persistence(resource) if resource.in_triplestore?
         end

--- a/app/indexers/oregon_digital/deep_indexing_service.rb
+++ b/app/indexers/oregon_digital/deep_indexing_service.rb
@@ -22,7 +22,7 @@ module OregonDigital
           next if value.is_a?(ActiveFedora::Base)
 
           # Fetch if the vocab is cached since this is fast and can be displayed quicker.
-          fetch_with_persistence(resource) if resource.in_triplestore?
+          fetch_with_persistence(resource) if (!resource.class.include?(Location) && resource.in_triplestore?)
         end
       end
     end

--- a/app/indexers/oregon_digital/deep_indexing_service.rb
+++ b/app/indexers/oregon_digital/deep_indexing_service.rb
@@ -24,7 +24,7 @@ module OregonDigital
           next if value.is_a?(ActiveFedora::Base)
 
           # Fetch if the vocab is cached since this is fast and can be displayed quicker.
-          fetch_with_persistence(resource) if !resource.class.to_s.include?("Location") && resource.in_triplestore?
+          fetch_with_persistence(resource) if !resource.class.to_s.include?('Location') && resource.in_triplestore?
         end
       end
     end

--- a/app/indexers/oregon_digital/deep_indexing_service.rb
+++ b/app/indexers/oregon_digital/deep_indexing_service.rb
@@ -13,6 +13,16 @@ module OregonDigital
     private
 
     # OVERRIDEN FROM HYRAX TO BYPASS THE FETCHING OF CONTROLLED VOCABULARIES
-    def fetch_value(value); end
+    def fetch_value(value)
+      object.controlled_properties.each do |property|
+        object[property].each do |value|
+          resource = value.respond_to?(:resource) ? value.resource : value
+          next unless resource.is_a?(ActiveTriples::Resource)
+          next if value.is_a?(ActiveFedora::Base)
+          # Fetch if the vocab is cached since this is fast and can be displayed quicker.
+          fetch_with_persistence(resource) if resource.in_triplestore?
+        end
+      end
+    end
   end
 end

--- a/app/indexers/oregon_digital/deep_indexing_service.rb
+++ b/app/indexers/oregon_digital/deep_indexing_service.rb
@@ -12,6 +12,8 @@ module OregonDigital
 
     private
 
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/AbcSize
     # OVERRIDEN FROM HYRAX TO BYPASS THE FETCHING OF CONTROLLED VOCABULARIES
     def fetch_external
       object.controlled_properties.each do |property|
@@ -22,9 +24,11 @@ module OregonDigital
           next if value.is_a?(ActiveFedora::Base)
 
           # Fetch if the vocab is cached since this is fast and can be displayed quicker.
-          fetch_with_persistence(resource) if (!resource.class.include?(Location) && resource.in_triplestore?)
+          fetch_with_persistence(resource) if !resource.class.include?(Location) && resource.in_triplestore?
         end
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/indexers/oregon_digital/deep_indexing_service.rb
+++ b/app/indexers/oregon_digital/deep_indexing_service.rb
@@ -24,7 +24,7 @@ module OregonDigital
           next if value.is_a?(ActiveFedora::Base)
 
           # Fetch if the vocab is cached since this is fast and can be displayed quicker.
-          fetch_with_persistence(resource) if !resource.class.to_s.include?(Location) && resource.in_triplestore?
+          fetch_with_persistence(resource) if !resource.class.to_s.include?("Location") && resource.in_triplestore?
         end
       end
     end

--- a/app/indexers/oregon_digital/deep_indexing_service.rb
+++ b/app/indexers/oregon_digital/deep_indexing_service.rb
@@ -24,7 +24,7 @@ module OregonDigital
           next if value.is_a?(ActiveFedora::Base)
 
           # Fetch if the vocab is cached since this is fast and can be displayed quicker.
-          fetch_with_persistence(resource) if !resource.class.include?(Location) && resource.in_triplestore?
+          fetch_with_persistence(resource) if !resource.class.to_s.include?(Location) && resource.in_triplestore?
         end
       end
     end

--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -3,7 +3,7 @@
 module Hyrax
   module ControlledVocabularies
     # Location object
-    class Location < ActiveTriples::Resource
+    class Location < OregonDigital::ControlledVocabularies::Resource
       configure rdf_label: ::RDF::Vocab::GEONAMES.name
 
       attr_accessor :top_level_element

--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -3,7 +3,7 @@
 module Hyrax
   module ControlledVocabularies
     # Location object
-    class Location < OregonDigital::ControlledVocabularies::Resource
+    class Location < ActiveTriples::Resource
       configure rdf_label: ::RDF::Vocab::GEONAMES.name
 
       attr_accessor :top_level_element

--- a/lib/oregon_digital/controlled_vocabularies/resource.rb
+++ b/lib/oregon_digital/controlled_vocabularies/resource.rb
@@ -51,6 +51,11 @@ module OregonDigital
         URI.parse(rdf_subject).is_a?(URI::HTTP) ? triplestore.fetch(rdf_subject) : RDF::Graph.new
       end
 
+      def in_triplestore?
+        # Nil return from triplestore signifies that the term isnt in the cache
+        !triplestore.fetch_from_cache(rdf_subject).nil?
+      end
+
       def language_label(language)
         language.blank? ? rdf_label.first : language
       end

--- a/lib/oregon_digital/controlled_vocabularies/resource.rb
+++ b/lib/oregon_digital/controlled_vocabularies/resource.rb
@@ -53,7 +53,7 @@ module OregonDigital
 
       def in_triplestore?
         # Nil return from triplestore signifies that the term isnt in the cache
-        !triplestore.fetch_from_cache(rdf_subject).nil?
+        !triplestore.fetch_cached_term(rdf_subject).nil?
       end
 
       def language_label(language)

--- a/lib/oregon_digital/triplestore.rb
+++ b/lib/oregon_digital/triplestore.rb
@@ -26,7 +26,7 @@ module OregonDigital
       TriplestoreAdapter::Client.new(ENV['TRIPLESTORE_ADAPTER_TYPE'], ENV['TRIPLESTORE_ADAPTER_URL'])
     end
 
-    def self.fetch_from_cache(uri)
+    def self.fetch_cached_term(uri)
       return if uri.blank?
 
       @triplestore ||= TriplestoreAdapter::Triplestore.new(triplestore_client)

--- a/lib/oregon_digital/triplestore.rb
+++ b/lib/oregon_digital/triplestore.rb
@@ -31,7 +31,7 @@ module OregonDigital
 
       @triplestore ||= TriplestoreAdapter::Triplestore.new(triplestore_client)
       # Returns nil if it doesn't exist in triplestore
-      @triplestore.fetch_cached_graph(rdf_url)
+      @triplestore.fetch_cached_graph(uri)
     end
 
     ##

--- a/lib/oregon_digital/triplestore.rb
+++ b/lib/oregon_digital/triplestore.rb
@@ -26,6 +26,14 @@ module OregonDigital
       TriplestoreAdapter::Client.new(ENV['TRIPLESTORE_ADAPTER_TYPE'], ENV['TRIPLESTORE_ADAPTER_URL'])
     end
 
+    def self.fetch_from_cache(uri)
+      return if uri.blank?
+
+      @triplestore ||= TriplestoreAdapter::Triplestore.new(triplestore_client)
+      # Returns nil if it doesn't exist in triplestore
+      @triplestore.fetch_cached_graph(rdf_url)
+    end
+
     ##
     # Common predicates which represent labels in a graph
     def self.rdf_label_predicates


### PR DESCRIPTION
So I modified two pieces here. First piece is to allow the triplestore to check to see if it has a term in the cache. This is done using the triplestore adapter's #fetch_from_cache. This method checks the cache and returns nil if it isnt in the cache. 

Next I modified the AT::Resources to allow them to check to see if their rdf_subject is in the cache. It returns a boolean depending on if it is in the cache.

Lastly, I updated the BLOCKING portion of the indexing, which is the #fetch_value portion of the deep_indexing_service. Now, what it does is iterates through all the CVs that were pushed through the form. It calls the #fetch_with_persistence method when the term is verified that it is in the triplestore. This will call fetch on the term, return quickly, and index the data. 

This is to ensure that MOST of the data is stored in solr, so that we continue to display as much information as possible. The rest of the terms will be handled by the fetch_graph_worker which will fetch and cache all terms that were not found to be in the cache. 

@CGillen Lemme know if i'm on the right track here with this code. I think this is the missing piece we want to make sure that the most amount of data is fetched and cached during the blocking portion of the save process. 

TO GET THIS TO WORK WE WILL HAVE TO UPDATE TRIPLESTORE ADAPTER to make fetch_cached_graph not private