### PR TITLE
Look for solr document parents based on the ID from the current solr document

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -59,7 +59,7 @@ class SolrDocument
   def parents
     config = ::CatalogController.new
     repository = config.repository
-    search_builder = OregonDigital::ParentsSearchBuilder.new(work: ActiveFedora::Base.find(self['id']))
+    search_builder = OregonDigital::ParentsSearchBuilder.new(id: self['id'])
     @parents ||= repository.search(search_builder).docs
   end
 

--- a/app/search_builders/oregon_digital/parents_search_builder.rb
+++ b/app/search_builders/oregon_digital/parents_search_builder.rb
@@ -7,14 +7,14 @@ module OregonDigital
 
     attr_reader :work
 
-    def initialize(work:)
-      @work = work
+    def initialize(id:)
+      @id = id
       super
     end
 
     def parent_works(solr_params)
       solr_params[:fq] ||= []
-      solr_params[:fq] << "member_ids_ssim:(#{work.id})"
+      solr_params[:fq] << "member_ids_ssim:(#{@id})"
     end
   end
 end

--- a/spec/search_builders/oregon_digital/parents_search_builder_spec.rb
+++ b/spec/search_builders/oregon_digital/parents_search_builder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OregonDigital::ParentsSearchBuilder do
   let(:solr_params) { {} }
   let(:child) { build(:generic, title: ['foo'], id: 123) }
   let(:parent) { build(:generic, title: ['foo'], id: 124, member_ids: [child.id]) }
-  let(:search_builder) { described_class.new(work: child) }
+  let(:search_builder) { described_class.new(id: child.id) }
 
   describe '#processor_chain' do
     subject { processor_chain }


### PR DESCRIPTION
Removes one ActiveFedora look up, that may happen many times in search

Attempts to fix #1742 