### PR TITLE
Fix non html safe rendering of encoded titles in Part Of view

### DIFF
--- a/app/views/hyrax/base/_index_gallery.html.erb
+++ b/app/views/hyrax/base/_index_gallery.html.erb
@@ -8,7 +8,7 @@
     <%= link_to(url_for_document(document), document_link_params(document, :counter => document_counter_with_offset(document_counter))) do |body| %>
       <span class="gradient-wrapper"><%= image_tag thumbnail_url(document), alt: "#{document.title_or_label} show page link" %></span>
       <h3>
-        <%= link_to document.title_or_label.truncate_words(10).html_safe, Rails.application.routes.url_helpers.polymorphic_path(document) unless document.collection? %>
+        <%= link_to document.title_or_label.truncate_words(10).html_safe, Rails.application.routes.url_helpers.polymorphic_path(document) %>
       </h3>
     <% end %>
   </div>

--- a/app/views/hyrax/base/_index_gallery.html.erb
+++ b/app/views/hyrax/base/_index_gallery.html.erb
@@ -8,7 +8,7 @@
     <%= link_to(url_for_document(document), document_link_params(document, :counter => document_counter_with_offset(document_counter))) do |body| %>
       <span class="gradient-wrapper"><%= image_tag thumbnail_url(document), alt: "#{document.title_or_label} show page link" %></span>
       <h3>
-        <%= truncate(index_presenter(document).label(document_show_link_field(document)), length: 89) %>
+        <%= link_to document.title_or_label.truncate_words(10).html_safe, Rails.application.routes.url_helpers.polymorphic_path(document) unless document.collection? %>
       </h3>
     <% end %>
   </div>


### PR DESCRIPTION
fixes #2861 

Before bug fix:
![Image before bug fix](https://github.com/OregonDigital/OD2/assets/54194852/04db8500-1bd1-4973-95cc-29947e929330)

After bug fix:
![Image after bug fix](https://github.com/OregonDigital/OD2/assets/54194852/01d36b4c-e0c6-4401-af50-0811506a9f4e)
