### PR TITLE
Prevent zoom and paging controls from hiding in UV

### DIFF
--- a/config/uv/uv-config.json
+++ b/config/uv/uv-config.json
@@ -36,7 +36,8 @@
     },
     "openSeadragonCenterPanel": {
       "options": {
-        "autoHideControls": false
+        "autoHideControls": true,
+        "controlsFadeLength": -1
       }
     },
     "footerPanel": {


### PR DESCRIPTION
Fixes #1423 
`options.modules.openSeadragonCenterPanel.autoHideControls` doesn't seem to do anything. Adding a negative value to `controlsFadeLength` seems to disable hide though