### PR TITLE
let reindex_extent be settable

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -38,9 +38,17 @@ class Collection < ActiveFedora::Base
     end
   end
 
+  # Adapted from Hyrax::CollectionNesting
   def reindex_extent
-    OD2::Application.config.reindex_extent
+    @reindex_extent ||= OD2::Application.config.reindex_extent
   end
+
+  # Borrowed from Hyrax::CollectionNesting
+  # rubocop:disable Style/TrivialAccessors
+  def reindex_extent=(extent)
+    @reindex_extent = extent
+  end
+  # rubocop:enable Style/TrivialAccessors
 
   private
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -78,4 +78,21 @@ RSpec.describe Collection do
       expect(csv[0].to_h).to eq('depositor' => user.email, 'has_model' => 'Collection', 'title' => 'foo')
     end
   end
+
+  describe '#reindex_extent' do
+    it 'returns the config value' do
+      expect(OD2::Application.config.reindex_extent).to eq 'full'
+      expect(model.reindex_extent).to eq 'full'
+    end
+  end
+
+  describe '#reindex_extent=' do
+    before do
+      model.reindex_extent = 'limited'
+    end
+
+    it 'allows reindex_extent to be temporarily set' do
+      expect(model.reindex_extent).to eq 'limited'
+    end
+  end
 end


### PR DESCRIPTION
As an afterthought, copying Hyrax::CollectionNesting methods for reindex_extent, to allow reindex_extent to behave the way hyrax expects it to, ie settable, eg in the case where the config is set to 'full', a full reindex is not necessary, and the request is coming from the dashboard.
followup to #2387