### PR TITLE
Update rules for users to see locks

### DIFF
--- a/app/controllers/oregon_digital/explore_collections_controller.rb
+++ b/app/controllers/oregon_digital/explore_collections_controller.rb
@@ -75,11 +75,11 @@ module OregonDigital
     end
 
     def osu_restricted?(id)
-      !osu_items(id).empty? && current_ability.cannot?(:show, {:any => osu_items(id)}, visibility: 'osu')
+      !osu_items(id).empty? && current_ability.cannot?(:show, { any: osu_items(id) }, visibility: 'osu')
     end
 
     def uo_restricted?(id)
-      !uo_items(id).empty? && current_ability.cannot?(:show, {:any => uo_items(id)}, visibility: 'uo')
+      !uo_items(id).empty? && current_ability.cannot?(:show, { any: uo_items(id) }, visibility: 'uo')
     end
 
     def institution_restricted?(id)

--- a/app/controllers/oregon_digital/explore_collections_controller.rb
+++ b/app/controllers/oregon_digital/explore_collections_controller.rb
@@ -63,19 +63,23 @@ module OregonDigital
     end
 
     def osu_items(id)
-      Hyrax::SolrService.query("member_of_collection_ids_ssim:#{id} AND visibility_ssi:osu")
+      Hyrax::SolrService.query("member_of_collection_ids_ssim:#{id} AND visibility_ssi:osu").map do |hit|
+        SolrDocument.find(hit.id)
+      end
     end
 
     def uo_items(id)
-      Hyrax::SolrService.query("member_of_collection_ids_ssim:#{id} AND visibility_ssi:uo")
+      Hyrax::SolrService.query("member_of_collection_ids_ssim:#{id} AND visibility_ssi:uo").map do |hit|
+        SolrDocument.find(hit.id)
+      end
     end
 
     def osu_restricted?(id)
-      !osu_items(id).empty? && current_ability.cannot?(:show, ActiveFedora::Base.find(osu_items(id).first.id), visibility: 'osu')
+      !osu_items(id).empty? && current_ability.cannot?(:show, {:any => osu_items(id)}, visibility: 'osu')
     end
 
     def uo_restricted?(id)
-      !uo_items(id).empty? && current_ability.cannot?(:show, ActiveFedora::Base.find(uo_items(id).first.id), visibility: 'uo')
+      !uo_items(id).empty? && current_ability.cannot?(:show, {:any => uo_items(id)}, visibility: 'uo')
     end
 
     def institution_restricted?(id)

--- a/app/controllers/oregon_digital/explore_collections_controller.rb
+++ b/app/controllers/oregon_digital/explore_collections_controller.rb
@@ -71,11 +71,11 @@ module OregonDigital
     end
 
     def osu_restricted?(id)
-      !osu_items(id).empty? && current_ability.cannot?(:show, osu_items(id), visibility: 'osu')
+      !osu_items(id).empty? && current_ability.cannot?(:show, ActiveFedora::Base.find(osu_items(id).first.id), visibility: 'osu')
     end
 
     def uo_restricted?(id)
-      !uo_items(id).empty? && current_ability.cannot?(:show, uo_items(id), visibility: 'uo')
+      !uo_items(id).empty? && current_ability.cannot?(:show, ActiveFedora::Base.find(uo_items(id).first.id), visibility: 'uo')
     end
 
     def institution_restricted?(id)

--- a/app/models/concerns/oregon_digital/ability/work_show_ability.rb
+++ b/app/models/concerns/oregon_digital/ability/work_show_ability.rb
@@ -16,8 +16,8 @@ module OregonDigital
           end
 
           cannot(%i[show], FileSet) unless current_user.role?(manager_permission_roles)
-          cannot(%i[show], ActiveFedora::Base, visibility: 'osu') unless current_user.role?(osu_roles)
-          cannot(%i[show], ActiveFedora::Base, visibility: 'uo') unless current_user.role?(uo_roles)
+          cannot(%i[show], SolrDocument, visibility: 'osu') unless current_user.role?(osu_roles)
+          cannot(%i[show], SolrDocument, visibility: 'uo') unless current_user.role?(uo_roles)
         end
 
         def show_record?(record)

--- a/app/views/oregon_digital/explore_collections/_index_table.html.erb
+++ b/app/views/oregon_digital/explore_collections/_index_table.html.erb
@@ -2,6 +2,9 @@
 <tr class="my-collections-row">
   <th scope="row" class="col-lg-6 col-md-5">
     <b><%= link_to(document.title_or_label, url_for_document(document), document_link_params(document, :counter => document_counter_with_offset(document_counter))) %></b>
+    <% if controller.institution_restricted?(document.id) == true %>
+      <span class="glyphicon glyphicon-lock"></span>
+    <% end %>
   </th>
   <% if controller.tab != controller.class::TABS[:my] %>
   <td>


### PR DESCRIPTION
Fixes #1487 

This changes the code to grab an active fedora item and do the ability check on that. If we don't do this, then what is returned is a `SolrHit` which is something we are not doing checks for. It gets transformed into an AF::Base object and then checked for compatibility.

<img width="1709" alt="Screen Shot 2021-11-15 at 2 53 12 PM" src="https://user-images.githubusercontent.com/6424683/141866205-4d3f9bd8-c81f-4730-a220-f966f494fc07.png">
<img width="1680" alt="Screen Shot 2021-11-15 at 2 55 05 PM" src="https://user-images.githubusercontent.com/6424683/141866207-7169875c-7a42-439e-8ec1-e7c74f4219fc.png">
<img width="1822" alt="Screen Shot 2021-11-15 at 2 55 47 PM" src="https://user-images.githubusercontent.com/6424683/141866209-7088b343-bfab-4252-929a-a16533ae27e9.png">
<img width="1816" alt="Screen Shot 2021-11-15 at 2 56 16 PM" src="https://user-images.githubusercontent.com/6424683/141866210-99a2c74a-b7a0-4295-a05f-9b764fad6e1a.png">
