### PR TITLE
[Ready] specify queues for graph/reindex sidekiq jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,9 @@ FROM code
 
 # Uninstall tools for compiling native code
 USER root
-RUN apk --no-cache update && apk del autoconf automake gcc g++ --purge
+RUN apk --no-cache update && apk del autoconf automake gcc g++ --purge && \
+  rm -f /data/docker-compose.override.yml-example /data/README.md \
+    /data/.env.example
 USER app
 
 ENV DEPLOYED_VERSION=${DEPLOYED_VERSION}

--- a/app/workers/fetch_failed_graph_worker.rb
+++ b/app/workers/fetch_failed_graph_worker.rb
@@ -4,6 +4,7 @@
 class FetchFailedGraphWorker
   include Sidekiq::Worker
   sidekiq_options retry: 11 # Around 2.5 days of retries
+  sidekiq_options queue: 'graph' # Use the 'graph' queue
 
   # JOBS TEND TOWARD BEING LARGE. DISABLED BECAUSE FETCHING IS HEAVY HANDED.
   # rubocop:disable Metrics/MethodLength

--- a/app/workers/fetch_failed_graph_worker.rb
+++ b/app/workers/fetch_failed_graph_worker.rb
@@ -4,7 +4,7 @@
 class FetchFailedGraphWorker
   include Sidekiq::Worker
   sidekiq_options retry: 11 # Around 2.5 days of retries
-  sidekiq_options queue: 'graph' # Use the 'graph' queue
+  sidekiq_options queue: 'fetch' # Use the 'fetch' queue
 
   # JOBS TEND TOWARD BEING LARGE. DISABLED BECAUSE FETCHING IS HEAVY HANDED.
   # rubocop:disable Metrics/MethodLength

--- a/app/workers/fetch_graph_worker.rb
+++ b/app/workers/fetch_graph_worker.rb
@@ -4,7 +4,7 @@
 class FetchGraphWorker
   include Sidekiq::Worker
   sidekiq_options retry: 11 # Around 2.5 days of retries
-  sidekiq_options queue: 'graph' # Use the 'graph' queue
+  sidekiq_options queue: 'fetch' # Use the 'fetch' queue
 
   # JOBS TEND TOWARD BEING LARGE. DISABLED BECAUSE FETCHING IS HEAVY HANDED.
   # rubocop:disable Metrics/MethodLength

--- a/app/workers/fetch_graph_worker.rb
+++ b/app/workers/fetch_graph_worker.rb
@@ -4,6 +4,7 @@
 class FetchGraphWorker
   include Sidekiq::Worker
   sidekiq_options retry: 11 # Around 2.5 days of retries
+  sidekiq_options queue: 'graph' # Use the 'graph' queue
 
   # JOBS TEND TOWARD BEING LARGE. DISABLED BECAUSE FETCHING IS HEAVY HANDED.
   # rubocop:disable Metrics/MethodLength

--- a/app/workers/reindex_worker.rb
+++ b/app/workers/reindex_worker.rb
@@ -5,6 +5,7 @@
 # failure to reindex doesn't stop the rest of the assets' reindex processes.
 class ReindexWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'reindex' # Use the 'reindex' queue
 
   # pids must be ordered with access control objects first, then the actual
   # asset, then its sub-objects (a.g., proxies, indirect containers, etc.)

--- a/build/entrypoint-tools.sh
+++ b/build/entrypoint-tools.sh
@@ -3,9 +3,14 @@
 echo "Starting tools container ${RAILS_ENV}"
 
 # Get setup to be able to do stuff
+echo "Installing gems..."
 ./build/install_gems.sh
 
+# Start init
+echo "Starting init"
+exec /sbin/init
+
 # Sleep forever, sweet container
-while `true`; do
-   sleep 600
-done
+#while `true`; do
+#   sleep 600
+#done

--- a/build/entrypoint-tools.sh
+++ b/build/entrypoint-tools.sh
@@ -9,8 +9,3 @@ echo "Installing gems..."
 # Start init
 echo "Starting init"
 exec /sbin/init
-
-# Sleep forever, sweet container
-#while `true`; do
-#   sleep 600
-#done

--- a/config/initializers/_hyrax.rb
+++ b/config/initializers/_hyrax.rb
@@ -199,7 +199,7 @@ Hyrax.config do |config|
   # config.fits_message_length = 5
 
   # ActiveJob queue to handle ingest-like jobs
-  # config.ingest_queue_name = :default
+  config.ingest_queue_name = :ingest
 
   ## Attributes for the lock manager which ensures a single process/thread is mutating a ore:Aggregation at once.
   # How many times to retry to acquire the lock before raising UnableToAcquireLockError

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -16,3 +16,11 @@ end
 Sidekiq.configure_client do |s|
   s.redis = redis_conn
 end
+
+# Override specific job queues
+CreateDerivativeJob.queue_as :ingest
+CreateWorkJob.queue_as :ingest
+AttachFilesToWorkJob.queue_as :ingest
+EventJob.queue_as :events
+CharacterizeJob.queue_as :ingest
+StreamNotificationsJob.queue_as :notify

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -18,9 +18,9 @@ Sidekiq.configure_client do |s|
 end
 
 # Override specific job queues
-CreateDerivativeJob.queue_as :ingest
-CreateWorkJob.queue_as :ingest
-AttachFilesToWorkJob.queue_as :ingest
-EventJob.queue_as :events
-CharacterizeJob.queue_as :ingest
-StreamNotificationsJob.queue_as :notify
+#CreateDerivativeJob.queue_as :ingest
+#CreateWorkJob.queue_as :ingest
+#AttachFilesToWorkJob.queue_as :ingest
+#EventJob.queue_as :events
+#CharacterizeJob.queue_as :ingest
+#StreamNotificationsJob.queue_as :notify

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -10,6 +10,7 @@ production:
 :queues:
   - notify
   - hyrax_migrator
+  - fetch
   - ingest
   - reindex
   - default

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,5 +8,7 @@ production:
   :concurrency: <%= ENV.fetch('SIDEKIQ_THREADS', 6) %>
   :max_retries: <%= ENV.fetch('SIDEKIQ_RETRY_LIMIT', 3) %>
 :queues:
-  - default
+  - notify
   - hyrax_migrator
+  - ingest
+  - default

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -11,4 +11,5 @@ production:
   - notify
   - hyrax_migrator
   - ingest
+  - reindex
   - default

--- a/lib/tasks/oregon_digital/reindex_all.rake
+++ b/lib/tasks/oregon_digital/reindex_all.rake
@@ -7,6 +7,7 @@ namespace :oregon_digital do
     base_url = ENV.fetch('REINDEX_ALL_FEDORA_URI', ActiveFedora.fedora.base_uri)
     debug = ENV.fetch('REINDEX_ALL_DEBUG', false) == '1'
     record = ENV.fetch('REINDEX_ALL_VCR', false) == '1'
+    sidekiq_options queue: 'reindex' # Use the 'reindex' queue
 
     puts 'Starting reindex...'
     puts '** DEBUG **' if debug


### PR DESCRIPTION
- Sets the ingest queue name config global that Hyrax uses for "ingest related" jobs to `:ingest`
- Sets graph jobs to `:graph`
- Sets reindex job to `:reindex`
- commented framework in config/initializers/sidekiq.rb for setting queue names for individual job types
- removed a few junk files from /data in the Dockerfile
- updates `build/entrypoint-tools.sh` script to exec `/sbin/init` instead of using a `while ... sleep` loop
- Add these queues to Sidekiq:
  - `:ingest`
  - `:reindex`
  - `:graph`
  - `:notify`