### PR TITLE
Run yarn install before rails runs yarn install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ ENV DEPLOYED_VERSION=${DEPLOYED_VERSION}
 
 RUN if [ "${RAILS_ENV}" = "production" ]; then \
   echo "Precompiling assets with $RAILS_ENV environment"; \
+  yarn install; \
   RAILS_ENV=$RAILS_ENV SECRET_KEY_BASE=temporary bundle exec rails assets:precompile; \
   cp public/assets/404-*.html public/404.html; \
   cp public/assets/500-*.html public/500.html; \


### PR DESCRIPTION
For some reason when Rails runs `yarn install` it doesn't install `shx` which is dependency of `uv`'s after-install scripts.
If we run yarn install before Rails does, `shx` will exist.
Fixes #1262 