### PR TITLE
Modify the meta-tag

### DIFF
--- a/app/views/shared/_citations.html.erb
+++ b/app/views/shared/_citations.html.erb
@@ -14,11 +14,9 @@
 
 <% content_for(:facebook_meta) do %>
   <meta property="og:site_name" content="<%= application_name %>" />
-  <meta property="og:type" content="website">
   <meta property="og:url" content="<%= polymorphic_url([main_app, @presenter]) %>">
+  <meta property="og:type" content="website">
   <meta property="og:title" content="<%= @presenter.title.first %>">
   <meta property="og:description" content="<%= @presenter.description.first.truncate(200) rescue @presenter.title.first %>">
   <meta property="og:image" content="<%= URI.join(root_url, thumbnail_url(@presenter.solr_document)) %>">
-  <meta property="og:image:width" content="1200" />
-  <meta property="og:image:height" content="630" />
 <% end %>


### PR DESCRIPTION
`UPDATE:` Remove unnecessary `width` and `height` dimension on meta-tag for Facebook. 