### PR TITLE
Breadcrumbs for search view

### DIFF
--- a/app/assets/stylesheets/oregon_digital/_breadcrumbs.scss
+++ b/app/assets/stylesheets/oregon_digital/_breadcrumbs.scss
@@ -1,0 +1,15 @@
+.breadcrumb li::before {
+  border: none;
+  content: '<';
+  height: 1em;
+  margin: 0 0.5em;
+  transform: unset;
+}
+.breadcrumb li + ::before {
+  margin-left: 2em;
+}
+
+.breadcrumb{
+  background: none;
+  border: none;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -7,7 +7,7 @@ class CatalogController < ApplicationController
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
 
-  add_breadcrumb '&lsaquo; Home'.html_safe, :root_path
+  add_breadcrumb 'Home'.html_safe, :root_path
 
   # This filter applies the hydra access controls
   before_action :enforce_show_permissions, only: :show

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -7,6 +7,8 @@ class CatalogController < ApplicationController
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
 
+  add_breadcrumb '&lsaquo; Home'.html_safe, :root_path
+
   # This filter applies the hydra access controls
   before_action :enforce_show_permissions, only: :show
 

--- a/config/initializers/hacks/hyrax_bootstrap_breadcrumbs_builder.rb
+++ b/config/initializers/hacks/hyrax_bootstrap_breadcrumbs_builder.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal:true
-
-Hyrax::BootstrapBreadcrumbsBuilder.class_eval do
-
-  # Override breadcrumbs_options to set role to navigation
-  def breadcrumbs_options
-    { class: 'breadcrumb', role: "navigation", "aria-label" => "Breadcrumb" }
-  end
-end


### PR DESCRIPTION
Last of the desktop view work for #1376 and some for #1377 

- Removes an init hack that has been fixed upstream related to breadcrumbs (a11y)
- Adds a breadcrumb linked to home to the search results
- CSS for breadcrumb

![image](https://user-images.githubusercontent.com/11052958/104365570-0262f280-54cd-11eb-87a7-34cc7e743713.png)
