### PR TITLE
Revert :read permissions for work show

### DIFF
--- a/app/models/concerns/oregon_digital/ability/work_show_ability.rb
+++ b/app/models/concerns/oregon_digital/ability/work_show_ability.rb
@@ -17,11 +17,11 @@ module OregonDigital
             read_doc?(solr_doc)
           end
 
-          cannot(%i[show read], FileSet) unless current_user.role?(manager_permission_roles)
-          cannot(%i[show read], SolrDocument, visibility: 'osu') unless current_user.role?(osu_roles)
-          cannot(%i[show read], SolrDocument, visibility: 'uo') unless current_user.role?(uo_roles)
-          cannot(%i[show read], ActiveFedora::Base, visibility: 'uo') unless current_user.role?(uo_roles)
-          cannot(%i[show read], ActiveFedora::Base, visibility: 'osu') unless current_user.role?(osu_roles)
+          cannot(%i[show], FileSet) unless current_user.role?(manager_permission_roles)
+          cannot(%i[show], SolrDocument, visibility: 'osu') unless current_user.role?(osu_roles)
+          cannot(%i[show], SolrDocument, visibility: 'uo') unless current_user.role?(uo_roles)
+          cannot(%i[show], ActiveFedora::Base, visibility: 'uo') unless current_user.role?(uo_roles)
+          cannot(%i[show], ActiveFedora::Base, visibility: 'osu') unless current_user.role?(osu_roles)
         end
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
Revert `:read` permission for unauthed manifest generation
Fixes #1423 #1450 #1386 