### PR TITLE
Use autocomplete attribute on contact forms

### DIFF
--- a/app/views/hyrax/base/_work_contact_form.html.erb
+++ b/app/views/hyrax/base/_work_contact_form.html.erb
@@ -23,12 +23,12 @@
 
   <div class="form-group">
     <%= f.label :name, t('hyrax.contact_form.name_label'), class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>
+    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', autocomplete: 'given-name', required: true %></div>
   </div>
 
   <div class="form-group">
     <%= f.label :email, t('hyrax.contact_form.email_label'), class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', required: true %></div>
+    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', autocomplete: 'home email', required: true %></div>
   </div>
 
   <div class="form-group">

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -28,12 +28,12 @@
 
   <div class="form-group">
     <%= f.label :name, t('hyrax.contact_form.name_label'), class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>
+    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', autocomplete: 'given-name', required: true %></div>
   </div>
 
   <div class="form-group">
     <%= f.label :email, t('hyrax.contact_form.email_label'), class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', required: true %></div>
+    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', autocomplete: 'home email', required: true %></div>
   </div>
 
   <div class="form-group">


### PR DESCRIPTION
Fixes #2024 
Note: This only works on browsers that support the new HTML 5 values for `autocomplete`. At time of writing that is Chrome & Opera. This is not a breaking attribute for other browsers and they should implement this standard over time.
Because this is "new" it is not supported by Firefox or Safari yet.