### PR TITLE
Apply imagemagick trim to pdf derivatives

### DIFF
--- a/app/services/oregon_digital/file_set_derivatives_service.rb
+++ b/app/services/oregon_digital/file_set_derivatives_service.rb
@@ -194,6 +194,7 @@ module OregonDigital
         cmd.density(300)
         cmd << format('%<filename>s[%<page>d]', filename: filename, page: pagenum)
         cmd.depth(8)
+        cmd.trim
         cmd << out_path
       end
     end

--- a/spec/services/oregon_digital/file_set_derivatives_service_spec.rb
+++ b/spec/services/oregon_digital/file_set_derivatives_service_spec.rb
@@ -252,6 +252,7 @@ RSpec.describe OregonDigital::FileSetDerivativesService do
       c = []
       c.define_singleton_method(:density) { |_| nil }
       c.define_singleton_method(:depth) { |_| nil }
+      c.define_singleton_method(:trim) { nil }
       c
     end
 
@@ -276,6 +277,11 @@ RSpec.describe OregonDigital::FileSetDerivativesService do
 
     it 'sets the PDF density to 300' do
       expect(convert).to receive(:density).with(300)
+      func.call
+    end
+
+    it 'trims the border of the PDF' do
+      expect(convert).to receive(:trim)
       func.call
     end
 


### PR DESCRIPTION
Fixes #1425
Trims border pixels, usually white padding but will be all border pixels that exactly match pixel [0, 0]