### PR TITLE
Migrator update 9e07bb9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,6 @@
 GIT
   remote: https://github.com/OregonDigital/hyrax-migrator.git
-<<<<<<< Updated upstream
-  revision: 90ae9c5adf899b08725d8bb405a1ca77f6313dd1
-=======
   revision: 9e07bb9be333775e070abd8e3bca1c9dddb51562
->>>>>>> Stashed changes
   branch: master
   specs:
     hyrax-migrator (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,10 @@
 GIT
   remote: https://github.com/OregonDigital/hyrax-migrator.git
+<<<<<<< Updated upstream
   revision: 90ae9c5adf899b08725d8bb405a1ca77f6313dd1
+=======
+  revision: 9e07bb9be333775e070abd8e3bca1c9dddb51562
+>>>>>>> Stashed changes
   branch: master
   specs:
     hyrax-migrator (0.1.0)


### PR DESCRIPTION
fix rubocop inflicted wound to full_size_download_allowed method in the migrator crosswalk service
