### PR TITLE
Fix has_number predicate

### DIFF
--- a/app/models/concerns/oregon_digital/document_metadata.rb
+++ b/app/models/concerns/oregon_digital/document_metadata.rb
@@ -28,7 +28,7 @@ module OregonDigital
         index.as :stored_searchable
       end
 
-      property :has_number, predicate: RDF::URI.new('http://opaquenamespace.org/ns/folderNumber'), multiple: true, basic_searchable: false do |index|
+      property :has_number, predicate: RDF::URI('http://purl.org/net/nknouf/ns/bibtex#hasNumber'), multiple: true, basic_searchable: false do |index|
         index.as :stored_searchable, :facetable
       end
 


### PR DESCRIPTION
Restore earlier value, match the MAP
Fixes #2411 