### PR TITLE
Use the correct command for cropping to pdf cropbox

### DIFF
--- a/app/services/oregon_digital/file_set_derivatives_service.rb
+++ b/app/services/oregon_digital/file_set_derivatives_service.rb
@@ -192,9 +192,9 @@ module OregonDigital
     def manual_convert(filename, pagenum, out_path)
       MiniMagick::Tool::Convert.new do |cmd|
         cmd.density(300)
-        cmd << format('%<filename>s[%<page>d]', filename: filename, page: pagenum)
+        cmd << '-define' << 'pdf:use-cropbox=true'
         cmd.depth(8)
-        cmd.trim
+        cmd << format('%<filename>s[%<page>d]', filename: filename, page: pagenum)
         cmd << out_path
       end
     end


### PR DESCRIPTION
Fixes #2817
Problem was with the PDF's image being larger than the cropbox. Use that cropbox to define where imagemagick should cut the PDF