### PR TITLE
Separate extracted and ocr text for searching

### DIFF
--- a/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
@@ -71,16 +71,23 @@ module OregonDigital
         # solr fields to be displayed in the index (search results) view
         #   The ordering of the field names is the order of the display
         config.add_index_field 'title_tesim', label: 'Title', itemprop: 'name', if: false, highlight: true
-        config.add_index_field 'description_tesim', itemprop: 'description', helper_method: :iconify_auto_link_with_highlight, truncate: { list: 20, masonry: 10 }, max_values: 1, highlight: true, if: lambda { |_context, _field_config, document|
+        config.add_index_field 'description_tesim', label: nil, itemprop: 'description', helper_method: :iconify_auto_link_with_highlight, truncate: { list: 20, masonry: 10 }, max_values: 1, highlight: true, if: lambda { |_context, _field_config, document|
           # Only display description if a highlight is hit
           !document.response.dig('highlighting', document.id, 'description_tesim').nil?
         }
-        config.add_index_field 'all_text_tsimv', itemprop: 'keyword', truncate: { list: 20, masonry: 10 }, max_values: 1, highlight: true, unless: lambda { |_context, _field_config, document|
+        config.add_index_field 'all_text_tsimv', label: nil, itemprop: 'keyword', truncate: { list: 20, masonry: 10 }, max_values: 1, highlight: true, unless: lambda { |_context, _field_config, document|
           # Don't display full text if description has a highlight hit
           !document.response.dig('highlighting', document.id, 'description_tesim').nil?
         }, if:  lambda { |_context, _field_config, document|
           # Only try to display full text if a highlight is hit
           !document.response.dig('highlighting', document.id, 'all_text_tsimv').nil?
+        }
+        config.add_index_field 'hocr_text_tsimv', label: nil, itemprop: 'keyword', truncate: { list: 20, masonry: 10 }, max_values: 1, highlight: true, unless: lambda { |_context, _field_config, document|
+          # Don't display hocr text if all text has a highlight hit
+          !document.response.dig('highlighting', document.id, 'all_text_tsimv').nil?
+        }, if:  lambda { |_context, _field_config, document|
+          # Only try to display hocr text if a highlight is hit
+          !document.response.dig('highlighting', document.id, 'hocr_text_tsimv').nil?
         }
         config.add_index_field 'date_tesim', itemprop: 'date'
         config.add_index_field 'rights_statement_label_sim', label: 'Rights Statement', link_to_search: 'rights_statement_label_sim', if: false
@@ -273,7 +280,7 @@ module OregonDigital
           all_names = search_fields.join(' ')
           title_name = 'title_tesim'
           field.solr_parameters = {
-            qf: "#{all_names} #{title_name} license_label_tesim file_format_sim all_text_tsimv",
+            qf: "#{all_names} #{title_name} license_label_tesim file_format_sim all_text_tsimv hocr_text_tsimv",
             pf: title_name.to_s
           }
           field.include_in_advanced_search = true

--- a/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
@@ -83,8 +83,9 @@ module OregonDigital
           !document.response.dig('highlighting', document.id, 'all_text_tsimv').nil?
         }
         config.add_index_field 'hocr_text_tsimv', label: nil, itemprop: 'keyword', truncate: { list: 20, masonry: 10 }, max_values: 1, highlight: true, unless: lambda { |_context, _field_config, document|
-          # Don't display hocr text if all text has a highlight hit
-          !document.response.dig('highlighting', document.id, 'all_text_tsimv').nil?
+          # Don't display hocr text if all text or description has a highlight hit
+          !document.response.dig('highlighting', document.id, 'all_text_tsimv').nil? ||
+            !document.response.dig('highlighting', document.id, 'description_tesim').nil?
         }, if:  lambda { |_context, _field_config, document|
           # Only try to display hocr text if a highlight is hit
           !document.response.dig('highlighting', document.id, 'hocr_text_tsimv').nil?

--- a/app/indexers/generic_indexer.rb
+++ b/app/indexers/generic_indexer.rb
@@ -42,7 +42,7 @@ class GenericIndexer < Hyrax::WorkIndexer
   end
 
   def find_hocr_text(file_set, solr_doc)
-    file_set&.hocr_content&.presence || file_set.to_solr['hocr_text_tsimv'].presence || solr_doc['hocr_text_tsimv'].presence
+    file_set&.hocr_text&.presence || file_set.to_solr['hocr_text_tsimv'].presence || solr_doc['hocr_text_tsimv'].presence
   end
 
   def index_copyright_combined_label(solr_doc, license_labels, rights_labels)

--- a/app/indexers/generic_indexer.rb
+++ b/app/indexers/generic_indexer.rb
@@ -29,8 +29,9 @@ class GenericIndexer < Hyrax::WorkIndexer
       index_edit_groups
       index_read_groups
       index_discover_groups
-      solr_doc['all_text_tsimv'] = object.file_sets.map { |file_set| find_all_text_value(file_set, solr_doc) } # Index file formats from file sets for faceting
-      solr_doc['file_format_sim'] = object.file_sets.map { |file_set| file_set.to_solr['file_format_sim'] }
+      solr_doc['all_text_tsimv'] = object.file_sets.map { |file_set| find_all_text_value(file_set, solr_doc) }
+      solr_doc['hocr_text_tsimv'] = object.file_sets.map { |file_set| find_hocr_text(file_set, solr_doc) }
+      solr_doc['file_format_sim'] = object.file_sets.map { |file_set| file_set.to_solr['file_format_sim'] } # Index file formats from file sets for faceting
     end
   end
   # rubocop:enable Metrics/AbcSize
@@ -38,6 +39,10 @@ class GenericIndexer < Hyrax::WorkIndexer
 
   def find_all_text_value(file_set, solr_doc)
     file_set.extracted_text&.content&.presence || file_set&.ocr_content&.presence || solr_doc['all_text_tsimv'].presence
+  end
+
+  def find_hocr_text(file_set, solr_doc)
+    file_set&.hocr_content&.presence || file_set.to_solr['hocr_text_tsimv'].presence || solr_doc['hocr_text_tsimv'].presence
   end
 
   def index_copyright_combined_label(solr_doc, license_labels, rights_labels)

--- a/app/indexers/oregon_digital/file_set_indexer.rb
+++ b/app/indexers/oregon_digital/file_set_indexer.rb
@@ -19,7 +19,7 @@ module OregonDigital
     # rubocop:enable Metrics/AbcSize
 
     def find_all_text_value(solr_doc)
-      object.extracted_text&.content&.presence || object&.ocr_content&.presence || object&.hocr_content&.presence || solr_doc['all_text_tsimv'].presence
+      object.extracted_text&.content.presence || object&.ocr_content.presence || solr_doc['all_text_tsimv'].presence
     end
 
     def find_hocr_text(solr_doc)

--- a/app/indexers/oregon_digital/file_set_indexer.rb
+++ b/app/indexers/oregon_digital/file_set_indexer.rb
@@ -23,7 +23,7 @@ module OregonDigital
     end
 
     def find_hocr_text(solr_doc)
-      object&.hocr_content&.presence || solr_doc['hocr_text_tsimv'].presence
+      object&.hocr_text&.presence || solr_doc['hocr_text_tsimv'].presence
     end
 
     def index_additional_characterization_terms(solr_doc)

--- a/app/indexers/oregon_digital/file_set_indexer.rb
+++ b/app/indexers/oregon_digital/file_set_indexer.rb
@@ -9,6 +9,7 @@ module OregonDigital
         solr_doc['oembed_url_sim'] = object.oembed_url
         # Collapse possible extracted text with OCRd text for searching
         solr_doc['all_text_tsimv'] = find_all_text_value(solr_doc)
+        solr_doc['hocr_text_tsimv'] = find_hocr_text(solr_doc)
         # Set bounding box information for blacklight_iiif_search
         solr_doc['all_text_bbox_tsimv'] = object.bbox_content unless object.bbox_content.nil?
         solr_doc['hocr_content_tsimv'] = object.hocr_content unless object.hocr_content.nil?
@@ -18,7 +19,11 @@ module OregonDigital
     # rubocop:enable Metrics/AbcSize
 
     def find_all_text_value(solr_doc)
-      object.extracted_text&.content&.presence || object&.ocr_content&.presence || solr_doc['all_text_tsimv'].presence
+      object.extracted_text&.content&.presence || object&.ocr_content&.presence || object&.hocr_content&.presence || solr_doc['all_text_tsimv'].presence
+    end
+
+    def find_hocr_text(solr_doc)
+      object&.hocr_content&.presence || solr_doc['hocr_text_tsimv'].presence
     end
 
     def index_additional_characterization_terms(solr_doc)

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -8,7 +8,7 @@ class FileSet < ActiveFedora::Base
 
   include ::Hyrax::FileSetBehavior
   include OregonDigital::AccessControls::Visibility
-  attr_writer :ocr_content, :hocr_content, :bbox_content
+  attr_writer :ocr_content, :hocr_content, :hocr_text, :bbox_content
 
   self.indexer = OregonDigital::FileSetIndexer
 
@@ -43,6 +43,12 @@ class FileSet < ActiveFedora::Base
 
   def hocr_content
     @hocr_content ||= SolrDocument.find(id).to_h.dig('hocr_content_tsimv')
+  rescue Blacklight::Exceptions::RecordNotFound
+    nil
+  end
+
+  def hocr_text
+    @hocr_text ||= SolrDocument.find(id).to_h.dig('hocr_text_tsimv')
   rescue Blacklight::Exceptions::RecordNotFound
     nil
   end

--- a/app/services/oregon_digital/hocr_derivative_service.rb
+++ b/app/services/oregon_digital/hocr_derivative_service.rb
@@ -34,8 +34,12 @@ module OregonDigital
     def create_derivatives
       result = processor.run!
       @file_set.hocr_content ||= {}
+      @file_set.hocr_text    ||= []
       words = Nokogiri::HTML(result.hocr_content).css('.ocrx_word')
 
+      @file_set.hocr_text << words.map do |nokogiri_element|
+        nokogiri_element.text
+      end.join(' ')
       # Create a hash of words and their bounding boxes
       # hOCR is returned as an xml doc string for the current page
       # For each word on the page parse out the bbox position and downcased+stemmed word

--- a/app/services/oregon_digital/hocr_derivative_service.rb
+++ b/app/services/oregon_digital/hocr_derivative_service.rb
@@ -31,21 +31,20 @@ module OregonDigital
     # OCR text and push all words into a hash, which will be serialized later in OregonDigital::FileSetDerivativesService
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/CyclomaticComplexity
     def create_derivatives
       result = processor.run!
       @file_set.hocr_content ||= {}
       @file_set.hocr_text    ||= []
       words = Nokogiri::HTML(result.hocr_content).css('.ocrx_word')
 
-      @file_set.hocr_text << words.map do |nokogiri_element|
-        nokogiri_element.text
-      end.join(' ')
+      # hocr_text will be the plain text equivilant to all_text_tismv, to allow searching on ocr text
+      @file_set.hocr_text << words.map(&:text).join(' ')
       # Create a hash of words and their bounding boxes
       # hOCR is returned as an xml doc string for the current page
       # For each word on the page parse out the bbox position and downcased+stemmed word
-      word_count = words.count
       words.each_with_index do |nokogiri_element, word|
-        Rails.logger.debug("word #{word}/#{word_count}") if (word % 10).zero?
+        Rails.logger.debug("word #{word}/#{words.count}") if (word % 10).zero?
         coords = nokogiri_element.attributes['title'].value.split(';').find { |x| x.include?('bbox') }.gsub('bbox ', '').split(' ')
 
         @file_set.hocr_content[nokogiri_element.text.downcase.stem] ||= []
@@ -56,6 +55,7 @@ module OregonDigital
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     # No cleanup necessary - all this does is set a property on FileSet.
     def cleanup_derivatives; end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -311,6 +311,22 @@ en:
       explore_my: 'Explore Collections/My Collections'
   simple_form:
     hints:
+      collection:
+        title: Use for primary title or name of work. For works without a title, create a descriptive title consulting institutional standards.
+        creator: Use for an entity primarily responsible for making the resource. Use specific creator roles if applicable and known. URI required.
+        contributor: Use for an individual or entity responsible for making contributions to the resource. URI required.
+        description: Use for additional information about the item that does not belong in other fields.
+        subject: Use for controlled topical terms of the work. URI required. For uncontrolled terms use Keyword.
+        date: Use for a date associated with the work. Use specific date fields if applicable and known. EDTF required.
+        date_created: Use for date associated with the creation of the work. EDTF required.
+        license: Use for specific statements describing official permission to do something with the work. URI required.
+        repository: Use for the institutional organization or sub-unit that hosts the work. Use Copy Location to further specify physical location of original object.
+        language: Use for the language of a work. URI required.
+        publisher: Use for the entity responsible for making the work available. URI required.
+        has_finding_aid: Use for an external link to the finding aid for the collection this work belongs to.
+        related_url: Use for an external but related work linked with a URL.
+        resource_type: Use for high level type of the work, selecting from the DCMI Type vocabulary. URI required.
+        institution: Use for the name of the institution responsible for the work. URI required.
       collection_type:
         facet_configurable: Allow users to configure facet availability, order, and labels
     labels:

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -76,6 +76,7 @@ en:
           subject_label_sim: Subject
         index:
           all_text_tsimv: Full Text
+          hocr_text_tsimv: Full Text
           based_near_label_tesim: Location
           contributor_tesim: Contributor
           creator_tesim: Creator


### PR DESCRIPTION
Fixes #1450 

FileSets and Works have new solr `hocr_text_tsimv` and add that field to blacklight searching/search results (description, full text, hocr text hit highlighting)