### PR TITLE
Add print button and move copyright on work show page

### DIFF
--- a/app/assets/stylesheets/oregon_digital/_work-show.scss
+++ b/app/assets/stylesheets/oregon_digital/_work-show.scss
@@ -18,8 +18,15 @@
   margin-left: 30px;
 }
 
-.edit-button-sections {
-  margin-top: 25px;
+.show-actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+
+  .edit-button-sections {
+    margin-top: 25px;
+    margin-left: 1.5em;
+  }
 }
 
 dl.work-show {

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -2,44 +2,20 @@
   <% if Hyrax.config.analytics? %>
     <%= link_to "Analytics", presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
   <% end %>
-  
+
   <%# OVERRIDE FROM HYRAX to remove restritctions from add to collection button #%>
 
 
 
 
   <div class="col-sm-4 edit-button-sections">
+    <%= link_to 'Print <i class="fa fa-print" aria-hidden="true"></i>'.html_safe, '#', class: 'btn btn-default', onclick: 'window.print();return false;'%>
+  </div>
+  <div class="col-sm-4 edit-button-sections">
     <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector edit-group" checked="checked" />
     <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
                   class: 'btn btn-default submits-batches submits-batches-add',
                   data: { toggle: "modal", target: "#collection-list-container" } %>
-
-    <% if presenter.editor? %>
-      <div class='row'>
-      <div class='col-sm-4 edit-button-sections'>
-      <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
-      </div>
-      <div class='col-sm-4 edit-button-sections'>
-      <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger delete-button-show-page', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
-      </div>
-      <% if presenter.member_presenters.size > 1 %>
-          <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
-      <% end %>
-      <% if presenter.valid_child_concerns.length > 0 %>
-        <div class="btn-group">
-          <button type="button" class="btn btn-default dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Attach Child <span class="caret"></span></button>
-            <ul class="dropdown-menu">
-              <% presenter.valid_child_concerns.each do |concern| %>
-                <li>
-                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
-                </li>
-              <% end %>
-            </ul>
-        </div>
-      <% end %>
-      </div>
-    <% end %>
   </div>
   <div class="col-sm-4 edit-button-sections">
     <div class="dropdown">
@@ -47,10 +23,37 @@
       <span class="caret"></span></button>
       <ul class="dropdown-menu">
         <li><%= link_to "Files + Metadata (ZIP)", ((current_ability.can? :download, ActiveFedora::Base.find(presenter.id)) ? main_app.send(:"download_hyrax_#{presenter.model_name.name.downcase}_path", presenter.id) : main_app.send(:"download_low_hyrax_#{presenter.model_name.name.downcase}_path", presenter.id)) %></li>
-        <li><%= link_to "Metadata Only (CSV)", main_app.send(:"metadata_hyrax_#{presenter.model_name.name.downcase}_path", presenter.id) %></li> 
+        <li><%= link_to "Metadata Only (CSV)", main_app.send(:"metadata_hyrax_#{presenter.model_name.name.downcase}_path", presenter.id) %></li>
       </ul>
     </div>
   </div>
+
+  <% if presenter.editor? %>
+  <div class='row'>
+    <div class='col-sm-4 edit-button-sections'>
+    <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
+    </div>
+    <div class='col-sm-4 edit-button-sections'>
+    <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger delete-button-show-page', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
+    </div>
+    <% if presenter.member_presenters.size > 1 %>
+        <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
+    <% end %>
+    <% if presenter.valid_child_concerns.length > 0 %>
+      <div class="btn-group">
+        <button type="button" class="btn btn-default dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Attach Child <span class="caret"></span></button>
+          <ul class="dropdown-menu">
+            <% presenter.valid_child_concerns.each do |concern| %>
+              <li>
+                <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+              </li>
+            <% end %>
+          </ul>
+      </div>
+    <% end %>
+  </div>
+  <% end %>
   <%# END OVERRIDE #%>
   <!-- >
   <% if presenter.work_featurable? %>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -8,16 +8,16 @@
 
 
 
-  <div class="col-sm-4 edit-button-sections">
+  <div class="edit-button-sections">
     <%= link_to 'Print <i class="fa fa-print" aria-hidden="true"></i>'.html_safe, '#', class: 'btn btn-default', onclick: 'window.print();return false;'%>
   </div>
-  <div class="col-sm-4 edit-button-sections">
+  <div class="edit-button-sections">
     <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector edit-group" checked="checked" />
     <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
                   class: 'btn btn-default submits-batches submits-batches-add',
                   data: { toggle: "modal", target: "#collection-list-container" } %>
   </div>
-  <div class="col-sm-4 edit-button-sections">
+  <div class="edit-button-sections">
     <div class="dropdown">
       <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">Download
       <span class="caret"></span></button>
@@ -29,11 +29,10 @@
   </div>
 
   <% if presenter.editor? %>
-  <div class='row'>
-    <div class='col-sm-4 edit-button-sections'>
+    <div class='edit-button-sections'>
     <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
     </div>
-    <div class='col-sm-4 edit-button-sections'>
+    <div class='edit-button-sections'>
     <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger delete-button-show-page', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
     </div>
     <% if presenter.member_presenters.size > 1 %>
@@ -52,7 +51,6 @@
           </ul>
       </div>
     <% end %>
-  </div>
   <% end %>
   <%# END OVERRIDE #%>
   <!-- >
@@ -68,10 +66,6 @@
 
 
   <-->
-
-
-
-
 </div>
 
 <!-- COinS hook for Zotero -->

--- a/app/views/hyrax/base/_work_title.html.erb
+++ b/app/views/hyrax/base/_work_title.html.erb
@@ -12,18 +12,18 @@
         <h1><%= title %></h1>
       <% end %>
     </div>
-    <div class="col-sm-3">
+    <div class="col-sm-6 text-right">
+      <% if index == 0 %>
+        <%= render "show_actions", presenter: presenter %>
+      <% end %>
+    </div>
+    <div class="col-sm-3 pull-right text-right">
       <div id="copyright-work-show" class="copyright-header">
         <a href="<%= ERB::Util.h(presenter.rights_statement.first) %>">
           <i class="large-icon fa fa-<%= presenter.solr_document.rights_statement_to_fa_class(presenter.rights_statement.first) %>" aria-hidden="true"></i>
           <%= Hyrax.config.rights_statement_service_class.new.label(presenter.rights_statement.first) { presenter.rights_statement.first } %>
         </a>
       </div>
-    </div>
-    <div class="col-sm-3 text-right">
-      <% if index == 0 %>
-        <%= render "show_actions", presenter: presenter %>
-      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11052958/105778682-b169ea00-5f21-11eb-8b32-a875f91ecdcb.png)
Fixes #1471 

Turns the work actions into a flexbox instead of BS grid. Also moves the second row of actions (admin actions) inline with regular actions, keeping the editor/admin checks