### PR TITLE
Get IDs for the review queue the Hyrax way

### DIFF
--- a/app/search_builders/oregon_digital/in_review_search_builder.rb
+++ b/app/search_builders/oregon_digital/in_review_search_builder.rb
@@ -9,9 +9,12 @@ module OregonDigital
 
     # Get all the ids for the works in review from Hyrax and pipe into this search builder
     def in_review_ids(solr_params)
-      solr_documents = Hyrax::Workflow::StatusListService.new(@scope, '-workflow_state_name_ssim:deposited').each
       solr_params[:fq] ||= []
       solr_params[:fq] << "id:(#{solr_documents.map(&:id).join(' OR ')})"
+    end
+
+    def solr_documents
+      Hyrax::Workflow::StatusListService.new(@scope, '-workflow_state_name_ssim:deposited').each
     end
   end
 end

--- a/app/search_builders/oregon_digital/in_review_search_builder.rb
+++ b/app/search_builders/oregon_digital/in_review_search_builder.rb
@@ -4,32 +4,14 @@ module OregonDigital
   # Finds works that are in review and the user can action on
   # Based on Hyrax::Workflow::StatusListService
   class InReviewSearchBuilder < ::SearchBuilder
-    self.default_processor_chain += %i[actionable not_deposited]
+    self.default_processor_chain += %i[in_review_ids]
     self.default_processor_chain -= %i[only_active_works]
 
-    def actionable(solr_params)
+    # Get all the ids for the works in review from Hyrax and pipe into this search builder
+    def in_review_ids(solr_params)
+      solr_documents = Hyrax::Workflow::StatusListService.new(@scope, '-workflow_state_name_ssim:deposited').each
       solr_params[:fq] ||= []
-      solr_params[:fq] << "{!terms f=actionable_workflow_roles_ssim}#{actionable_roles.join(',')}"
-    end
-
-    def not_deposited(solr_params)
-      solr_params[:fq] ||= []
-      solr_params[:fq] << '-workflow_state_name_ssim:deposited'
-    end
-
-    # @return [Array<String>] the list of workflow-role combinations this user has
-    def actionable_roles
-      Sipity::Workflow.all.flat_map do |wf|
-        workflow_roles_for_user_and_workflow(wf).map do |wf_role|
-          "#{wf.permission_template.source_id}-#{wf.name}-#{wf_role.role.name}"
-        end
-      end
-    end
-
-    # @param workflow [Sipity::Workflow]
-    # @return [ActiveRecord::Relation<Sipity::WorkflowRole>]
-    def workflow_roles_for_user_and_workflow(workflow)
-      Hyrax::Workflow::PermissionQuery.scope_processing_workflow_roles_for_user_and_workflow(user: @scope.current_user, workflow: workflow)
+      solr_params[:fq] << "id:(#{solr_documents.map(&:id).join(' OR ')})"
     end
   end
 end

--- a/spec/search_builders/oregon_digital/in_review_search_builder_spec.rb
+++ b/spec/search_builders/oregon_digital/in_review_search_builder_spec.rb
@@ -9,26 +9,20 @@ RSpec.describe OregonDigital::InReviewSearchBuilder do
 
     let(:processor_chain) { search_builder.processor_chain }
 
-    it { is_expected.to include(:actionable, :not_deposited) }
+    it { is_expected.to include(:in_review_ids) }
+    it { is_expected.not_to include(:only_active_works) }
   end
 
-  describe '#actionable' do
+  describe '#in_review_ids' do
     subject { solr_params }
 
     let(:solr_params) { {} }
 
-    before { search_builder.actionable(solr_params) }
+    before do
+      allow(search_builder).to receive(:solr_documents).and_return([])
+      search_builder.in_review_ids(solr_params)
+    end
 
-    it { is_expected.to eq(fq: ['{!terms f=actionable_workflow_roles_ssim}']) }
-  end
-
-  describe '#not_deposited' do
-    subject { solr_params }
-
-    let(:solr_params) { {} }
-
-    before { search_builder.not_deposited(solr_params) }
-
-    it { is_expected.to eq(fq: ['-workflow_state_name_ssim:deposited']) }
+    it { is_expected.to eq(fq: ['id:()']) }
   end
 end


### PR DESCRIPTION
Fixes #1460 
The old search builder would get confused when the Solr index was out-of-sync with Sipity entities in Postgres. Sipity entities seem to be more likely to get out-of-sync, probably because they're not very relevant to search.
The new way uses the Hyrax method to get all the correct Solr documents then pipes those IDs into the search builder. This will work much more often, but it will query all three datasources several times (Postgres, Fedora, Solr)