### PR TITLE
Fire off FetchGraphWorker after attaching fileset to work on ingest

### DIFF
--- a/app/services/oregon_digital/listeners/metadata_fetch_listener.rb
+++ b/app/services/oregon_digital/listeners/metadata_fetch_listener.rb
@@ -9,6 +9,12 @@ module OregonDigital
       def on_object_metadata_updated(event)
         FetchGraphWorker.perform_at(2.seconds, event[:object].id, event[:object].depositor)
       end
+
+      ##
+      # @param event [Dry::Event]
+      def on_file_set_attached(event)
+        FetchGraphWorker.perform_at(2.seconds, event[:file_set].parent.id, event[:file_set].parent.depositor)
+      end
     end
   end
 end


### PR DESCRIPTION
This is needed because of multiple worker nodes. If the FetchGraphWorker starts before AttachFilesToWork we can end up overwriting the work of the FetchGraphWorker. This change enqueues another FGW after AttachFilesToWork finishes.

Fixes #1432 