### PR TITLE
Update Twitter logo on share page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,4 +105,5 @@ end
 
 gem "vcr", "~> 5.1"
 
-gem "font-awesome-sass", "~> 5.15"
+# INSTALL: Get the new Font Awesome
+gem 'font-awesome-sass', '~> 6.4', '>= 6.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,8 +416,8 @@ GEM
       jquery-rails
     font-awesome-rails (4.7.0.7)
       railties (>= 3.2, < 7)
-    font-awesome-sass (5.15.1)
-      sassc (>= 1.11)
+    font-awesome-sass (6.4.2)
+      sassc (~> 2.0)
     geocoder (1.6.7)
     globalid (1.0.1)
       activesupport (>= 5.0)
@@ -1139,7 +1139,7 @@ DEPENDENCIES
   equivalent-xml
   factory_bot_rails
   faraday_middleware (~> 0.10.0)
-  font-awesome-sass (~> 5.15)
+  font-awesome-sass (~> 6.4, >= 6.4.2)
   honeycomb-beeline (>= 2.10.0)
   hydra-derivatives!
   hydra-role-management
@@ -1194,4 +1194,4 @@ DEPENDENCIES
   zip_tricks (~> 5.3)
 
 BUNDLED WITH
-   2.3.12
+   2.4.15

--- a/app/assets/stylesheets/font_awesome.scss
+++ b/app/assets/stylesheets/font_awesome.scss
@@ -1,12 +1,12 @@
 // Here we have to import the font-awesome-sass libraries manualy because the font-awesome base name is being used by font-awesome-rails
 // The imports here should match the imports in this file: https://github.com/FortAwesome/font-awesome-sass/blob/master/assets/stylesheets/_font-awesome.scss
+// Font Awesome - Version 6.4.2
 
-@import "font-awesome-sprockets";
+@import "font-awesome/functions";
 @import "font-awesome/variables";
 @import "font-awesome/mixins";
-@import "font-awesome/path";
 @import "font-awesome/core";
-@import "font-awesome/larger";
+@import "font-awesome/sizing";
 @import "font-awesome/fixed-width";
 @import "font-awesome/list";
 @import "font-awesome/bordered-pulled";
@@ -15,3 +15,6 @@
 @import "font-awesome/stacked";
 @import "font-awesome/icons";
 @import "font-awesome/screen-reader";
+@import "font-awesome/solid";
+@import "font-awesome/regular";
+@import "font-awesome/brands";

--- a/app/views/hyrax/base/_social_media.html.erb
+++ b/app/views/hyrax/base/_social_media.html.erb
@@ -2,13 +2,13 @@
 <% share_url ||= request.original_url %>
 <div class="pull-right social-buttons">
   <%= link_to "https://facebook.com/sharer/sharer.php?#{{u: share_url}.to_param}", class: 'share-button share-button-facebook', target: '_blank', rel: 'noopener noreferrer', title: t('hyrax.base.social_media.facebook'), 'aria-label': t('hyrax.base.social_media.facebook') do %>
-    <i class="fa fa-facebook-square" aria-hidden="true"></i>
+    <i class="fa-brands fa-square-facebook" aria-hidden="true"></i>
     <span class="sr-only">Post to Facebook</span>
   <% end %>
 
   <!-- Sharingbutton Twitter -->
   <%= link_to "https://twitter.com/intent/tweet/?#{{text: page_title, url: share_url}.to_param}", class: 'share-button share-button-twitter', target: '_blank', rel: 'noopener noreferrer', title: t('hyrax.base.social_media.twitter'), 'aria-label': t('hyrax.base.social_media.twitter') do %>
-    <i class="fa fa-twitter" aria-hidden="true"></i>
+    <i class="fa-brands fa-x-twitter" aria-hidden="true"></i>
     <span class="sr-only">Post to Twitter</span>
   <% end %>
 </div>

--- a/app/views/shared/_fileset_collection_social_media.html.erb
+++ b/app/views/shared/_fileset_collection_social_media.html.erb
@@ -11,13 +11,13 @@
     </button>
   <div class="pull-right centered-socials">
     <%= link_to "https://facebook.com/sharer/sharer.php?#{{u: share_url}.to_param}", class: 'share-button share-button-facebook', target: '_blank', rel: 'noopener noreferrer', title: t('hyrax.base.social_media.facebook'), 'aria-label': t('hyrax.base.social_media.facebook') do %>
-      <i class="fa fa-facebook-square" aria-hidden="true"></i>
+      <i class="fa-brands fa-square-facebook" aria-hidden="true"></i>
       <span class="sr-only">Post to Facebook</span>
     <% end %>
 
     <!-- Sharingbutton Twitter -->
     <%= link_to "https://twitter.com/intent/tweet/?#{{text: page_title, url: share_url}.to_param}", class: 'share-button share-button-twitter', target: '_blank', rel: 'noopener noreferrer', title: t('hyrax.base.social_media.twitter'), 'aria-label': t('hyrax.base.social_media.twitter') do %>
-      <i class="fa fa-twitter" aria-hidden="true"></i>
+      <i class="fa-brands fa-x-twitter" aria-hidden="true"></i>
       <span class="sr-only">Post to Twitter</span>
     <% end %>
   </div>


### PR DESCRIPTION
Update local gem to get a new layout of replacing the `Twitter` icon with the new logo.