### PR TITLE
Update barcode predicate, including crosswalk, add override.

### DIFF
--- a/app/models/concerns/oregon_digital/generic_metadata.rb
+++ b/app/models/concerns/oregon_digital/generic_metadata.rb
@@ -349,7 +349,7 @@ module OregonDigital
         index.as :stored_searchable
       end
 
-      property :barcode, predicate: ::RDF::Vocab::Bibframe.barcode do |index|
+      property :barcode, predicate: ::RDF::URI.new('http://opaquenamespace.org/ns/barcode') do |index|
         index.as :stored_searchable
       end
 

--- a/config/initializers/migrator/crosswalk.yml
+++ b/config/initializers/migrator/crosswalk.yml
@@ -400,7 +400,7 @@ crosswalk:
     multiple: true
     function:
   - property: barcode
-    predicate: http://id.loc.gov/ontologies/bibframe/barcode
+    predicate: http://opaquenamespace.org/ns/barcode
     multiple: true
     function:
   - property: hydrologic_unit_code

--- a/config/initializers/migrator/crosswalk_overrides.yml
+++ b/config/initializers/migrator/crosswalk_overrides.yml
@@ -145,6 +145,11 @@ overrides:
     multiple: true
     function: attributes_data
 
+  #flip barcode predicate, from old bibframe to ons
+  - property: barcode
+    predicate: http://bibframe.org/vocab/barcode
+    multiple: true
+
   #in cpds, not used in OD2
   - predicate: http://www.openarchives.org/ore/1.0/datamodel#proxyFor
     function: return_nil


### PR DESCRIPTION
Fixes #1418 

Update barcode predicate and the migrator crosswalk, and then add the override to flip it from the current OD1 predicate.