### PR TITLE
Remove italicize for collection section

### DIFF
--- a/app/assets/stylesheets/oregon_digital/collections/show.scss
+++ b/app/assets/stylesheets/oregon_digital/collections/show.scss
@@ -60,7 +60,6 @@
   }
   .hyc-desc {
     font-weight: lighter;
-    font-style: italic;
   }
   .item-count {
     padding-right: 0.5em;


### PR DESCRIPTION
Remove the `font-style: italic` part in the `.hyc-desc` to fit with the `a11y` standard.