### PR TITLE
update alt text to describe purpose and not image

### DIFF
--- a/app/views/hyrax/homepage/_login_modal.html.erb
+++ b/app/views/hyrax/homepage/_login_modal.html.erb
@@ -13,7 +13,7 @@
                 <div class="col-md-4">
                   <label>
                     <input type="radio" name="login-select" onclick="toggleFooter('OSU-footer')">
-                    <%= image_tag('osu_logo.png', height: '50', width: '50', alt: 'Oregon State University Logo') %>OSU
+                    <%= image_tag('osu_logo.png', height: '50', width: '50', alt: 'Oregon State University Login') %>OSU
                   </label>
                 </div>
               </li>
@@ -21,7 +21,7 @@
                 <div class="col-md-4">
                   <label>
                     <input type="radio" name="login-select" onclick="toggleFooter('UO-footer')">
-                    <%= image_tag('uo.png', height: '50', width: '50', alt: 'University of Oregon Logo') %>UO
+                    <%= image_tag('uo.png', height: '50', width: '50', alt: 'University of Oregon Login') %>UO
                   </label>
                 </div>
               </li>


### PR DESCRIPTION
Fixes #1338

Adds more accurate description of purpose of the images rather than the image itself.