### PR TITLE
AZ Topic facet filter

### DIFF
--- a/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
@@ -217,7 +217,7 @@ module OregonDigital
         config.add_facet_field 'copyright_combined_label_sim', label: I18n.translate('simple_form.labels.defaults.copyright_combined'), limit: 5
         config.add_facet_field 'file_format_sim', label: I18n.translate('simple_form.labels.defaults.file_format'), limit: 5
         config.add_facet_field 'resource_type_label_sim', label: I18n.translate('simple_form.labels.defaults.resource_type_label'), limit: 5
-        config.add_facet_field 'topic_combined_label_sim', label: I18n.translate('simple_form.labels.defaults.topic_combined'), limit: 5
+        config.add_facet_field 'topic_combined_label_sim', label: I18n.translate('simple_form.labels.defaults.topic_combined'), limit: 5, index_range: 'A'..'Z'
         config.add_facet_field 'scientific_combined_label_sim', label: I18n.translate('simple_form.labels.defaults.scientific_combined'), limit: 5
         config.add_facet_field 'creator_combined_label_sim', label: I18n.translate('simple_form.labels.defaults.creator_combined'), limit: 5
         config.add_facet_field 'date_combined_year_label_ssim', label: I18n.translate('simple_form.labels.defaults.date_year_combined'), limit: 5, range: { segments: false }, include_in_advanced_search: false

--- a/app/views/catalog/_facet_index_navigation.html.erb
+++ b/app/views/catalog/_facet_index_navigation.html.erb
@@ -1,4 +1,4 @@
-<nav id="az-index" aria-label="'A' to 'Z' topic index">
+<nav id="az-index" aria-label="'A' to 'Z' topic filter">
   <ol class="pagination pagination-sm justify-content-center">
     <li class="page-item <%= 'active' if @pagination.prefix.blank? %>" >
       <a class="page-link" data-href="<%= url_for(@pagination.params_for_resort_url('index', @search_state.to_h.except(@pagination.request_keys[:prefix]))) %>" data-ajax-modal="preserve" aria-controls="facet_list_header">

--- a/app/views/catalog/_facet_index_navigation.html.erb
+++ b/app/views/catalog/_facet_index_navigation.html.erb
@@ -1,0 +1,16 @@
+<nav id="az-index" aria-label="'A' to 'Z' topic index">
+  <ol class="pagination pagination-sm justify-content-center">
+    <li class="page-item <%= 'active' if @pagination.prefix.blank? %>" >
+      <a class="page-link" data-href="<%= url_for(@pagination.params_for_resort_url('index', @search_state.to_h.except(@pagination.request_keys[:prefix]))) %>" data-ajax-modal="preserve" aria-controls="facet_list_header">
+        <%= t('blacklight.search.facets.all') %>
+      </a>
+    </li>
+    <% @facet.index_range.each do |letter| %>
+      <li class="page-item  <%= 'active' if @pagination.prefix == letter %>">
+        <a class="page-link" data-href="<%= url_for(@pagination.params_for_resort_url('index', @search_state.to_h.merge(@pagination.request_keys[:prefix] => letter))) %>" data-ajax-modal="preserve" aria-controls="facet_sorted_list">
+          <%= letter  %>
+        </a>
+      </li>
+    <% end %>
+  </ol>
+</nav>

--- a/app/views/catalog/_facet_index_navigation.html.erb
+++ b/app/views/catalog/_facet_index_navigation.html.erb
@@ -1,4 +1,4 @@
-<nav id="az-index" aria-label="'A' to 'Z' topic filter">
+<nav id="az-index" aria-label="'A' to 'Z' <%= @facet.label %> filter">
   <ol class="pagination pagination-sm justify-content-center">
     <li class="page-item <%= 'active' if @pagination.prefix.blank? %>" >
       <a class="page-link" data-href="<%= url_for(@pagination.params_for_resort_url('index', @search_state.to_h.except(@pagination.request_keys[:prefix]))) %>" data-ajax-modal="preserve" aria-controls="facet_list_header">

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -13,13 +13,13 @@
 </div>
 <div class="modal-body">
   <div role="region" id="facet_list_header" aria-live="polite">
-    <%if @pagination.prefix && @display_facet.index? %>
+    <% if @pagination.prefix && @display_facet.index? %>
       <h4>Topics starting with "<%= @pagination.prefix %>" </h4>
     <% elsif @display_facet.index? %>
       <h4><%= t('blacklight.search.facets.all') %> Topics</h4> 
-    <%end %>
-    
+    <% end %>
   </div>
+
   <div class="facet_extended_list">
     <% ordered_facet = @display_facet.items.sort_by { |v| v.value.downcase } if @display_facet.sort == 'index' %>
     <% ordered_facet = @display_facet.items.group_by { |v| v.hits }.map do |key, value| %>

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -12,13 +12,21 @@
 
 </div>
 <div class="modal-body">
+  <div role="region" id="facet_list_header" aria-live="polite">
+    <%if @pagination.prefix && @display_facet.index? %>
+      <h4>Topics starting with "<%= @pagination.prefix %>" </h4>
+    <% elsif @display_facet.index? %>
+      <h4><%= t('blacklight.search.facets.all') %> Topics</h4> 
+    <%end %>
+    
+  </div>
   <div class="facet_extended_list">
-  <% ordered_facet = @display_facet.items.sort_by { |v| v.value.downcase } if @display_facet.sort == 'index' %>
-  <% ordered_facet = @display_facet.items.group_by { |v| v.hits }.map do |key, value| %>
-    <% value.sort_by! { |v| v.value.downcase }.reverse.reverse %>
-  <% end.flatten if @display_facet.sort == 'count' %>
-  <% field_facet = Blacklight::Solr::Response::Facets::FacetField.new(@display_facet.name, ordered_facet) %>
-  <%= render_facet_limit(field_facet, layout: false) %>
+    <% ordered_facet = @display_facet.items.sort_by { |v| v.value.downcase } if @display_facet.sort == 'index' %>
+    <% ordered_facet = @display_facet.items.group_by { |v| v.hits }.map do |key, value| %>
+      <% value.sort_by! { |v| v.value.downcase }.reverse.reverse %>
+    <% end.flatten if @display_facet.sort == 'count' %>
+    <% field_facet = Blacklight::Solr::Response::Facets::FacetField.new(@display_facet.name, ordered_facet) %>
+    <%= render_facet_limit(field_facet, layout: false) %>
   </div>
 </div>
 

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -14,9 +14,9 @@
 <div class="modal-body">
   <div role="region" id="facet_list_header" aria-live="polite">
     <% if @pagination.prefix && @display_facet.index? %>
-      <h4>Topics starting with "<%= @pagination.prefix %>" </h4>
+      <h4><%= facet_field_label(@facet.key) %>s starting with "<%= @pagination.prefix %>" </h4>
     <% elsif @display_facet.index? %>
-      <h4><%= t('blacklight.search.facets.all') %> Topics</h4> 
+      <h4><%= t('blacklight.search.facets.all') %> <%= facet_field_label(@facet.key) %>s</h4> 
     <% end %>
   </div>
 

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -14,9 +14,9 @@
 <div class="modal-body">
   <div role="region" id="facet_list_header" aria-live="polite">
     <% if @pagination.prefix && @display_facet.index? %>
-      <h4><%= facet_field_label(@facet.key) %>s starting with "<%= @pagination.prefix %>" </h4>
+      <h4><%= facet_field_label(@facet.key).pluralize %> starting with "<%= @pagination.prefix %>" </h4>
     <% elsif @display_facet.index? %>
-      <h4><%= t('blacklight.search.facets.all') %> <%= facet_field_label(@facet.key) %>s</h4> 
+      <h4><%= t('blacklight.search.facets.all') %> <%= facet_field_label(@facet.key).pluralize %></h4> 
     <% end %>
   </div>
 


### PR DESCRIPTION
Rough working implementation of an A-Z index filter (closes #1133 ) in the Filters > Topic > More modal.

Default "All Topics":
![Screenshot 2023-08-23 at 4 30 09 PM](https://github.com/OregonDigital/OD2/assets/54194852/5c57a668-43f0-46ea-ad8c-1c395d59eeba)


Topics filtered by letter:
![Screenshot 2023-08-23 at 4 30 32 PM](https://github.com/OregonDigital/OD2/assets/54194852/fe2439a0-1776-42f9-a2f2-cafe1d795784)


Topics filtered by letter (case: no topics):
![Screenshot 2023-08-23 at 4 30 38 PM](https://github.com/OregonDigital/OD2/assets/54194852/cdb8fce2-c4a2-4cb7-a9e0-1cf701104cb9)


Accessibility work that’s happened so far:
- A-Z Links are each list items so that screen reader users know how long the list is + make an informed decision.
- Wrapped a nav tag around the list with an aria-label for easier navigation and clarity of purpose.
- Added a heading after the navigation for a screen reader user to skip to. 
- Designated the heading as an aria-live region that screen readers will read after a live update. Only the heading is read to prevent an uninterrupted, not-useful reading of every topic on screen. 

Needs feedback/more work:
- Content of live heading. Currently "Topics starting with "{letter}"", but that doesn’t seem in line with the rest of the site. The description of what has changed on update is essential so updating the header to be more concise would mean this description would go somewhere else (visible or not). 
- After clicking on one of the A-Z links, the focus of the screen reader returns to the modal (as opposed to staying in the nav). Is this expected behavior? The same is true when clicking the "next" and "prev" links meaning the user has to skip past the nav to get to the list of topics. The heading after the nav should help with this.
- I need to implement something different for the case where no topics starting with a certain letter exist? 

In the future:
- Would a text input field be a viable option as a filter instead of the A-Z index? Following something inspired by the proposal in https://www.scottohara.me/blog/2022/02/05/dynamic-results.html. An implemented example of this found here: https://a11ysupport.io/.