### PR TITLE
Add ReindexOneLite worker.

### DIFF
--- a/app/workers/reindex_one_lite.rb
+++ b/app/workers/reindex_one_lite.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# ReindexOneLite is a small worker to reindex an existing work.
+# Uses 'reindex' queue.
+# For more thorough reindexing use ReindexWorker
+class ReindexOneLite
+  include Sidekiq::Worker
+  sidekiq_options queue: 'reindex' # Use the 'reindex' queue
+
+  # A single pid is expected
+  def perform(pid)
+    w = ActiveFedora::Base.find(pid)
+    w.update_index
+  end
+end


### PR DESCRIPTION
This simplifies the ReindexWorker, for existing works that just need metadata and indexing refreshed. With the 'reindex' queue specified, larger reindex jobs can be spread out across workers as needed.