### PR TITLE
add id

### DIFF
--- a/app/views/hyrax/base/_work_contact_form.html.erb
+++ b/app/views/hyrax/base/_work_contact_form.html.erb
@@ -22,7 +22,7 @@ Please use the following form to send us feedback:
   <% nm = '' %>
   <% em = '' %>
 <% end %>
-<%= form_for OregonDigital::ContactForm.new({subject: @presenter.title.first}), url: hyrax.contact_form_index_path,
+<%= form_for OregonDigital::ContactForm.new({subject: "#{@presenter.title.first} (#{@presenter.id})"}), url: hyrax.contact_form_index_path,
                             html: { class: 'form-horizontal' } do |f| %>
   <%= f.text_field :contact_method, class: 'hide' %>
   <div class="form-group">


### PR DESCRIPTION
This adds the ID to the subject. We don't have a mechanism to add any info about the work into the message unless we pass in more information through the form. This just adds the ID to the subject which should be sufficient. 