### PR TITLE
Bootstrap modal improvements

### DIFF
--- a/app/assets/javascripts/blacklight/ajax_modal.js
+++ b/app/assets/javascripts/blacklight/ajax_modal.js
@@ -212,8 +212,29 @@ $(document).ready(function() {
   $('body').on('show.bs.modal', function(e) {
     Blacklight.ajaxModal.clickTarget = e.relatedTarget;
   });
+  // Find first and last focusable elements in the modal
+  // and making tabing off the modal wrap around instead
+  $('body').on('shown.bs.modal', function(e) {
+    // Find the focusable elements and save them
+    var focusable = $(e.target).find('button:visible, [href]:visible, input:visible, select:visible, textarea:visible, [tabindex]:visible:not([tabindex="-1"])');
+    Blacklight.ajaxModal.firstFocusable = $(focusable[0])
+    Blacklight.ajaxModal.lastFocusable = $(focusable[focusable.length - 1]);
+    // On the first focusable, if we shift+tab off, jump to last focusable
+    Blacklight.ajaxModal.firstFocusable.on('keydown', function(e) {
+      if(e.keyCode == 9 && e.shiftKey) {
+        e.preventDefault();
+        Blacklight.ajaxModal.lastFocusable.focus();
+      }
+    });
+    // On the last focusable, if we tab (but not shift+tab) off, jump to the first focusable
+    Blacklight.ajaxModal.lastFocusable.on('keydown', function(e) {
+      if(e.keyCode == 9 && !e.shiftKey) {
+        e.preventDefault();
+        Blacklight.ajaxModal.firstFocusable.focus();
+      }
+    });
+  });
   $('body').on('hidden.bs.modal', function(e) {
-    console.log(Blacklight.ajaxModal.clickTarget);
     Blacklight.ajaxModal.clickTarget.focus();
   });
 });

--- a/app/assets/javascripts/blacklight/ajax_modal.js
+++ b/app/assets/javascripts/blacklight/ajax_modal.js
@@ -107,8 +107,8 @@ Blacklight.ajaxModal.modalCloseSelector   = "[data-ajax-modal~=close], span.ajax
 // network errors.
 Blacklight.ajaxModal.onFailure = function() {
   var contents =  "<div class='modal-header'>" +
-          "<button type='button' class='close' data-dismiss='modal' aria-label='Close'><span aria-hidden='true'>×</span></button>" +
-          "<h4 id='modal-title'>Network Error</h4></div>";
+          "<h4 id='modal-title'>Network Error</h4>" +
+          "<button type='button' class='close' data-dismiss='modal' aria-label='Close'><span aria-hidden='true'>×</span></button></div>";
   $(Blacklight.ajaxModal.modalSelector).find('.modal-content').html(contents);
   $(Blacklight.ajaxModal.modalSelector).modal('show', this.relatedObject);
   // Blacklight.ajaxModal.clickTarget = clickTarget;

--- a/app/assets/javascripts/blacklight/ajax_modal.js
+++ b/app/assets/javascripts/blacklight/ajax_modal.js
@@ -1,0 +1,219 @@
+//= require blacklight/core
+
+/*
+  The ajax_modal plugin can display some interactions inside a Bootstrap
+  modal window, including some multi-page interactions.
+
+  It supports unobtrusive Javascript, where a link or form that would have caused
+  a new page load is changed to display it's results inside a modal dialog,
+  by this plugin.  The plugin assumes there is a Bootstrap modal div
+  on the page with id #ajax-modal to use as the modal -- the standard Blacklight
+  layout provides this.
+
+  To make a link or form have their results display inside a modal, add
+  `data-ajax-modal="trigger"` to the link or form. (Note, form itself not submit input)
+  With Rails link_to helper, you'd do that like:
+
+      link_to something, link, :data => {:ajax_modal => "trigger"}
+
+  The results of the link href or form submit will be displayed inside
+  a modal -- they should include the proper HTML markup for a bootstrap modal's
+  contents. Also, you ordinarily won't want the Rails template with wrapping
+  navigational elements to be used.  The Rails controller could suppress
+  the layout when a JS AJAX request is detected, OR the response
+  can include a `<div data-ajax-modal="container">` -- only the contents
+  of the container will be placed inside the modal, the rest of the
+  page will be ignored.
+
+  If you'd like to have a link or button that closes the modal,
+  you can just add a `data-dismiss="modal"` to the link,
+  standard Bootstrap convention. But you can also have
+  an href on this link for non-JS contexts, we'll make sure
+  inside the modal it closes the modal and the link is NOT followed.
+
+  Link or forms inside the modal will ordinarily cause page loads
+  when they are triggered. However, if you'd like their results
+  to stay within the modal, just add `data-ajax-modal="preserve"`
+  to the link or form.
+
+  Here's an example of what might be returned, demonstrating most of the devices available:
+
+    <div data-ajax-modal="container">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <h3 class="modal-title">Request Placed</h3>
+      </div>
+
+      <div class="modal-body">
+        <p>Some message</p>
+        <%= link_to "This result will still be within modal", some_link, :data => {:ajax_modal => "preserve"} %>
+      </div>
+
+
+      <div class="modal-footer">
+        <%= link_to "Close the modal", request_done_path, :class => "submit button dialog-close", :data => {:dismiss => "modal"} %>
+      </div>
+    </div>
+
+
+  One additional feature. If the content returned from the AJAX modal load
+  has an element with `data-ajax-modal=close`, that will trigger the modal
+  to be closed. And if this element includes a node with class "flash_messages",
+  the flash-messages node will be added to the main page inside #main-flahses.
+
+  == Events
+
+  We'll send out an event 'loaded.blacklight.ajax-modal' with the #ajax-modal
+  dialog as the target, right after content is loaded into the modal but before
+  it is shown (if not already a shown modal).  In an event handler, you can
+  inspect loaded content by looking inside $(this).  If you call event.preventDefault(),
+  we won't 'show' the dialog (although it may already have been shown, you may want to
+  $(this).modal("hide") if you want to ensure hidden/closed.
+
+  The data-ajax-modal=close behavior is implemented with this event, see for example.
+*/
+
+// We keep all our data in Blacklight.ajaxModal object.
+// Create lazily if someone else created first.
+if (Blacklight.ajaxModal === undefined) {
+  Blacklight.ajaxModal = {};
+}
+
+
+// a Bootstrap modal div that should be already on the page hidden
+Blacklight.ajaxModal.modalSelector = "#ajax-modal";
+
+// Trigger selectors identify forms or hyperlinks that should open
+// inside a modal dialog.
+Blacklight.ajaxModal.triggerLinkSelector  = "a[data-ajax-modal~=trigger], a.lightboxLink,a.more_facets_link,.ajax_modal_launch";
+Blacklight.ajaxModal.triggerFormSelector  = "form[data-ajax-modal~=trigger], form.ajax_form";
+
+// preserve selectors identify forms or hyperlinks that, if activated already
+// inside a modal dialog, should have destinations remain inside the modal -- but
+// won't trigger a modal if not already in one.
+//
+// No need to repeat selectors from trigger selectors, those will already
+// be preserved. MUST be manually prefixed with the modal selector,
+// so they only apply to things inside a modal.
+Blacklight.ajaxModal.preserveLinkSelector = Blacklight.ajaxModal.modalSelector + ' a[data-ajax-modal~=preserve]';
+Blacklight.ajaxModal.preserveFormSelector = Blacklight.ajaxModal.modalSelector + ' form[data-ajax-modal~=preserve]'
+
+Blacklight.ajaxModal.containerSelector    = "[data-ajax-modal~=container]";
+
+Blacklight.ajaxModal.modalCloseSelector   = "[data-ajax-modal~=close], span.ajax-close-modal";
+
+// Called on fatal failure of ajax load, function returns content
+// to show to user in modal.  Right now called only for extreme
+// network errors.
+Blacklight.ajaxModal.onFailure = function() {
+  var contents =  "<div class='modal-header'>" +
+          "<button type='button' class='close' data-dismiss='modal' aria-label='Close'><span aria-hidden='true'>×</span></button>" +
+          "<h4 id='modal-title'>Network Error</h4></div>";
+  $(Blacklight.ajaxModal.modalSelector).find('.modal-content').html(contents);
+  $(Blacklight.ajaxModal.modalSelector).modal('show', this.relatedObject);
+  // Blacklight.ajaxModal.clickTarget = clickTarget;
+};
+
+Blacklight.ajaxModal.receiveAjax = function (contents) {
+  // does it have a data- selector for container?
+  // important we don't execute script tags, we shouldn't.
+  // code modelled off of JQuery ajax.load. https://github.com/jquery/jquery/blob/master/src/ajax/load.js?source=c#L62
+  var container =  $("<div>").
+    append( jQuery.parseHTML(contents) ).find( Blacklight.ajaxModal.containerSelector ).first();
+  if (container.length !== 0) {
+    contents = container.html();
+  }
+
+  $(Blacklight.ajaxModal.modalSelector).find('.modal-content').html(contents);
+
+  // send custom event with the modal dialog div as the target
+  var e    = $.Event('loaded.blacklight.ajax-modal');
+  $(Blacklight.ajaxModal.modalSelector).trigger(e);
+  // if they did preventDefault, don't show the dialog
+  if (e.isDefaultPrevented()) return;
+
+  $(Blacklight.ajaxModal.modalSelector).modal('show', this.relatedObject);
+};
+
+
+Blacklight.ajaxModal.modalAjaxLinkClick = function(e) {
+  e.preventDefault();
+
+  $.ajax({
+    url: $(this).attr('href'),
+    relatedObject: this,
+  })
+  .fail(Blacklight.ajaxModal.onFailure)
+  .done(Blacklight.ajaxModal.receiveAjax)
+};
+
+Blacklight.ajaxModal.modalAjaxFormSubmit = function(e) {
+  e.preventDefault();
+
+  $.ajax({
+    url: $(this).attr('action'),
+    data: $(this).serialize(),
+    type: $(this).attr('method') // POST
+  })
+  .fail(Blacklight.ajaxModal.onFailure)
+  .done(Blacklight.ajaxModal.receiveAjax)
+}
+
+
+
+Blacklight.ajaxModal.setup_modal = function() {
+	// Event indicating blacklight is setting up a modal link,
+  // you can catch it and call e.preventDefault() to abort
+  // setup.
+	var e = $.Event('setup.blacklight.ajax-modal');
+	$("body").trigger(e);
+	if (e.isDefaultPrevented()) return;
+
+  // Register both trigger and preserve selectors in ONE event handler, combining
+  // into one selector with a comma, so if something matches BOTH selectors, it
+  // still only gets the event handler called once.
+  $("body").on("click", Blacklight.ajaxModal.triggerLinkSelector  + ", " + Blacklight.ajaxModal.preserveLinkSelector,
+    Blacklight.ajaxModal.modalAjaxLinkClick);
+  $("body").on("submit", Blacklight.ajaxModal.triggerFormSelector + ", " + Blacklight.ajaxModal.preserveFormSelector,
+    Blacklight.ajaxModal.modalAjaxFormSubmit);
+
+  // Catch our own custom loaded event to implement data-ajax-modal=closed
+  $("body").on("loaded.blacklight.ajax-modal", Blacklight.ajaxModal.check_close_ajax_modal);
+
+  // we support doing data-dismiss=modal on a <a> with a href for non-ajax
+  // use, we need to suppress following the a's href that's there for
+  // non-JS contexts.
+  $("body ").on("click", Blacklight.ajaxModal.modalSelector + " a[data-dismiss~=modal]", function (e) {
+    e.preventDefault();
+  });
+};
+
+// A function used as an event handler on loaded.blacklight.ajax-modal
+// to catch contained data-ajax-modal=closed directions
+Blacklight.ajaxModal.check_close_ajax_modal = function(event) {
+  if ($(event.target).find(Blacklight.ajaxModal.modalCloseSelector).length) {
+    modal_flashes = $(this).find('.flash_messages');
+
+    $(event.target).modal("hide");
+    event.preventDefault();
+
+    main_flashes = $('#main-flashes');
+    main_flashes.append(modal_flashes);
+    modal_flashes.fadeIn(500);
+  }
+}
+
+Blacklight.onLoad(function() {
+  Blacklight.ajaxModal.setup_modal();
+});
+
+// Reset focus to element that opened the modal
+$(document).ready(function() {
+  $('body').on('show.bs.modal', function(e) {
+    Blacklight.ajaxModal.clickTarget = e.relatedTarget;
+  });
+  $('body').on('hidden.bs.modal', function(e) {
+    console.log(Blacklight.ajaxModal.clickTarget);
+    Blacklight.ajaxModal.clickTarget.focus();
+  });
+});

--- a/app/assets/stylesheets/oregon_digital/_facets.scss
+++ b/app/assets/stylesheets/oregon_digital/_facets.scss
@@ -1,0 +1,11 @@
+#facets, #advanced-facet-limits {
+  .panel-title {
+    color: $black;
+  }
+}
+
+.facet_limit-active > .panel-heading {
+  h4, .h4 {
+    color: #3c763d; //Bootstrap green
+  }
+}

--- a/app/assets/stylesheets/oregon_digital/bootstrap/_modals.scss
+++ b/app/assets/stylesheets/oregon_digital/bootstrap/_modals.scss
@@ -15,9 +15,8 @@
   }
 }
 #ajax-modal {
-    .close {
-      margin-top: -64px;
-    }
+  .close {
+    margin-top: -64px;
   }
 }
 

--- a/app/assets/stylesheets/oregon_digital/bootstrap/_modals.scss
+++ b/app/assets/stylesheets/oregon_digital/bootstrap/_modals.scss
@@ -14,6 +14,12 @@
     font-weight: normal;
   }
 }
+#ajax-modal {
+    .close {
+      margin-top: -64px;
+    }
+  }
+}
 
 .modal-body {
   padding: 15px 30px 45px;

--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,4 +1,4 @@
-<div aria-labelledby="<%= facet_field_id(facet_field) %>-header" role="group" class="panel facet_limit blacklight-<%= facet_field.key %> <%= 'facet-limit-active' if facet_field_in_params?(facet_field.key) %>">
+<div aria-labelledby="<%= facet_field_id(facet_field) %>-header" role="group" class="panel facet_limit blacklight-<%= facet_field.key %> <%= 'facet_limit-active' if facet_field_in_params?(facet_field.key) %>">
   <div class="collapse-toggle panel-heading">
     <h4 class="panel-header p-0 facet-field-heading" id="<%= facet_field_id(facet_field) %>-header">
       <button
@@ -14,7 +14,7 @@
       </button>
     </h4>
   </div>
-  <div id="<%= facet_field_id(facet_field) %>" class="panel-collapse facet-content collapse <%= "show" unless should_collapse_facet?(facet_field) %>">
+  <div id="<%= facet_field_id(facet_field) %>" class="panel-collapse facet-content collapse <%= "in" unless should_collapse_facet?(facet_field) %>" aria-expanded="<%= should_collapse_facet?(facet_field) ? 'false' : 'true' %>">
     <div class="panel-body">
       <%= yield %>
     </div>

--- a/app/views/catalog/_facet_limit.html.erb
+++ b/app/views/catalog/_facet_limit.html.erb
@@ -1,0 +1,10 @@
+<ul class="facet-values list-unstyled">
+  <% paginator = facet_paginator(facet_field, display_facet) %>
+  <%= render_facet_limit_list paginator, facet_field.key %>
+
+  <% unless paginator.last_page? || params[:action] == "facet" %>
+    <li class="more_facets_link">
+      <button type="button" class="btn btn-primary btn-sm ajax_modal_launch" href="<%= search_facet_path(id: facet_field.key) %>" data-toggle="modal" data-target=""><%= t("more_#{field_name}_html", scope: 'blacklight.search.facets', default: :more_html, field_name: facet_field.label) %></button>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -1,0 +1,25 @@
+<div class="facet_pagination top">
+  <%= render :partial=>'facet_pagination' %>
+</div>
+
+<div class="modal-header">
+  <h3 id="modal-title" class="modal-title"><%= facet_field_label(@facet.key) %></h3>
+  <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+    <span aria-hidden="true">&times;</span>
+  </button>
+
+  <%= render partial: 'facet_index_navigation' if @facet.index_range && @display_facet.index? %>
+
+</div>
+<div class="modal-body">
+  <div class="facet_extended_list">
+  <%= render_facet_limit(@display_facet, layout: false) %>
+  </div>
+</div>
+
+<div class="modal-footer">
+
+  <div class="facet_pagination bottom">
+    <%= render :partial=>'facet_pagination' %>
+  </div>
+</div>

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -28,7 +28,7 @@
         <%= content_for?(:content) ? yield(:content) : yield %>
 
     </div><!-- /#content-wrapper -->
-    <%= render 'shared/footer' %>
     <%= render 'shared/ajax_modal' %>
+    <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/shared/_ajax_modal.html.erb
+++ b/app/views/shared/_ajax_modal.html.erb
@@ -1,0 +1,6 @@
+<div id="ajax-modal" class="modal fade" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Fixes #1840

Moving the modal above the footer is just good practice (footer should be last-ish) and prevents the modal from tabbing into the browser interface
Modals should open from buttons, not links
When closing the modal, focus jumps back to the opening element
Move button after modal title to get screen readers to announce the modal title