### PR TITLE
Force InheritPermissionsJob to run before visibility copy and propagation

### DIFF
--- a/config/initializers/hacks/hyrax_permission_controller_hack.rb
+++ b/config/initializers/hacks/hyrax_permission_controller_hack.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  Hyrax::PermissionsController.class_eval do
+    def copy_access
+      authorize! :edit, curation_concern
+      # OVERRIDE FROM HYRAX to forcefully inherit permissions before copying visibility
+      # copy permissions
+      InheritPermissionsJob.perform_now(curation_concern)
+      # copy visibility
+      VisibilityCopyJob.perform_later(curation_concern)
+
+      redirect_to [main_app, curation_concern], notice: I18n.t("hyrax.upload.change_access_flash_message")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2596 I think
The issue here should be that the `InheritPermissionsJob` and `VisibilityCopyJob` jobs both want to update the FileSet, however `InheritPermissionsJob` might grab the Work/FS before the visibility is updated and `VisibilityCopyJob` might grab the Work/FS before the permissions are updated. When each call save, the updates from the other are clobbered.

Classic race condition

By performing one before the other this is solved. I'm not sure if it matters if one is done before the other, but it seems like visibility might depend on permissions 🤷‍♂️ 