### PR TITLE
Handle case where location may be in multiple counties

### DIFF
--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -30,18 +30,21 @@ module Hyrax
 
           @label = @label.first
           parent_hierarchy.each do |p|
-            parent_label = if p.first.us_county?
-              county_labels = p.map do |county|
-                county.rdf_label.first
-              end
-              county_labels.join('/') + ' County'.pluralize(county_labels.count)
-            else
-              p.first.rdf_label.first
-            end
-            @label = "#{@label} >> #{parent_label}"
+            @label = "#{@label} >> #{parent_label(p)}"
           end
         end
         Array(@label)
+      end
+
+      def parent_label(parent)
+        if parent.first.us_county?
+          county_labels = parent.map do |county|
+            county.rdf_label.first
+          end
+          county_labels.join('/') + ' County'.pluralize(county_labels.count)
+        else
+          parent.first.rdf_label.first
+        end
       end
 
       def fetch_from_cache(subject)
@@ -87,8 +90,6 @@ module Hyrax
         result
       end
 
-      private
-
       # Identify if this is a county in the USA
       def us_county?
         feature_code = featureCode.first
@@ -97,6 +98,8 @@ module Hyrax
         us_country_code = 'sws.geonames.org/6252001/'
         feature_code.respond_to?(:rdf_subject) && feature_code.rdf_subject.to_s.include?(sec_adm_level_code) && parent_country.respond_to?(:rdf_subject) && parent_country.rdf_subject.to_s.include?(us_country_code)
       end
+
+      private
 
       def no_county_label
         !@label.first.downcase.include?('county')

--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -16,9 +16,9 @@ module Hyrax
       property :featureCode, predicate: RDF::URI('http://www.geonames.org/ontology#featureCode')
 
       def solrize
-        fetch
         return [rdf_subject.to_s] if rdf_label.first.to_s.blank? || rdf_label_uri_same?
 
+        fetch
         [rdf_subject.to_s, { label: "#{rdf_label.first}$#{rdf_subject}" }]
       end
 

--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -16,6 +16,7 @@ module Hyrax
       property :featureCode, predicate: RDF::URI('http://www.geonames.org/ontology#featureCode')
 
       def solrize
+        fetch
         return [rdf_subject.to_s] if rdf_label.first.to_s.blank? || rdf_label_uri_same?
 
         [rdf_subject.to_s, { label: "#{rdf_label.first}$#{rdf_subject}" }]

--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -22,6 +22,8 @@ module Hyrax
       end
 
       # Overrides rdf_label to add location disambiguation when available.
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
       def rdf_label
         @label = super
         @label = Array("#{@label.first} County") if us_county? && no_county_label
@@ -42,6 +44,8 @@ module Hyrax
         end
         Array(@label)
       end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
 
       def fetch_from_cache(subject)
         OregonDigital::Triplestore.fetch_cached_term(subject)
@@ -80,9 +84,7 @@ module Hyrax
         return result if top_level_element?
 
         parent_hierarchy.each do |p|
-          p.each do |loc|
-            loc.persist!
-          end
+          p.each(&:persist!)
         end
 
         result

--- a/spec/hyrax/controlled_vocabularies/location_spec.rb
+++ b/spec/hyrax/controlled_vocabularies/location_spec.rb
@@ -53,6 +53,10 @@ RSpec.describe Hyrax::ControlledVocabularies::Location do
   end
 
   describe '#solrize' do
+    before do
+      allow_any_instance_of(described_class).to receive('fetch')
+    end
+
     context 'with a valid label and subject' do
       before do
         allow(location).to receive(:rdf_label).and_return(['RDF_Label'])

--- a/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
+++ b/spec/indexers/oregon_digital/deep_indexing_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe OregonDigital::DeepIndexingService do
       end
 
       before do
+        allow(location).to receive('solrize')
         newberg = <<RDFXML.strip_heredoc
           <?xml version="1.0" encoding="UTF-8" standalone="no"?>
           <rdf:RDF xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gn="http://www.geonames.org/ontology#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
@@ -51,6 +52,7 @@ RDFXML
           .to_return(status: 500, body: '', headers: {})
         stub_request(:get, 'http://ci-test:8080/bigdata/namespace/rw/sparql?GETSTMTS&includeInferred=false&s=%3Chttp://sws.geonames.org/5037650%3E')
           .to_return(status: 500, body: '', headers: {})
+        allow(location).to receive('fetch')
       end
 
       it 'handles the error' do

--- a/spec/workers/fetch_graph_worker_spec.rb
+++ b/spec/workers/fetch_graph_worker_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe FetchGraphWorker, type: :worker do
         stub_request(:get, 'http://opaquenamespace.org/ns/creator/ChabreWayne').to_return(status: 500, body: '', headers: {})
         stub_request(:get, 'https://opaquenamespace.org/ns/creator/ChabreWayne').to_return(status: 500, body: '', headers: {})
         stub_request(:get, 'http://opaquenamespace.org/ns/genus/Acnanthes').to_return(status: 500, body: '', headers: {})
+        allow(location_controlled_val).to receive('fetch')
       end
 
       it 'calls #fetch_failed_graph to fire off new job' do


### PR DESCRIPTION
Fixes #2452 
The issue with the label being wrong is an issue with the cache. This implements a fix for the case where a city may be in multiple counties:

`Salem >> Marion/Polk Counties >> Oregon >> United States`