### PR TITLE
make export jobs cancellable

### DIFF
--- a/app/jobs/bulkrax/exporter_job.rb
+++ b/app/jobs/bulkrax/exporter_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  # Adding method to cancel
+  class ExporterJob < ApplicationJob
+    queue_as :export
+
+    before_perform do |job|
+      if cancelled?(job.provider_job_id)
+        Rails.logger.info "Job #{job.provider_job_id} is cancelled."
+        throw(:abort)
+      end
+    end
+
+    def perform(exporter_id)
+      exporter = Exporter.find(exporter_id)
+      exporter.export
+      exporter.write
+      exporter.save
+      true
+    end
+
+    def cancelled?(jid)
+      Sidekiq.redis { |c| c.exists?("cancelled-#{jid}") } # Use c.exists? on Redis >= 4.2.0
+    end
+
+    # rubocop:disable Style/NumericLiterals
+    def self.cancel!(jid)
+      Sidekiq.redis { |c| c.setex("cancelled-#{jid}", 86400, 1) }
+    end
+    # rubocop:enable Style/NumericLiterals
+  end
+end


### PR DESCRIPTION
fixes #2934 

I was going to add the same code to the importer job, but that doesn't really stick around the same way the exporter job does.