### PR TITLE
Handle errors

### DIFF
--- a/app/workers/fetch_graph_worker.rb
+++ b/app/workers/fetch_graph_worker.rb
@@ -36,7 +36,7 @@ class FetchGraphWorker
             val.fetch(headers: { 'Accept' => default_accept_header })
             val.persist!
           end
-        rescue TriplestoreAdapter::TriplestoreException, IOError
+        rescue TriplestoreAdapter::TriplestoreException, IOError, OregonDigital::ControlledVocabularies::ControlledVocabularyFetchError
           fetch_failed_graph(pid, val, controlled_prop)
           next
         end

--- a/lib/oregon_digital/controlled_vocabularies/resource.rb
+++ b/lib/oregon_digital/controlled_vocabularies/resource.rb
@@ -104,5 +104,6 @@ module OregonDigital
       end
     end
     class ControlledVocabularyError < StandardError; end
+    class ControlledVocabularyFetchError < StandardError; end
   end
 end

--- a/lib/oregon_digital/controlled_vocabularies/scientific.rb
+++ b/lib/oregon_digital/controlled_vocabularies/scientific.rb
@@ -23,6 +23,8 @@ module OregonDigital
         else
           super
         end
+      rescue IOError
+        raise IOError
       end
     end
   end

--- a/lib/oregon_digital/controlled_vocabularies/scientific.rb
+++ b/lib/oregon_digital/controlled_vocabularies/scientific.rb
@@ -23,8 +23,8 @@ module OregonDigital
         else
           super
         end
-      rescue IOError
-        raise IOError
+      rescue ControlledVocabularyFetchError
+        raise ControlledVocabularyFetchError
       end
     end
   end

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/itis.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/itis.rb
@@ -21,7 +21,7 @@ module OregonDigital
         label = json_parse_service.json(vocabulary.as_query(subject.to_s))['scientificName']['combinedName']
         statement(subject, label)
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Net::ReadTimeout
-        raise IOError
+        raise ControlledVocabularyFetchError, 'connection failed'
       end
 
       def self.json_parse_service

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/itis.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/itis.rb
@@ -20,6 +20,8 @@ module OregonDigital
       def self.fetch(vocabulary, subject)
         label = json_parse_service.json(vocabulary.as_query(subject.to_s))['scientificName']['combinedName']
         statement(subject, label)
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Net::ReadTimeout
+        raise IOError
       end
 
       def self.json_parse_service

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/ubio.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/ubio.rb
@@ -20,7 +20,7 @@ module OregonDigital
         label = xml_parse_service.xml(vocabulary.as_query(subject.to_s)).at_xpath('/rdf:RDF/rdf:Description/dc:title/text()')
         statement(subject, label)
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Net::ReadTimeout
-        raise IOError
+        raise ControlledVocabularyFetchError, 'connection failed'
       end
 
       def self.xml_parse_service

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/ubio.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/ubio.rb
@@ -19,6 +19,8 @@ module OregonDigital
       def self.fetch(vocabulary, subject)
         label = xml_parse_service.xml(vocabulary.as_query(subject.to_s)).at_xpath('/rdf:RDF/rdf:Description/dc:title/text()')
         statement(subject, label)
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Net::ReadTimeout
+        raise IOError
       end
 
       def self.xml_parse_service

--- a/spec/oregon_digital/controlled_vocabularies/scientific_spec.rb
+++ b/spec/oregon_digital/controlled_vocabularies/scientific_spec.rb
@@ -23,4 +23,14 @@ RSpec.describe OregonDigital::ControlledVocabularies::Scientific do
       it { expect(vocab.query_to_vocabulary('http://my.queryuri.com')).to be nil }
     end
   end
+
+  describe '#fetch' do
+    context 'when ubio throws an error' do
+      before do
+        allow(OregonDigital::ControlledVocabularies::Vocabularies::Ubio).to receive(:fetch).and_raise(OregonDigital::ControlledVocabularies::ControlledVocabularyFetchError)
+      end
+
+      it { expect { new_vocab.fetch }.to raise_error OregonDigital::ControlledVocabularies::ControlledVocabularyFetchError }
+    end
+  end
 end


### PR DESCRIPTION
fixes #2128
fixes #2153
Automatically calling the FetchFailedGraphWorker when the connection fails for itis and ubio fetching could be a mess, but hopefully not once we're checking the triplestore before fetching.