### PR TITLE
comment out possible unnecessary perms

### DIFF
--- a/app/controllers/concerns/hyrax/dashboard_authorization.rb
+++ b/app/controllers/concerns/hyrax/dashboard_authorization.rb
@@ -14,10 +14,12 @@ module Hyrax
       render(file: File.join("public/#{response_code}.html"), status: response_code, layout: false) unless dashboard_allowed
     end
 
+    #rubocop:disable Metrics/CyclomaticComplexity
     def dashboard_allowed
       # current user has a managing role || current user has a workflow responsibility || if user is trying to create user_collection
       current_user&.role?(::Ability.manager_permission_roles) || current_user&.sipity_agent&.workflow_responsibilities&.count&.positive? || user_is_creating_collection?
     end
+    #rubocop:enable Metrics/CyclomaticComplexity
 
     def user_is_creating_collection?
       controller_name.to_s.include?('collections') && params[:collection_type_gid] == Hyrax::CollectionType.find_by(machine_id: :user_collection).gid

--- a/app/controllers/concerns/hyrax/dashboard_authorization.rb
+++ b/app/controllers/concerns/hyrax/dashboard_authorization.rb
@@ -20,7 +20,7 @@ module Hyrax
     end
 
     def user_is_creating_collection?
-      controller_name.to_s.include?("collections") && params[:action] == "create" && params[:collection_type_gid] == "gid://od2/Hyrax::CollectionType/1"
+      controller_name.to_s.include?("collections") && params[:action] == "create" && params[:collection_type_gid] == Hyrax::CollectionType.find_by(machine_id: :user_collection).gid
     end
   end
 end

--- a/app/controllers/concerns/hyrax/dashboard_authorization.rb
+++ b/app/controllers/concerns/hyrax/dashboard_authorization.rb
@@ -20,7 +20,7 @@ module Hyrax
     end
 
     def user_is_creating_collection?
-      controller_name.to_s.include?("collections") && params[:action] == "create" && params[:collection_type_gid] == Hyrax::CollectionType.find_by(machine_id: :user_collection).gid
+      controller_name.to_s.include?('collections') && params[:collection_type_gid] == Hyrax::CollectionType.find_by(machine_id: :user_collection).gid
     end
   end
 end

--- a/app/controllers/concerns/hyrax/dashboard_authorization.rb
+++ b/app/controllers/concerns/hyrax/dashboard_authorization.rb
@@ -14,12 +14,12 @@ module Hyrax
       render(file: File.join("public/#{response_code}.html"), status: response_code, layout: false) unless dashboard_allowed
     end
 
-    #rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/CyclomaticComplexity
     def dashboard_allowed
       # current user has a managing role || current user has a workflow responsibility || if user is trying to create user_collection
       current_user&.role?(::Ability.manager_permission_roles) || current_user&.sipity_agent&.workflow_responsibilities&.count&.positive? || user_is_creating_collection?
     end
-    #rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def user_is_creating_collection?
       controller_name.to_s.include?('collections') && params[:collection_type_gid] == Hyrax::CollectionType.find_by(machine_id: :user_collection).gid

--- a/app/controllers/concerns/hyrax/dashboard_authorization.rb
+++ b/app/controllers/concerns/hyrax/dashboard_authorization.rb
@@ -15,8 +15,12 @@ module Hyrax
     end
 
     def dashboard_allowed
-      # current user has a managing role || current user has a workflow responsibility
-      current_user&.role?(::Ability.manager_permission_roles) || current_user&.sipity_agent&.workflow_responsibilities&.count&.positive?
+      # current user has a managing role || current user has a workflow responsibility || if user is trying to create user_collection
+      current_user&.role?(::Ability.manager_permission_roles) || current_user&.sipity_agent&.workflow_responsibilities&.count&.positive? || user_is_creating_collection?
+    end
+
+    def user_is_creating_collection?
+      controller_name.to_s.include?("collections") && params[:action] == "create" && params[:collection_type_gid] == "gid://od2/Hyrax::CollectionType/1"
     end
   end
 end

--- a/config/initializers/hacks/hyrax_dashboard_authorization.rb
+++ b/config/initializers/hacks/hyrax_dashboard_authorization.rb
@@ -9,12 +9,12 @@ Rails.application.config.to_prepare do
   Hyrax::DashboardController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::TransfersController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::Dashboard::WorksController.class_eval { include Hyrax::DashboardAuthorization }
-  Hyrax::Dashboard::CollectionsController.class_eval { include Hyrax::DashboardAuthorization }
+  # Hyrax::Dashboard::CollectionsController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::Dashboard::CollectionMembersController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::Dashboard::NestCollectionsController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::Dashboard::ProfilesController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::My::WorksController.class_eval { include Hyrax::DashboardAuthorization }
-  Hyrax::My::CollectionsController.class_eval { include Hyrax::DashboardAuthorization }
+  #Hyrax::My::CollectionsController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::My::HighlightsController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::My::SharesController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::Admin::PermissionTemplatesController.class_eval { include Hyrax::DashboardAuthorization }

--- a/config/initializers/hacks/hyrax_dashboard_authorization.rb
+++ b/config/initializers/hacks/hyrax_dashboard_authorization.rb
@@ -9,12 +9,12 @@ Rails.application.config.to_prepare do
   Hyrax::DashboardController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::TransfersController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::Dashboard::WorksController.class_eval { include Hyrax::DashboardAuthorization }
-  # Hyrax::Dashboard::CollectionsController.class_eval { include Hyrax::DashboardAuthorization }
+  Hyrax::Dashboard::CollectionsController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::Dashboard::CollectionMembersController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::Dashboard::NestCollectionsController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::Dashboard::ProfilesController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::My::WorksController.class_eval { include Hyrax::DashboardAuthorization }
-  #Hyrax::My::CollectionsController.class_eval { include Hyrax::DashboardAuthorization }
+  Hyrax::My::CollectionsController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::My::HighlightsController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::My::SharesController.class_eval { include Hyrax::DashboardAuthorization }
   Hyrax::Admin::PermissionTemplatesController.class_eval { include Hyrax::DashboardAuthorization }


### PR DESCRIPTION
@CGillen Wanna check this out? This is the fix i found for the logged in users not being able to generate collections. The controllers were blocking the access through rails stuff and bypassing our cancan permissions. The other idea would be to figure out how to refine the DashboardAuthorization to be able to check if they are trying to create a collection or create a new authorization. Im not sure we need it though.

Thoughts?