### PR TITLE
Move combined labels

### DIFF
--- a/app/indexers/oregon_digital/deep_indexing_service.rb
+++ b/app/indexers/oregon_digital/deep_indexing_service.rb
@@ -10,12 +10,33 @@ module OregonDigital
     self.stored_fields = %i[]
     self.symbol_fields = %i[]
 
+    protected
+
+    # override Hyrax/ActiveFedora add_assertions to insert combined labels
+    # rubocop:disable Metrics/MethodLength
+    def add_assertions(prefix_method, solr_doc = {})
+      fetch_external
+      fields.each do |field_key, field_info|
+        solr_field_key = solr_document_field_name(field_key, prefix_method)
+        field_info.values.each do |val|
+          append_to_solr_doc(solr_doc, solr_field_key, field_info, val)
+          combined_prop = combined_properties[field_key]
+          next if combined_prop.blank?
+
+          label = labelize(val)
+          append_combined_label(solr_doc, "#{combined_prop}_combined_label", field_info, label)
+        end
+      end
+      solr_doc
+    end
+
     private
 
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/AbcSize
-    # OVERRIDEN FROM HYRAX TO BYPASS THE FETCHING OF CONTROLLED VOCABULARIES
+    # block this until asset has reached a later stage in its workflow
+    # potentially remove block post migration
     def fetch_external
+      return if object.representative_id.nil?
+
       object.controlled_properties.each do |property|
         object[property].each do |value|
           resource = value.respond_to?(:resource) ? value.resource : value
@@ -23,12 +44,54 @@ module OregonDigital
 
           next if value.is_a?(ActiveFedora::Base)
 
-          # Fetch if the vocab is cached since this is fast and can be displayed quicker.
-          fetch_with_persistence(resource) if !resource.class.to_s.include?('Location') && resource.in_triplestore?
+          # assuming the FetchGraphWorker has run
+          # potentially redo using OregonDigital::Triplestore.fetch_cached_term
+          fetch_with_persistence(resource)
         end
       end
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/AbcSize
+
+    # override Hyrax fetch_value to get rid of misleading logging
+    def fetch_value(value)
+      value.fetch(headers: { 'Accept' => default_accept_header })
+    rescue IOError, SocketError => e
+      # IOError could result from a 500 error on the remote server
+      # SocketError results if there is no server to connect to
+      Rails.logger.error "Unable to fetch #{value.rdf_subject}.\n#{e.message}"
+    end
+
+    # modelled after Hyrax::DeepIndexingService methods
+    def append_combined_label(solr_doc, solr_field_key, field_info, val)
+      ActiveFedora::Indexing::Inserter.create_and_insert_terms(solr_field_key, val, field_info.behaviors, solr_doc)
+    end
+
+    # adapted from FetchGraphWorker
+    def labelize(val)
+      return val if val.first.is_a?(String)
+
+      val.solrize.last.is_a?(String) ? val.solrize.last : val.solrize.last[:label].split('$').first
+    end
+
+    def combined_properties
+      @combined_properties ||= combined_property_map
+    end
+
+    def combined_property_map
+      cpm = {}
+      %w[ranger_district water_basin location].each do |prop|
+        cpm[prop] = 'location'
+      end
+      %w[arranger artist author cartographer collector composer creator contributor dedicatee donor designer editor illustrator interviewee interviewer lyricist owner patron photographer print_maker recipient transcriber translator].each do |prop|
+        cpm[prop] = 'creator'
+      end
+      %w[keyword subject].each do |prop|
+        cpm[prop] = 'topic'
+      end
+      %w[taxon_class family genus order species phylum_or_division].each do |prop|
+        cpm[prop] = 'scientific'
+      end
+      cpm
+    end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/app/workers/fetch_failed_graph_worker.rb
+++ b/app/workers/fetch_failed_graph_worker.rb
@@ -6,35 +6,12 @@ class FetchFailedGraphWorker
   sidekiq_options retry: 11 # Around 2.5 days of retries
   sidekiq_options queue: 'fetch' # Use the 'fetch' queue
 
-  # JOBS TEND TOWARD BEING LARGE. DISABLED BECAUSE FETCHING IS HEAVY HANDED.
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
-  def perform(pid, val, controlled_prop)
-    # Fetch the solr_doc
-    solr_doc = SolrDocument.find(pid)
+  def perform(val)
+    return unless val.respond_to?(:fetch)
 
-    if val.respond_to?(:fetch)
-      val.fetch(headers: { 'Accept' => default_accept_header })
-      val.persist!
-    end
-
-    # Insert into SolrDocument
-    if val.is_a?(String)
-      solr_doc["#{controlled_prop}_label_tesim"] = val
-    else
-      extractred_val = val.solrize.last.is_a?(String) ? val.solrize.last : val.solrize.last[:label].split('$').first
-      if controlled_prop.to_sym == :based_near
-        solr_doc['location_label'] = [extractred_val]
-      else
-        solr_doc["#{controlled_prop}_label_tesim"] = [extractred_val]
-      end
-    end
-
-    Hyrax::SolrService.add(solr_doc)
-    Hyrax::SolrService.commit
+    val.fetch(headers: { 'Accept' => default_accept_header })
+    val.persist!
   end
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/AbcSize
 
   def default_accept_header
     RDF::Util::File::HttpAdapter.default_accept_header.sub(%r{, \*\/\*;q=0\.1\Z}, '')

--- a/app/workers/fetch_graph_worker.rb
+++ b/app/workers/fetch_graph_worker.rb
@@ -6,91 +6,34 @@ class FetchGraphWorker
   sidekiq_options retry: 11 # Around 2.5 days of retries
   sidekiq_options queue: 'fetch' # Use the 'fetch' queue
 
-  # JOBS TEND TOWARD BEING LARGE. DISABLED BECAUSE FETCHING IS HEAVY HANDED.
   # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
+  # user not needed any longer?
   def perform(pid, _user_key)
-    # Fetch Work and SolrDoc
     work = ActiveFedora::Base.find(pid)
-    solr_doc = SolrDocument.find(pid)
-    # TODO: ADD BACK IN WHEN SETTING UP EMAIL
-    # user = User.where(email: user_key).first
-
-    # Use 0 for version to tell Solr that the document just needs to exist to be updated
-    # Versions dont need to match and set defaults
-    solr_doc.response['response']['docs'].first['_version_'] = 0
-    solr_doc['_version_'] = 0
-    solr_doc['creator_combined_label_sim'] = []
-    solr_doc['location_combined_label_sim'] = []
-    solr_doc['topic_combined_label_sim'] = solr_doc['keyword_tesim'].to_a
-    solr_doc['scientific_combined_label_sim'] = []
-    # Iterate over Controller Props values
     work.controlled_properties.each do |controlled_prop|
-      # Set to empty array for cleanliness
-      solr_doc["#{controlled_prop}_label_sim"] = []
       work.attributes[controlled_prop.to_s].each do |val|
-        begin
-          # Fetch labels
-          if val.respond_to?(:fetch)
-            val.fetch(headers: { 'Accept' => default_accept_header })
-            val.persist!
-          end
-        rescue TriplestoreAdapter::TriplestoreException, IOError, OregonDigital::ControlledVocabularies::ControlledVocabularyFetchError
-          fetch_failed_graph(pid, val, controlled_prop)
-          next
-        end
+        next unless val.respond_to?(:fetch)
 
-        # Insert into SolrDocument
-        val = (val.solrize.last.is_a?(String) ? val.solrize.last : val.solrize.last[:label].split('$').first) unless val.first.is_a?(String)
-        solr_doc["#{controlled_prop}_label_sim"] << val
-        solr_doc['creator_combined_label_sim'] << val if creator_combined_facet?(controlled_prop)
-        solr_doc['location_combined_label_sim'] << val if location_combined_facet?(controlled_prop)
-        solr_doc['topic_combined_label_sim'] << val if topic_combined_facet?(controlled_prop)
-        solr_doc['scientific_combined_label_sim'] << val if scientific_combined_facet?(controlled_prop)
-
-        solr_doc["#{controlled_prop}_label_tesim"] = solr_doc["#{controlled_prop}_label_sim"]
-        solr_doc['creator_combined_label_tesim'] = solr_doc['creator_combined_label_sim']
-        solr_doc['location_combined_label_tesim'] = solr_doc['location_combined_label_sim']
-        solr_doc['topic_combined_label_tesim'] = solr_doc['topic_combined_label_sim']
-        solr_doc['scientific_combined_label_tesim'] = solr_doc['scientific_combined_label_sim']
-        Hyrax::SolrService.add(solr_doc)
-        Hyrax::SolrService.commit
+        val.fetch(headers: { 'Accept' => default_accept_header })
+        val.persist!
+      rescue TriplestoreAdapter::TriplestoreException, IOError, OregonDigital::ControlledVocabularies::ControlledVocabularyFetchError
+        fetch_failed_graph(val)
+        next
       end
     end
   end
   # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
   # TODO: WILL INTEGRATE THIS WHEN REDOING EMAILING FOR THESE JOBS
   # def fetch_failed_callback(user, val)
   #   Hyrax.config.callback.run(:ld_fetch_failure, user, val.rdf_subject.value)
   # end
 
-  def fetch_failed_graph(pid, val, controlled_prop)
-    FetchFailedGraphWorker.perform_async(pid, val, controlled_prop)
+  def fetch_failed_graph(val)
+    FetchFailedGraphWorker.perform_async(val)
   end
 
   def default_accept_header
     RDF::Util::File::HttpAdapter.default_accept_header.sub(%r{, \*\/\*;q=0\.1\Z}, '')
-  end
-
-  def location_combined_facet?(controlled_prop)
-    %i[ranger_district water_basin location].include? controlled_prop
-  end
-
-  def creator_combined_facet?(controlled_prop)
-    %i[arranger artist author cartographer collector composer creator contributor dedicatee donor designer editor illustrator interviewee interviewer lyricist owner patron photographer print_maker recipient transcriber translator].include? controlled_prop
-  end
-
-  def topic_combined_facet?(controlled_prop)
-    %i[keyword subject].include? controlled_prop
-  end
-
-  def scientific_combined_facet?(controlled_prop)
-    %i[taxon_class family genus order species phylum_or_division].include? controlled_prop
   end
 end

--- a/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
+++ b/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
@@ -49,7 +49,7 @@ RDFXML
       before do
         stub_request(:get, 'http://sws.geonames.org/5037650')
           .to_return(status: 500, body: '', headers: {})
-        stub_request(:get, 'http://ci-test:8080/bigdata/namespace/rw/sparql?GETSTMTS&includeInferred=false&s=%3Chttp://sws.geonames.org/5037650')
+        stub_request(:get, 'http://ci-test:8080/bigdata/namespace/rw/sparql?GETSTMTS&includeInferred=false&s=%3Chttp://sws.geonames.org/5037650%3E')
           .to_return(status: 500, body: '', headers: {})
       end
 

--- a/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
+++ b/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
@@ -26,6 +26,9 @@ RDFXML
         stub_request(:get, 'https://sws.geonames.org/5037649/')
           .to_return(status: 200, body: newberg,
                      headers: { 'Content-Type' => 'application/rdf+xml;charset=UTF-8' })
+        stub_request(:get, 'http://ci-test:8080/bigdata/namespace/rw/sparql?GETSTMTS&includeInferred=false&s=%3Chttps://sws.geonames.org/5037649/%3E')
+          .to_return(status: 200, body: newberg,
+                     headers: { 'Content-Type' => 'application/rdf+xml;charset=UTF-8' })
       end
 
       it 'adds both property label and combined label' do
@@ -46,7 +49,6 @@ RDFXML
       end
 
       it 'handles the error' do
-        expect { location.fetch }.to raise_error(IOError)
         solr_doc = service.send(:add_assertions, nil)
         expect(solr_doc['location_combined_label_sim']).to eq nil
       end

--- a/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
+++ b/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe OregonDigital::DeepIndexingService do
+  subject(:service) { described_class.new(work) }
+
+  let(:user) { build(:user) }
+  let(:file_set) { FactoryBot.create(:file_set, user: user, title: ['Shark'], content: file) }
+  let(:file) { File.open(fixture_path + '/test.jpg') }
+  let(:work) { create(:image, title: ['Sharks on a plane'], location: [location], depositor: user.email, id: 'abcde1234', ordered_members: [file_set], representative_id: file_set.id) }
+  let(:location) { Hyrax::ControlledVocabularies::Location.new('http://sws.geonames.org/5037649/') }
+
+  before do
+    newberg = <<RDFXML.strip_heredoc
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+          <rdf:RDF xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gn="http://www.geonames.org/ontology#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+          <gn:Feature rdf:about="http://sws.geonames.org/5037649/">
+          <rdfs:label>an RDFS Label</gn:name>
+          <gn:name>Newberg</gn:name>
+          </gn:Feature>
+          </rdf:RDF>
+RDFXML
+
+    stub_request(:get, 'http://sws.geonames.org/5037649/')
+      .to_return(status: 200, body: newberg,
+                 headers: { 'Content-Type' => 'application/rdf+xml;charset=UTF-8' })
+  end
+
+  describe '#add_assertions' do
+    it 'adds both property label and combined label' do
+      solr_doc = service.send(:add_assertions, nil)
+      expect(solr_doc['location_combined_label_sim']).to eq(['Newberg'])
+      expect(solr_doc['location_label_sim']).to eq(['Newberg'])
+    end
+  end
+end

--- a/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
+++ b/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
@@ -7,20 +7,20 @@ RSpec.describe OregonDigital::DeepIndexingService do
   let(:file_set) { FactoryBot.create(:file_set, user: user, title: ['Shark'], content: file) }
   let(:file) { File.open(fixture_path + '/test.jpg') }
   let(:work) { create(:image, title: ['Sharks on a plane'], location: [location], depositor: user.email, id: 'abcde1234', ordered_members: [file_set], representative_id: file_set.id) }
-  let(:location) { Hyrax::ControlledVocabularies::Location.new('http://sws.geonames.org/5037649/') }
+  let(:location) { Hyrax::ControlledVocabularies::Location.new('https://sws.geonames.org/5037649/') }
 
   before do
     newberg = <<RDFXML.strip_heredoc
       <?xml version="1.0" encoding="UTF-8" standalone="no"?>
           <rdf:RDF xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gn="http://www.geonames.org/ontology#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
-          <gn:Feature rdf:about="http://sws.geonames.org/5037649/">
-          <rdfs:label>an RDFS Label</gn:name>
+          <gn:Feature rdf:about="https://sws.geonames.org/5037649/">
+          <rdfs:label>an RDFS Label</rdfs:label>
           <gn:name>Newberg</gn:name>
           </gn:Feature>
           </rdf:RDF>
 RDFXML
 
-    stub_request(:get, 'http://sws.geonames.org/5037649/')
+    stub_request(:get, 'https://sws.geonames.org/5037649/')
       .to_return(status: 200, body: newberg,
                  headers: { 'Content-Type' => 'application/rdf+xml;charset=UTF-8' })
   end
@@ -30,6 +30,22 @@ RDFXML
       solr_doc = service.send(:add_assertions, nil)
       expect(solr_doc['location_combined_label_sim']).to eq(['Newberg'])
       expect(solr_doc['location_label_sim']).to eq(['Newberg'])
+    end
+
+    context 'when a fetch fails' do
+      let(:location) { Hyrax::ControlledVocabularies::Location.new('http://sws.geonames.org/5037650') }
+
+      before do
+        stub_request(:get, 'http://sws.geonames.org/5037650')
+          .to_return(status: 500, body: '', headers: {})
+        stub_request(:get, 'http://ci-test:8080/bigdata/namespace/rw/sparql?GETSTMTS&includeInferred=false&s=%3Chttp://sws.geonames.org/5037650').to_return(status: 500, body: '', headers: {})
+      end
+
+      it 'handles the error' do
+        expect { location.fetch }.to raise_error(IOError)
+        solr_doc = service.send(:add_assertions, nil)
+        expect(solr_doc['location_combined_label_sim']).to eq nil
+      end
     end
   end
 end

--- a/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
+++ b/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
@@ -4,13 +4,20 @@ RSpec.describe OregonDigital::DeepIndexingService do
   subject(:service) { described_class.new(work) }
 
   let(:user) { build(:user) }
-  let(:file_set) { FactoryBot.create(:file_set, user: user, title: ['Shark'], content: file) }
   let(:file) { File.open(fixture_path + '/test.jpg') }
   let(:work) { create(:image, title: ['Sharks on a plane'], location: [location], depositor: user.email, id: 'abcde1234', ordered_members: [file_set], representative_id: file_set.id) }
+  let(:file_set) { create(:file_set, user: user, title: ['Shark'], content: file) }
 
   describe '#add_assertions' do
     context 'when there is a label to fetch' do
       let(:location) { Hyrax::ControlledVocabularies::Location.new('https://sws.geonames.org/5037649/') }
+      let(:geo_subject) { RDF::URI('https://sws.geonames.org/5037649/') }
+      let(:graph) do
+        g = RDF::Graph.new
+        g << RDF::Statement.new(geo_subject, RDF::URI('http://www.geonames.org/ontology#name'), 'Newberg')
+        g << RDF::Statement.new(geo_subject, RDF::URI('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), RDF::URI('http://www.geonames.org/ontology#Feature'))
+        g
+      end
 
       before do
         newberg = <<RDFXML.strip_heredoc
@@ -26,9 +33,7 @@ RDFXML
         stub_request(:get, 'https://sws.geonames.org/5037649/')
           .to_return(status: 200, body: newberg,
                      headers: { 'Content-Type' => 'application/rdf+xml;charset=UTF-8' })
-        stub_request(:get, 'http://ci-test:8080/bigdata/namespace/rw/sparql?GETSTMTS&includeInferred=false&s=%3Chttps://sws.geonames.org/5037649/%3E')
-          .to_return(status: 200, body: newberg,
-                     headers: { 'Content-Type' => 'application/rdf+xml;charset=UTF-8' })
+        allow(OregonDigital::Triplestore).to receive(:fetch_cached_term).and_return(graph)
       end
 
       it 'adds both property label and combined label' do

--- a/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
+++ b/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
@@ -7,11 +7,14 @@ RSpec.describe OregonDigital::DeepIndexingService do
   let(:file_set) { FactoryBot.create(:file_set, user: user, title: ['Shark'], content: file) }
   let(:file) { File.open(fixture_path + '/test.jpg') }
   let(:work) { create(:image, title: ['Sharks on a plane'], location: [location], depositor: user.email, id: 'abcde1234', ordered_members: [file_set], representative_id: file_set.id) }
-  let(:location) { Hyrax::ControlledVocabularies::Location.new('https://sws.geonames.org/5037649/') }
 
-  before do
-    newberg = <<RDFXML.strip_heredoc
-      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+  describe '#add_assertions' do
+    context 'when there is a label to fetch' do
+      let(:location) { Hyrax::ControlledVocabularies::Location.new('https://sws.geonames.org/5037649/') }
+
+      before do
+        newberg = <<RDFXML.strip_heredoc
+          <?xml version="1.0" encoding="UTF-8" standalone="no"?>
           <rdf:RDF xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gn="http://www.geonames.org/ontology#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
           <gn:Feature rdf:about="https://sws.geonames.org/5037649/">
           <rdfs:label>an RDFS Label</rdfs:label>
@@ -20,16 +23,16 @@ RSpec.describe OregonDigital::DeepIndexingService do
           </rdf:RDF>
 RDFXML
 
-    stub_request(:get, 'https://sws.geonames.org/5037649/')
-      .to_return(status: 200, body: newberg,
-                 headers: { 'Content-Type' => 'application/rdf+xml;charset=UTF-8' })
-  end
+        stub_request(:get, 'https://sws.geonames.org/5037649/')
+          .to_return(status: 200, body: newberg,
+                     headers: { 'Content-Type' => 'application/rdf+xml;charset=UTF-8' })
+      end
 
-  describe '#add_assertions' do
-    it 'adds both property label and combined label' do
-      solr_doc = service.send(:add_assertions, nil)
-      expect(solr_doc['location_combined_label_sim']).to eq(['Newberg'])
-      expect(solr_doc['location_label_sim']).to eq(['Newberg'])
+      it 'adds both property label and combined label' do
+        solr_doc = service.send(:add_assertions, nil)
+        expect(solr_doc['location_combined_label_sim']).to eq(['Newberg'])
+        expect(solr_doc['location_label_sim']).to eq(['Newberg'])
+      end
     end
 
     context 'when a fetch fails' do
@@ -38,7 +41,8 @@ RDFXML
       before do
         stub_request(:get, 'http://sws.geonames.org/5037650')
           .to_return(status: 500, body: '', headers: {})
-        stub_request(:get, 'http://ci-test:8080/bigdata/namespace/rw/sparql?GETSTMTS&includeInferred=false&s=%3Chttp://sws.geonames.org/5037650').to_return(status: 500, body: '', headers: {})
+        stub_request(:get, 'http://ci-test:8080/bigdata/namespace/rw/sparql?GETSTMTS&includeInferred=false&s=%3Chttp://sws.geonames.org/5037650')
+          .to_return(status: 500, body: '', headers: {})
       end
 
       it 'handles the error' do

--- a/spec/workers/fetch_failed_graph_worker_spec.rb
+++ b/spec/workers/fetch_failed_graph_worker_spec.rb
@@ -8,36 +8,31 @@ RSpec.describe FetchFailedGraphWorker, type: :worker do
   let(:model) { create(:generic, title: ['foo'], creator: [controlled_val], depositor: user.email, id: 123) }
   let(:controlled_val) { OregonDigital::ControlledVocabularies::Creator.new('http://opaquenamespace.org/ns/creator/ChabreWayne') }
   let(:work) { model }
-  let(:controlled_prop) { :creator }
   let(:headers) { { headers: { 'Accept' => 'application/n-triples, text/plain;q=0.2, application/ld+json, application/x-ld+json, application/rdf+xml, text/turtle, text/rdf+turtle, application/turtle;q=0.2, application/x-turtle;q=0.2, text/html;q=0.5, application/xhtml+xml;q=0.7, image/svg+xml;q=0.4, application/n-quads, text/x-nquads;q=0.2, application/rdf+json, text/n3, text/rdf+n3;q=0.2, application/rdf+n3;q=0.2, application/normalized+n-quads, application/x-normalized+n-quads, text/csv;q=0.4, text/tab-separated-values;q=0.4, application/csvm+json, application/trig, application/x-trig;q=0.2, application/trix' } } }
 
   describe '#perform' do
     context 'when the request works' do
       before do
-        allow(controlled_val).to receive(:fetch).with(headers).and_return({})
-        allow(controlled_val).to receive(:solrize).and_return(['http://opaquenamespace.org/ns/creator/ChabreWayne', { label: 'Chabre, Wayne$http://opaquenamespace.org/ns/creator/ChabreWayne' }])
         stub_request(:get, 'http://ci-test:8080/bigdata/namespace/rw/sparql?GETSTMTS&includeInferred=false&s=%3Chttp://opaquenamespace.org/ns/creator/ChabreWayne%3E').with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Host' => 'ci-test:8080', 'Keep-Alive' => '30', 'User-Agent' => 'Ruby' }).to_return(status: 200, body: '', headers: {})
         stub_request(:get, 'http://opaquenamespace.org/ns/creator/ChabreWayne').to_return(status: 200, body: '', headers: {})
         stub_request(:get, 'https://opaquenamespace.org/ns/creator/ChabreWayne').to_return(status: 200, body: '', headers: {})
       end
 
-      it 'fetches a work and indexes its linked data labels' do
-        worker.perform(work.id, controlled_val, controlled_prop)
-        expect(SolrDocument.find(work.id)['creator_label_tesim'].first).to eq 'Chabre, Wayne'
+      it 'fetches a work' do
+        expect(OregonDigital::Triplestore).to receive(:fetch).once
+        worker.perform(controlled_val)
       end
     end
 
     context 'when the request fails' do
       before do
-        allow(controlled_val).to receive(:fetch).with(headers).and_raise(TriplestoreAdapter::TriplestoreException)
-        allow(controlled_val).to receive(:solrize).and_return(['http://opaquenamespace.org/ns/creator/ChabreWayne', { label: 'Chabre, Wayne$http://opaquenamespace.org/ns/creator/ChabreWayne' }])
         stub_request(:get, 'http://ci-test:8080/bigdata/namespace/rw/sparql?GETSTMTS&includeInferred=false&s=%3Chttp://opaquenamespace.org/ns/creator/ChabreWayne%3E').with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Host' => 'ci-test:8080', 'Keep-Alive' => '30', 'User-Agent' => 'Ruby' }).to_return(status: 500, body: '', headers: {})
-        stub_request(:get, 'http://opaquenamespace.org/ns/creator/ChabreWayne').to_return(status: 200, body: '', headers: {})
-        stub_request(:get, 'https://opaquenamespace.org/ns/creator/ChabreWayne').to_return(status: 200, body: '', headers: {})
+        stub_request(:get, 'http://opaquenamespace.org/ns/creator/ChabreWayne').to_return(status: 500, body: '', headers: {})
+        stub_request(:get, 'https://opaquenamespace.org/ns/creator/ChabreWayne').to_return(status: 500, body: '', headers: {})
       end
 
       it 'raises an exception' do
-        expect { worker.perform(work.id, controlled_val, controlled_prop) }.to raise_error TriplestoreAdapter::TriplestoreException
+        expect { worker.perform(controlled_val) }.to raise_error TriplestoreAdapter::TriplestoreException
       end
     end
   end

--- a/spec/workers/fetch_graph_worker_spec.rb
+++ b/spec/workers/fetch_graph_worker_spec.rb
@@ -12,17 +12,6 @@ RSpec.describe FetchGraphWorker, type: :worker do
   let(:scientific_controlled_val) { OregonDigital::ControlledVocabularies::Scientific.new('http://opaquenamespace.org/ns/genus/Acnanthes') }
   let(:work) { model }
 
-  before do
-    allow(creator_controlled_val).to receive(:fetch).with(:anything).and_return({})
-    allow(subject_controlled_val).to receive(:fetch).with(:anything).and_return({})
-    allow(location_controlled_val).to receive(:fetch).with(:anything).and_return({})
-    allow(scientific_controlled_val).to receive(:fetch).with(:anything).and_return({})
-    allow_any_instance_of(OregonDigital::ControlledVocabularies::Creator).to receive(:solrize).and_return(['http://opaquenamespace.org/ns/creator/ChabreWayne', { label: 'Chabre, Wayne$http://opaquenamespace.org/ns/creator/ChabreWayne' }])
-    allow_any_instance_of(OregonDigital::ControlledVocabularies::Subject).to receive(:solrize).and_return(['http://opaquenamespace.org/ns/creator/ChabreWayne', { label: 'Chabre, Wayne$http://opaquenamespace.org/ns/creator/ChabreWayne' }])
-    allow_any_instance_of(Hyrax::ControlledVocabularies::Location).to receive(:solrize).and_return(['http://opaquenamespace.org/ns/creator/ChabreWayne', { label: 'Chabre, Wayne$http://opaquenamespace.org/ns/creator/ChabreWayne' }])
-    allow_any_instance_of(OregonDigital::ControlledVocabularies::Scientific).to receive(:solrize).and_return(['http://opaquenamespace.org/ns/genus/Acnanthes', { label: 'Acnanthes$http://opaquenamespace.org/ns/genus/Acnanthes' }])
-  end
-
   describe '#perform' do
     context 'when the request works' do
       before do
@@ -34,34 +23,10 @@ RSpec.describe FetchGraphWorker, type: :worker do
         stub_request(:get, 'http://opaquenamespace.org/ns/genus/Acnanthes').to_return(status: 200, body: '', headers: {})
       end
 
-      it 'fetches a work and indexes its linked data labels' do
+      it 'fetches all of its linked data labels' do
+        expect(OregonDigital::Triplestore).to receive(:fetch).exactly(3).times
+        expect(OregonDigital::Triplestore).to receive(:fetch_cached_term).once
         worker.perform(work.id, work.depositor)
-        expect(SolrDocument.find(work.id)['creator_label_tesim'].first).to eq 'Chabre, Wayne'
-      end
-
-      it 'indexes creator data into the creator_combined_label field' do
-        worker.perform(work.id, work.depositor)
-        expect(SolrDocument.find(work.id)['creator_combined_label_sim'].first).to eq 'Chabre, Wayne'
-      end
-
-      it 'indexes data into the location_combined_label field' do
-        worker.perform(work.id, work.depositor)
-        expect(SolrDocument.find(work.id)['location_combined_label_sim'].first).to eq 'Chabre, Wayne'
-      end
-
-      it 'indexes non-linked topic data into the creator_combined_label field' do
-        worker.perform(work.id, work.depositor)
-        expect(SolrDocument.find(work.id)['topic_combined_label_sim']).to include 'bar'
-      end
-
-      it 'indexes linked topic data into the topic_combined_label field' do
-        worker.perform(work.id, work.depositor)
-        expect(SolrDocument.find(work.id)['topic_combined_label_sim']).to include 'Chabre, Wayne'
-      end
-
-      it 'indexes data into the scientific_combined_label field' do
-        worker.perform(work.id, work.depositor)
-        expect(SolrDocument.find(work.id)['scientific_combined_label_sim'].first).to eq 'Acnanthes'
       end
     end
 


### PR DESCRIPTION
fixes #2287 
This branch includes the following:
1. moves the indexing of combined labels and location label from FetchGraphWorker and stashes it all in the DeepIndexingService
2. similarly, removes indexing from FetchFailedGraphWorker.
3. overrides add_assertions in DIS to index the combined labels and prevents unfetched labels from being indexed
4. overrides fetch_external to block it from running if the asset has not passed a certain point in the workflow; at the moment the test is object.representative_id, which is assigned when the AttachFilesJob runs. After that, all indexing jobs will also index the labels for controlled fields. Potentially we could delay it even further, but this seems like a fair compromise: the asset has finished its initial creation but we are not waiting for the derivative.
5. overrides fetch_value to stop it from logging (the triplestore does plenty of logging)
Side note:  At the moment, it doesn't look like the FGW runs early enough. For migration this shouldn't be a problem, but it would be good to rethink the trigger.