### PR TITLE
Ticket #1747: Collection Landing: Link Names for Images

### DIFF
--- a/app/views/hyrax/collections/_showcase_tile.html.erb
+++ b/app/views/hyrax/collections/_showcase_tile.html.erb
@@ -1,6 +1,6 @@
 <div class="thumbnail">
     <div id="image-<%= index %>">
-      <%= link_to link do |body| %>
+      <%= link_to link, aria: { haspopup: true, expanded: false, controls: 'user-util-links', label: title } do |body| %>
         <%= img %>
         <span class="h3 hover-over-collection-text show-me<%= index %>" >
           <%= title %>

--- a/app/views/hyrax/collections/_showcase_tile.html.erb
+++ b/app/views/hyrax/collections/_showcase_tile.html.erb
@@ -1,6 +1,6 @@
 <div class="thumbnail">
     <div id="image-<%= index %>">
-      <%= link_to link, aria: { haspopup: true, expanded: false, controls: 'user-util-links', label: title } do |body| %>
+      <%= link_to link, aria: { label: title } do |body| %>
         <%= img %>
         <span class="h3 hover-over-collection-text show-me<%= index %>" >
           <%= title %>


### PR DESCRIPTION
Added aria-label to collection landing images to ensure that links had discernible text when titles are hidden