### PR TITLE
updates advanced search field configuration

### DIFF
--- a/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
@@ -297,35 +297,35 @@ module OregonDigital
           }
         end
         config.add_search_field('description_field', label: 'Description') do |field|
-          title_name = 'description_tesim'
+          solr_name = 'description_tesim'
           field.solr_parameters = {
             qf: solr_name,
             pf: solr_name
           }
         end
         config.add_search_field('date_field', label: 'Date') do |field|
-          title_name = 'date_combined_year_label_sim'
+          solr_name = 'date_combined_year_label_sim'
           field.solr_parameters = {
             qf: solr_name,
             pf: solr_name
           }
         end
         config.add_search_field('institution_field', label: 'Institution') do |field|
-          title_name = 'institution_label_sim'
+          solr_name = 'institution_label_sim'
           field.solr_parameters = {
             qf: solr_name,
             pf: solr_name
           }
         end
         config.add_search_field('language_field', label: 'Language') do |field|
-          title_name = 'language_label_sim'
+          solr_name = 'language_label_sim'
           field.solr_parameters = {
             qf: solr_name,
             pf: solr_name
           }
         end
         config.add_search_field('subject_field', label: 'Subject') do |field|
-          title_name = 'subject_label_sim'
+          solr_name = 'subject_label_sim'
           field.solr_parameters = {
             qf: solr_name,
             pf: solr_name


### PR DESCRIPTION
<img width="1160" alt="Screen Shot 2021-10-11 at 1 49 05 PM" src="https://user-images.githubusercontent.com/6424683/136853978-be068d7c-95ce-4f58-b5d8-ae5f502b7eef.png">

This makes progress toward #2064 

The next step will be to configure the facets to be in line with whats needed by #2064
