### PR TITLE
Allow controllers and presenters to control the page title

### DIFF
--- a/app/controllers/oregon_digital/explore_collections_controller.rb
+++ b/app/controllers/oregon_digital/explore_collections_controller.rb
@@ -17,6 +17,10 @@ module OregonDigital
       super + ['catalog']
     end
 
+    def page_title
+      "#{@tab.titleize} - Explore Collections"
+    end
+
     configure_blacklight do |config|
       config.view.gallery.if = false
       config.view.list.if = false

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -1,3 +1,5 @@
+<% provide :page_title, construct_page_title(controller.page_title) if controller.respond_to? :page_title %>
+<% provide :page_title, construct_page_title(@presenter.page_title) if @presenter.respond_to? :page_title %>
 <!-- OVERRIDDEN FROM HYRAX TO ALLOW OUR FILES TO HOOK INTO THE MASTHEAD AND USER UTIL LINKS -->
 <!DOCTYPE html>
 <html lang="<%= I18n.locale.to_s %>" prefix="og:http://ogp.me/ns#">


### PR DESCRIPTION
Fixes #1896 
This allows controllers and presenters to set the page title with the method `#page_title` as seen in the explore collections controller