### PR TITLE
Set file naming schema for downloads: <5_word_title>_<pid>.<extension>

### DIFF
--- a/app/controllers/concerns/oregon_digital/download_controller_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/download_controller_behavior.rb
@@ -14,7 +14,7 @@ module OregonDigital
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     def download(standard_size = false)
-      formatted_page_title = presenter.page_title.split[0..4].join("_")
+      formatted_page_title = presenter.page_title.split[0..4].join('_')
       zipname = "#{formatted_page_title}_#{curation_concern.id}.zip"
 
       send_file_headers!(
@@ -35,7 +35,7 @@ module OregonDigital
     # rubocop:enable Metrics/MethodLength
 
     def metadata
-      formatted_page_title = presenter.page_title.split[0..4].join("_")
+      formatted_page_title = presenter.page_title.split[0..4].join('_')
       send_data OregonDigital::FileSetStreamer.stream_metadata(curation_concern), filename: "#{formatted_page_title}_#{curation_concern.id}.csv"
     end
   end

--- a/app/controllers/concerns/oregon_digital/download_controller_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/download_controller_behavior.rb
@@ -14,7 +14,8 @@ module OregonDigital
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     def download(standard_size = false)
-      zipname = "#{curation_concern.id}.zip"
+      formatted_page_title = presenter.page_title.split[0..4].join("_")
+      zipname = "#{formatted_page_title}_#{curation_concern.id}.zip"
 
       send_file_headers!(
         type: 'application/zip',
@@ -34,7 +35,8 @@ module OregonDigital
     # rubocop:enable Metrics/MethodLength
 
     def metadata
-      send_data OregonDigital::FileSetStreamer.stream_metadata(curation_concern), filename: "#{curation_concern.id}.csv"
+      formatted_page_title = presenter.page_title.split[0..4].join("_")
+      send_data OregonDigital::FileSetStreamer.stream_metadata(curation_concern), filename: "#{formatted_page_title}_#{curation_concern.id}.csv"
     end
   end
 end


### PR DESCRIPTION
Fixes #1942 

Downloading zip with title length greater than 5:
![zip title length greater than 5](https://github.com/OregonDigital/OD2/assets/54194852/706156fa-1120-44fe-aebb-477907313f0d)

Downloading csv with title length greater than 5:
![csv title length greater than 5](https://github.com/OregonDigital/OD2/assets/54194852/22377cac-d321-4290-9b71-b94d9ab1316c)

Downloading zip with title length less than 5:
![zip title length less than 5](https://github.com/OregonDigital/OD2/assets/54194852/b15f262a-9fbe-4b24-9e42-daaa4b7da4ac)
