### PR TITLE
Add 'items' to item count parenthetical

### DIFF
--- a/app/views/oregon_digital/explore_collections/_showcase_tile.html.erb
+++ b/app/views/oregon_digital/explore_collections/_showcase_tile.html.erb
@@ -3,7 +3,7 @@
     <%= img %>
     <div>
       <h3 class="visible-all-inline-block"> <%= title %> </h3>
-      <%= "(#{count})" %>
+      <%= "(#{count} items)" %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
Fixes #1244 
Chose `items` over `total items` because the latter very often introduces line breaks between `total` and `items`.