### PR TITLE
IIIF Manifest fixes for compound objects

### DIFF
--- a/app/models/blacklight_iiif_search/iiif_search.rb
+++ b/app/models/blacklight_iiif_search/iiif_search.rb
@@ -33,8 +33,10 @@ module BlacklightIiifSearch
     def solr_params
       return { q: 'nil:nil' } unless q
 
+      ids = parent_document.member_ids
+      ids << id
       # OVERRIDE FROM BLACKLIGHT_IIIF_SEARCH to make the solr query join work with fileset documents
-      { q: q, fq: ["{!join from=file_set_ids_ssim to=id}id:#{id}"], rows: rows, page: page }
+      { q: q, fq: ["{!join from=file_set_ids_ssim to=id}id:#{ids.join ' OR id:'}"], rows: rows, page: page }
     end
   end
 end

--- a/app/presenters/oregon_digital/iiif_presenter.rb
+++ b/app/presenters/oregon_digital/iiif_presenter.rb
@@ -24,6 +24,27 @@ module OregonDigital
       presenters
     end
 
+    def work_presenters
+      presenters = []
+
+      (ordered_ids - file_sets.map(&:id)).each do |work_id|
+        work = ActiveFedora::Base.find(work_id)
+        doc = SolrDocument.find(work_id)
+        work.file_sets.each do |fs|
+          urls = file_set_derivatives_service(fs).sorted_derivative_urls('jp2')
+
+          urls.each_with_index do |derivative, i|
+            label = urls.length > 1 ? page_label(fs.label, i) : fs.label
+            presenter = IIIFPresenter.new(doc, current_ability, request)
+            presenter.file_sets = work.file_sets
+            presenters << presenter
+          end
+        end
+      end
+
+      presenters
+    end
+
     def search_service
       Rails.application.routes.url_helpers.solr_document_iiif_search_url(solr_document_id: id.to_s)
     end

--- a/app/presenters/oregon_digital/iiif_presenter.rb
+++ b/app/presenters/oregon_digital/iiif_presenter.rb
@@ -30,16 +30,10 @@ module OregonDigital
       (ordered_ids - file_sets.map(&:id)).each do |work_id|
         work = ActiveFedora::Base.find(work_id)
         doc = SolrDocument.find(work_id)
-        work.file_sets.each do |fs|
-          urls = file_set_derivatives_service(fs).sorted_derivative_urls('jp2')
 
-          urls.each_with_index do |derivative, i|
-            label = urls.length > 1 ? page_label(fs.label, i) : fs.label
-            presenter = IIIFPresenter.new(doc, current_ability, request)
-            presenter.file_sets = work.file_sets
-            presenters << presenter
-          end
-        end
+        presenter = IIIFPresenter.new(doc, current_ability, request)
+        presenter.file_sets = work.file_sets
+        presenters << presenter
       end
 
       presenters

--- a/config/initializers/hacks/iiif_manifest_canvas_builder.rb
+++ b/config/initializers/hacks/iiif_manifest_canvas_builder.rb
@@ -3,7 +3,7 @@
 IIIFManifest::ManifestBuilder::CanvasBuilder.class_eval do
   # Add a page number to the canvas URL so we can reference different canvases within the same sequence.
   def path
-    page = record.label.gsub(/^.*Page ([0-9]*)$/, '\1').to_i
+    page = record.label.respond_to?('gsub') ? record.label.gsub(/^.*Page ([0-9]*)$/, '\1').to_i : 0;
     page = [0, page - 1].max
     "#{parent.manifest_url}/canvas/#{record.id}/#{page}"
   end


### PR DESCRIPTION
Fixes #1110 
This includes the gsub fix but also two new bugfixes.
- Parent works were not properly setting the id for child canvases. This was fixed by making sure that child work presenters are properly set to our custom IIIFPresenter class, not Hyrax's WorkPresenter class (`iiif_presenter.rb`)
- Only the parent work id was joined against file sets to find OCRd/scraped text. This was fixed by including all member ids into the solr fq join statement. (`iiif_search.rb`)