### PR TITLE
White text on orange background contrast improvements

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -2,6 +2,7 @@
 $navy-blue: #073C5C;
 $apple-green: #89BC41;
 $lime-green: #D0DD28;
+$contrast-orange: #E88F2A;
 $dark-orange: #E28A25;
 $light-orange: #FDBB49;
 

--- a/app/assets/stylesheets/oregon_digital/_search.scss
+++ b/app/assets/stylesheets/oregon_digital/_search.scss
@@ -9,8 +9,8 @@
   border: none;
   box-shadow: none;
   &.active {
-    color: white;
-    background-color: $dark-orange;
+    color: $navy-blue;
+    background-color: $contrast-orange;
   }
 }
 
@@ -210,8 +210,9 @@ div.pagination {
 }
 ul.pagination li {
   &.active span {
-    background-color: $dark-orange;
+    background-color: $contrast-orange;
     border: none;
+    color: $navy-blue;
   }
   &.next span,
   &.next a,

--- a/app/assets/stylesheets/oregon_digital/_search.scss
+++ b/app/assets/stylesheets/oregon_digital/_search.scss
@@ -220,6 +220,16 @@ ul.pagination li {
   &.previous a {
     background: none;
   }
+  &.disabled {
+    span,
+    span:hover,
+    span:focus,
+    a,
+    a:hover,
+    a:focus {
+      color: $dark-grey;
+    }
+  }
 
   a,
   span {

--- a/app/assets/stylesheets/oregon_digital/explore_collections/_buttons.scss
+++ b/app/assets/stylesheets/oregon_digital/explore_collections/_buttons.scss
@@ -35,9 +35,9 @@
   .nav-pills > li.active > div > a,
   .nav-pills > li.active > div > a:hover,
   .nav-pills > li.active > div > a:focus {
-    background-color: $dark-orange;
-    border: 3px solid $dark-orange;
-    color: white;
+    background-color: $contrast-orange;
+    border: 3px solid $contrast-orange;
+    color: $navy-blue;
   }
 }
 
@@ -58,7 +58,7 @@
   height: 0;
   border-left: 20px solid transparent;
   border-right: 20px solid transparent;
-  border-top: 20px solid $dark-orange;
+  border-top: 20px solid $contrast-orange;
   position: relative;
   margin-left: 22.5px;
   visibility: hidden;


### PR DESCRIPTION
Fixes #1885
Fixes #1788 
#1788 mentions POSM's decision to change the orange we use in cases like this. I added a new `$contrast-orange` to use with `$navy-blue`
When we're all done with a11y tickets, we need to go and audit various links and mouse-over cursors, to make sure enough is changing on hover & on focus to meet a11y standards.