### PR TITLE
Add relevant alt text to collection institution image

### DIFF
--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -23,7 +23,8 @@
       <%# Institutional image %>
       <div class="col-md-4 text-right">
         <%# check if institution is OSU or UO. OSU image needs 100px hieght, UO 55px %>
-        <%= image_tag controller.institution_image_path, alt: '', height: "#{@presenter.solr_document.institution.first.to_s.include?('http://id.loc.gov/authorities/names/n80017721') ? 100 : 55 }px;" %>
+        <% path, alt, height = controller.institution_image_info %>
+        <%= image_tag path, alt: alt, height: height %>
       </div>
       <%# Social media share icons %>
       <div class="col-md-12 text-right share-links">

--- a/config/initializers/hacks/hyrax_collections_controller_behavior.rb
+++ b/config/initializers/hacks/hyrax_collections_controller_behavior.rb
@@ -42,17 +42,22 @@ Hyrax::CollectionsControllerBehavior.module_eval do
   end
 
   # Get the path to institutional branding imag
-  def institution_image_path
+  def institution_image_info
     image = 'no-institution-collection.png'
+    alt = ''
+    height = 55
 
     case OregonDigital::InstitutionPicker.institution_acronym(@curation_concern)
     when 'OSU' then
       image = 'osu-collection.png'
+      alt = 'Oregon State University Libraries and Press'
+      height = 100
     when 'UO'
       image = 'uo-collection.png'
+      alt = 'University of Oregon Libraries'
     end unless @curation_concern.institution.first.nil?
 
-    ApplicationController.helpers.asset_path(image)
+    return ApplicationController.helpers.asset_path(image), alt, height
   end
 
   private


### PR DESCRIPTION
Convert `institution_image_path` to `institution_image_info` which returns alt text, image height, and image path
Fixes #1830 