### PR TITLE
Mobile layout and tweaks for search results (list)

### DIFF
--- a/app/assets/stylesheets/oregon_digital/_buttons.scss
+++ b/app/assets/stylesheets/oregon_digital/_buttons.scss
@@ -32,3 +32,8 @@
 .btn-default {
   border: 3px solid $brand-primary;
 }
+
+/* increase checkbox size */
+input[type=checkbox] {
+  transform: scale(1.5);
+}

--- a/app/assets/stylesheets/oregon_digital/_search.scss
+++ b/app/assets/stylesheets/oregon_digital/_search.scss
@@ -91,13 +91,21 @@
 .search-result-wrapper {
   border-bottom: 1px solid $very-light-grey;
 
+  img {
+    max-width: 120px; // Set to longest side of thumbnails
+  }
+
   .metadata-row .fa {
     filter: contrast(0%);
     width: 1.5em;
   }
 
   .search-results-title-row .search-result-title {
+    display: inline-block;
     margin: 0;
+  }
+  .search-results-title-row .label {
+    margin-left: 15px;
   }
 }
 

--- a/app/assets/stylesheets/oregon_digital/_search.scss
+++ b/app/assets/stylesheets/oregon_digital/_search.scss
@@ -27,19 +27,25 @@
   }
 }
 
-.search-widgets {
-  display: inline-block;
+#sortAndPerPage {
+  .search-widgets {
+    .btn {
+      background-color: $very-light-grey;
+    }
+  }
 
-  .btn {
-    background-color: $very-light-grey;
+  #sort-dropdown,
+  #per_page-dropdown {
+    display: inline-block;
+    margin-right: 1em;
+    margin-bottom: 1em;
+
+    .btn-group {
+      margin-left: 1em;
+    }
   }
 }
 
-#sort-dropdown,
-#per_page-dropdown {
-  margin-right: 1em;
-  margin-left: 1em;
-}
 
 .result-count {
   font-size: 18px;
@@ -120,8 +126,7 @@ em {
   border-top: 0px solid $very-light-grey;
   border-left: 0px solid $very-light-grey;
   border-bottom: 0px solid $very-light-grey;
-  margin-left: -15px;
-
+  padding-left: 0;
 }
 .deselect-button {
   background: none;

--- a/app/assets/stylesheets/oregon_digital/_work-show.scss
+++ b/app/assets/stylesheets/oregon_digital/_work-show.scss
@@ -24,29 +24,25 @@
 
 dl.work-show {
 	display: grid;
-	grid-template: auto / 10em 1fr;
-}
+  grid-template: auto / 10em 1fr;
 
-dl.work-show > dt {
-  grid-column: 1;
-}
-
-dl.work-show > dd, .field {
-  grid-column: 2;
-}
-
-dl.work-show > dt, dd, .field {
-	padding: 1em;
-  line-height: 1.5;
+  dt {
+    grid-column: 1;
+  }
+  dd {
+    grid-column: 2;
+    ul {
+      padding: 0;
+    }
+  }
+  dt, dd {
+    padding: 0;
+    line-height: 1.5;
+  }
 }
 
 .columns {
   column-count: 2;
   column-gap: 2em;
   margin-bottom: 20px;
-}
-
-dl.work-show > dd > ul > li {
-  padding-top: 15px;
-  margin-left: -50px;
 }

--- a/app/assets/stylesheets/oregon_digital/utils.scss
+++ b/app/assets/stylesheets/oregon_digital/utils.scss
@@ -17,3 +17,7 @@
     }
   }
 }
+
+.float-none {
+  float: none !important;
+}

--- a/app/views/catalog/_index_header_list_collection.html.erb
+++ b/app/views/catalog/_index_header_list_collection.html.erb
@@ -1,4 +1,4 @@
-<div class="search-results-title-row">
+<div class="search-results-title-row col-xs-12">
   <h3 class="search-result-title"><%= link_to document.title_or_label.truncate_words(10), [hyrax, document] %></h3>
   <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
 </div>

--- a/app/views/catalog/_index_header_list_collection.html.erb
+++ b/app/views/catalog/_index_header_list_collection.html.erb
@@ -1,4 +1,4 @@
-<div class="search-results-title-row col-xs-12">
+<div class="search-results-title-row col-xs-9 col-sm-7 col-md-7">
   <h3 class="search-result-title"><%= link_to document.title_or_label.truncate_words(10), [hyrax, document] %></h3>
   <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
 </div>

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,4 +1,4 @@
-<div class="search-results-title-row col-xs-12">
+<div class="search-results-title-row col-xs-9 col-sm-7 col-md-7">
   <% if document.has_highlight_field?('title_tesim') %>
     <h3 class="search-result-title"><%= link_to document.highlight_field('title_tesim').first, document %></h3>
   <% else %>

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,4 +1,4 @@
-<div class="search-results-title-row">
+<div class="search-results-title-row col-xs-12">
   <% if document.has_highlight_field?('title_tesim') %>
     <h3 class="search-result-title"><%= link_to document.highlight_field('title_tesim').first, document %></h3>
   <% else %>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,5 +1,5 @@
 <!-- OVERRIDE FROM HYRAX -->
-<div class="col-xs-12 col-md-<%= document.collection? ? 7 : 8 %>">
+<div class="col-xs-9 col-sm-7 col-md-7">
   <div class="metadata row">
     <dl class="row">
     <% doc_presenter = index_presenter(document) %>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,5 +1,5 @@
 <!-- OVERRIDE FROM HYRAX -->
-<div class="col-md-<%= document.collection? ? 7 : 8 %>">
+<div class="col-xs-12 col-md-<%= document.collection? ? 7 : 8 %>">
   <div class="metadata row">
     <dl class="row">
     <% doc_presenter = index_presenter(document) %>
@@ -13,7 +13,7 @@
   </div>
   <% if document.collection? %>
     <% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
-    <div class="collection-counts-wrapper">
+    <div class="collection-counts-wrapper row">
       <div class="collection-counts-item">
         <span><%= collection_presenter.total_viewable_collections %></span>Collections
       </div>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,12 +1,12 @@
 <!-- OVERRIDE FROM HYRAX -->
 <div class="col-md-<%= document.collection? ? 7 : 8 %>">
   <div class="metadata row">
-    <dl class="dl-horizontal">
+    <dl class="row">
     <% doc_presenter = index_presenter(document) %>
     <% index_fields(document).each do |field_name, field| -%>
       <% if should_render_index_field? document, field %>
-          <dt><%= render_index_field_label document, field: field_name %></dt>
-          <dd><%= doc_presenter.field_value field %></dd>
+          <dt class="col-sm-3"><%= render_index_field_label document, field: field_name %></dt>
+          <dd class="col-sm-9"><%= doc_presenter.field_value field %></dd>
       <% end %>
     <% end %>
     </dl>

--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -1,13 +1,15 @@
 <% if show_sort_and_per_page? and !blacklight_config.per_page.blank? %>
-<span class="uppercase dark-grey lato-b"><%= t('blacklight.search.per_page.title') %></span>
-<div id="per_page-dropdown" class="btn-group">
-  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-    <%= t(:'blacklight.search.per_page.button_label', :count => current_per_page) %> <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu" role="menu">
-    <%- per_page_options_for_select.each do |(label, count)| %>
-      <li role="menuitem"><%= link_to(label, url_for(search_state.params_for_search(per_page: count))) %></li>
-    <%- end -%>
-  </ul>
+<div id="per_page-dropdown" class="uppercase dark-grey lato-b">
+  <%= t('blacklight.search.per_page.title') %>
+  <div class="btn-group">
+    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+      <%= t(:'blacklight.search.per_page.button_label', :count => current_per_page) %> <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+      <%- per_page_options_for_select.each do |(label, count)| %>
+        <li role="menuitem"><%= link_to(label, url_for(search_state.params_for_search(per_page: count))) %></li>
+      <%- end -%>
+    </ul>
+  </div>
 </div>
 <% end %>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,9 +1,9 @@
 <!-- OVERRIDE FROM HYRAX TO ADD SAVE BUTTON AND MODAL -->
 
-<div id="sortAndPerPage" class="sort-pagination d-md-flex justify-content-between" role="navigation" aria-label="<%= t('blacklight.search.per_page.aria_label')%>">
-  <%= render_results_collection_tools wrapping_class: "search-widgets" %>
+<div id="sortAndPerPage" class="row sort-pagination d-md-flex justify-content-between" role="navigation" aria-label="<%= t('blacklight.search.per_page.aria_label')%>">
+  <%= render_results_collection_tools wrapping_class: "search-widgets col-md-6 col-xs-12" %>
 
-  <div class="save-widgets pull-right">
+  <div class="save-widgets col-md-6 col-xs-12 text-right">
     <%= button_tag t('hyrax.dashboard.my.action.select_all'),
                     class: 'select-button',
                     onclick: 'javascript:selectAllSearchResults()' %>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,13 +1,15 @@
 <% if show_sort_and_per_page? and active_sort_fields.many? %>
-<span class="uppercase dark-grey lato-b"><%= t('blacklight.search.sort.title') %></span>
-<div id="sort-dropdown" class="btn-group">
-  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-    <%= t('blacklight.search.sort.button_label', :field =>sort_field_label(current_sort_field.key)) %> <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu" role="menu">
-    <%- active_sort_fields.each do |sort_key, field_config| %>
-      <li role="menuitem"><%= link_to(sort_field_label(sort_key), url_for(search_state.params_for_search(sort: sort_key))) %></li>
-    <%- end -%>
-  </ul>
+<div id="sort-dropdown" class="uppercase dark-grey lato-b">
+  <%= t('blacklight.search.sort.title') %>
+  <div class="btn-group">
+    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+      <%= t('blacklight.search.sort.button_label', :field =>sort_field_label(current_sort_field.key)) %> <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+      <%- active_sort_fields.each do |sort_key, field_config| %>
+        <li role="menuitem"><%= link_to(sort_field_label(sort_key), url_for(search_state.params_for_search(sort: sort_key))) %></li>
+      <%- end -%>
+    </ul>
+  </div>
 </div>
 <% end %>

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,0 +1,4 @@
+<div class="col-xs-12 col-sm-4 col-md-3">
+  <%= render_thumbnail_tag document, {}, suppress_link: true %>
+</div>
+

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,0 +1,5 @@
+<div class="col-md-2 col-xs-11">
+  <div class="list-thumbnail">
+    <%= render_thumbnail_tag document %>
+  </div>
+</div>

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,4 +1,4 @@
-<div class="col-md-2 col-xs-11">
+<div class="col-xs-12 col-sm-4 col-md-3">
   <div class="list-thumbnail">
     <%= render_thumbnail_tag document %>
   </div>

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -6,4 +6,3 @@
     <%# OVERRIDE FROM HYRAX: Removed license render. Fixed but not in any <3.0.0 releases https://github.com/samvera/hyrax/pull/3153 %>
   </dl>
 </div>
- 

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -32,7 +32,7 @@
           <%= render 'social_media' %>
         </div>
         <div class='row'>
-          <div class='col-md-8 col-sm-6'>
+          <div class='col-sm-12'>
             <%# OVERRIDE FROM HYRAX remove work description %>
             <ul class="nav nav-tabs" role="tablist">
               <li role="presentation" class="active">
@@ -70,41 +70,46 @@
           </div>
         </div>
         <div class='row'>
-          <div class='col-md-8 col-sm-6'>
-            <%#= render 'citations', presenter: @presenter %>
+          <div class='col-sm-12'>
+            <!-- Renders children of a parent work -->
+            <% children = @presenter.member_presenters.delete_if { |work| work.class.to_s.include?('FileSet') } %>
+            <% if children.length > 0 %>
+              Contained In This Object: &nbsp; <%= children.length %> items
+              <hr style='border-width: 3px;'>
+              <%= render 'paginated_works', works: children %>
+            <% end %>
+          </div>
+        </div>
+        <div class='row'>
+          <div class='col-sm-12'>
+            <!-- Renders parent of a work. -->
+            <% in_work_ids = ActiveFedora::Base.find(@presenter.id).in_work_ids %>
+            <% unless in_work_ids.empty? %>
+              <% parent = ActiveFedora::Base.find(in_work_ids.first)%>
+              <% parent_presenter = OregonDigital::WorkToPresenterConverter.convert_to_presenter(parent, current_ability) %>
+              Contained In:
+              <hr style='border-width: 3px;'>
+              <%= render 'paginated_works', works: [parent_presenter] %>
+            <% end %>
+          </div>
+        </div>
+        <div class='row'>
+          <div class='col-sm-12'>
+            <!-- Renders siblings of a work -->
+            <% in_work_ids = ActiveFedora::Base.find(@presenter.id).in_work_ids %>
+            <% unless in_work_ids.empty? %>
+              <% parent = ActiveFedora::Base.find(in_work_ids.first)%>
+              <% parent_presenter = OregonDigital::WorkToPresenterConverter.convert_to_presenter(parent, current_ability) %>
+              <% children = parent_presenter.member_presenters.delete_if { |work| work.class.to_s.include?('FileSet') || work.title.first == @presenter.title.first } %>
+              <% if children.length > 0 %>
+                Related Items: &nbsp; <%= children.length %> items
+                <hr style='border-width: 3px;'>
+                <%= render 'paginated_works', works: children %>
+              <% end %>
+            <% end %>
           </div>
         </div>
 
-        <!-- Renders children of a parent work -->
-        <% children = @presenter.member_presenters.delete_if { |work| work.class.to_s.include?('FileSet') } %>
-        <% if children.length > 0 %>
-          Contained In This Object: &nbsp; <%= children.length %> items
-          <hr style='border-width: 3px;'>
-          <%= render 'paginated_works', works: children %>
-        <% end %>
-        
-        <!-- Renders parent of a work. -->
-        <% in_work_ids = ActiveFedora::Base.find(@presenter.id).in_work_ids %>
-        <% unless in_work_ids.empty? %>
-          <% parent = ActiveFedora::Base.find(in_work_ids.first)%>
-          <% parent_presenter = OregonDigital::WorkToPresenterConverter.convert_to_presenter(parent, current_ability) %> 
-          Contained In:
-          <hr style='border-width: 3px;'>
-          <%= render 'paginated_works', works: [parent_presenter] %>
-        <% end %>
-
-        <!-- Renders siblings of a work -->
-        <% in_work_ids = ActiveFedora::Base.find(@presenter.id).in_work_ids %>
-        <% unless in_work_ids.empty? %>
-          <% parent = ActiveFedora::Base.find(in_work_ids.first)%>
-          <% parent_presenter = OregonDigital::WorkToPresenterConverter.convert_to_presenter(parent, current_ability) %> 
-          <% children = parent_presenter.member_presenters.delete_if { |work| work.class.to_s.include?('FileSet') || work.title.first == @presenter.title.first } %>
-          <% if children.length > 0 %>
-            Related Items: &nbsp; <%= children.length %> items
-            <hr style='border-width: 3px;'>
-            <%= render 'paginated_works', works: children %>
-          <% end %>
-        <% end %>
       </div>
     </div>
   </div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -13,7 +13,7 @@ en:
       per_page:
         label: '%{count}'
         button_label: '%{count}'
-        title: 'Show: '
+        title: 'Show:'
       sort:
         button_label: '%{field}'
-        title: 'Sort: '
+        title: 'Sort:'


### PR DESCRIPTION
Fixes #1376 

iPhone X/XS:
![image](https://user-images.githubusercontent.com/11052958/104632192-34519180-5652-11eb-86fc-b98d135b8b9b.png)

iPad:
![image](https://user-images.githubusercontent.com/11052958/104632942-43850f00-5653-11eb-94ee-384e86e14d13.png)

1080p:
![image](https://user-images.githubusercontent.com/11052958/104633007-644d6480-5653-11eb-9c42-233a1583256f.png)


Does work to separate some CSS from work show page and search results.
Then reconciles mobile and desktop views for list view of search results.
