### PR TITLE
Ticket #1908: Commit to set focus to search content

### DIFF
--- a/app/assets/javascripts/hyrax/search.js
+++ b/app/assets/javascripts/hyrax/search.js
@@ -69,3 +69,7 @@
 Blacklight.onLoad(function() {
   $('#search-form-header').search();
 });
+
+Blacklight.onLoad(function() {
+  location.hash = 'content'
+});

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -4,7 +4,7 @@
   <%= render_constraints(params) %>
 </div>
 <div class="widget-wrapper">
-  <div class="pull-right catalog-search">
+  <div id="catalog-search" tabindex="0" class="pull-right catalog-search">
     <%# OVERRIDE FROM BLACKLIGHT to remove start over link and replace with view type widget %>
     <% tool_config = Blacklight::Configuration::ToolConfig.new %>
     <% tool_config.name = :view_type_group %>
@@ -21,3 +21,7 @@
 </div>
 
 <div class="constraints-divider"></div>
+
+<script>
+  document.getElementById('catalog-search').focus()
+</script>

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -4,7 +4,7 @@
   <%= render_constraints(params) %>
 </div>
 <div class="widget-wrapper">
-  <div id="catalog-search" tabindex="0" class="pull-right catalog-search">
+  <div class="pull-right catalog-search">
     <%# OVERRIDE FROM BLACKLIGHT to remove start over link and replace with view type widget %>
     <% tool_config = Blacklight::Configuration::ToolConfig.new %>
     <% tool_config.name = :view_type_group %>
@@ -22,6 +22,3 @@
 
 <div class="constraints-divider"></div>
 
-<script>
-  document.getElementById('catalog-search').focus()
-</script>


### PR DESCRIPTION
(fixes #1908  )

@CGillen confirmed that the title issue had been previously fixed. 

I chose to automatically place the focus on the view type group because that seemed like the first piece of search content. Let me know if I need to place the focus on a different element or if you want the <script> in a separate file. 