### PR TITLE
Add metadata and compound object information to masonry search results

### DIFF
--- a/app/views/catalog/_metadata_masonry_default.html.erb
+++ b/app/views/catalog/_metadata_masonry_default.html.erb
@@ -12,7 +12,6 @@
 </div>
 
 <div class="metadata-row">
-  <%#= doc_presenter.field_value index_fields(document)['type_label_tesim'] do |block| %>
   <% if document.children? %>
     <%= render 'index_type_icon', document: document unless document.type_label.first.nil? || document.type_label.first.empty? %>
     <span class="sr-only"><%= document.type_label.first %></span>

--- a/app/views/catalog/_metadata_masonry_default.html.erb
+++ b/app/views/catalog/_metadata_masonry_default.html.erb
@@ -1,1 +1,21 @@
-METADATA
+<% doc_presenter = index_presenter(document) %>
+
+<div class="metadata-row">
+  <dl class="row">
+  <% index_fields(document).each do |field_name, field| -%>
+    <% if should_render_index_field? document, field %>
+        <dt class="col-sm-4"><%= render_index_field_label document, field: field_name %></dt>
+        <dd class="col-sm-8"><%= doc_presenter.field_value field %></dd>
+    <% end %>
+  <% end %>
+  </dl>
+</div>
+
+<div class="metadata-row">
+  <%#= doc_presenter.field_value index_fields(document)['type_label_tesim'] do |block| %>
+  <% if document.children? %>
+    <%= render 'index_type_icon', document: document unless document.type_label.first.nil? || document.type_label.first.empty? %>
+    <span class="sr-only"><%= document.type_label.first %></span>
+    (<%= document.children.count %> Items)
+  <% end %>
+</div>


### PR DESCRIPTION
Work for #1377 
![image](https://user-images.githubusercontent.com/11052958/105094382-107abb00-5a59-11eb-866e-22f638974fb7.png)
