### PR TITLE
Set CCI remote docker version to 20.10.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,8 @@ jobs:
             echo export RAILS_ENV="$RAILS_ENV" >> $BASH_ENV
             echo export TAG="$DATETIME-$APP_VERSION-$GIT_SHORT_HASH" >> $BASH_ENV
             echo export DEPLOYED_VERSION="$DATETIME-$GIT_SHORT_HASH" >> $BASH_ENV
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.2
       - docker/check:
           registry: registry.library.oregonstate.edu
       - docker/pull:


### PR DESCRIPTION
According to [this yarn issue](https://github.com/yarnpkg/yarn/issues/8389) updating the CCI version of docker will fix this error:
```
error An unexpected error occurred: "EPERM: operation not permitted, copyfile '/data/.cache/yarn/v6/npm-form-data-2.3.3-dcce52c05f644f298c6a7ab936bd724ceffbf3a6-integrity/node_modules/form-data/License' -> '/data/node_modules/form-data/License'".
```
while building on CCI