### PR TITLE
Add in cultural facet

### DIFF
--- a/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
@@ -228,6 +228,7 @@ module OregonDigital
         config.add_facet_field 'non_user_collections_ssim', limit: 5, label: 'Collection', helper_method: 'collection_title_from_id'
         config.add_facet_field 'local_collection_name_label_sim', label: I18n.translate('simple_form.labels.defaults.local_collection'), limit: 5
         config.add_facet_field 'institution_label_sim', limit: 5, label: 'Institution'
+        config.add_facet_field 'cultural_context_label_sim', label: 'Cultural Context', limit: 5
 
         config.add_facet_field 'former_owner_sim', label: I18n.translate('simple_form.labels.defaults.former_owner'), limit: 5
         config.add_facet_field 'mode_of_issuance_sim', label: I18n.translate('simple_form.labels.defaults.mode_of_issuance'), limit: 5


### PR DESCRIPTION
Add in the `cultural context` facet to the OD2 search filter for users.