### PR TITLE
Log user in after visiting confirmation link

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Controller for user email confirmation
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  def show
+    self.resource = resource_class.confirm_by_token(params[:confirmation_token])
+    yield resource if block_given?
+
+    if resource.errors.empty?
+      set_flash_message!(:notice, :confirmed)
+      # OVERRIDE FROM DEVISE to sign user in after confirming email
+      sign_in(resource)
+      respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }
+    else
+      respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new }
+    end
+  end
+end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -2,6 +2,7 @@
 
 # Controller for user email confirmation
 class Users::ConfirmationsController < Devise::ConfirmationsController
+  # rubocop:disable Metrics/AbcSize
   def show
     self.resource = resource_class.confirm_by_token(params[:confirmation_token])
     yield resource if block_given?
@@ -10,9 +11,10 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
       set_flash_message!(:notice, :confirmed)
       # OVERRIDE FROM DEVISE to sign user in after confirming email
       sign_in(resource)
-      respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }
+      respond_with_navigational(resource) { redirect_to after_confirmation_path_for(resource_name, resource) }
     else
-      respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new }
+      respond_with_navigational(resource.errors, status: :unprocessable_entity) { render :new }
     end
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
     concerns :range_searchable
   end
 
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks', sessions: 'users/sessions', registrations: 'users/registrations', passwords: 'users/passwords' }
+  devise_for :users, controllers: { confirmations: 'users/confirmations', omniauth_callbacks: 'users/omniauth_callbacks', sessions: 'users/sessions', registrations: 'users/registrations', passwords: 'users/passwords' }
   devise_scope :user do
     get 'users/auth/cas', to: 'users/omniauth_authorize#passthru', defaults: { provider: :cas }, as: 'new_osu_session'
     get 'users/auth/saml', to: 'users/omniauth_authorize#passthru', defaults: { provider: :saml }, as: 'new_uo_session'


### PR DESCRIPTION
Fixes #1540 
This causes a user to login after they visit the confirmation link they are sent. This is technically a security risk, but accounts are not really tied to very sensitive information, maybe just email address.
Adapted from this SO: https://stackoverflow.com/questions/18655334/avoid-sign-in-after-confirmation-link-click-using-devise-gem