### PR TITLE
Feature/route for content blocks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -581,7 +581,7 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (2.6.3)
-    json-canonicalization (0.3.2)
+    json-canonicalization (0.4.0)
     json-ld (3.1.10)
       htmlentities (~> 4.3)
       json-canonicalization (~> 0.2)
@@ -1250,4 +1250,4 @@ DEPENDENCIES
   zip_tricks (~> 5.3)
 
 BUNDLED WITH
-   2.4.15
+   2.4.21

--- a/app/jobs/oregon_digital/swap_visibility_job.rb
+++ b/app/jobs/oregon_digital/swap_visibility_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# reindexes chunks of uris
+class OregonDigital::SwapVisibilityJob < ContentEventJob 
+  def perform(work, visibility)
+    work.visibility = visibility
+    work.save
+    Hyrax::VisibilityPropagator.for(source: work).propagate
+    OregonDigital::PermissionChangePropagationJob.perform_later(work)
+  end
+end
+

--- a/app/jobs/oregon_digital/swap_visibility_job.rb
+++ b/app/jobs/oregon_digital/swap_visibility_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# reindexes chunks of uris
+# Swaps the visibility of an object as a job
 class OregonDigital::SwapVisibilityJob < ContentEventJob 
   def perform(work, visibility)
     work.visibility = visibility
@@ -9,4 +9,3 @@ class OregonDigital::SwapVisibilityJob < ContentEventJob
     OregonDigital::PermissionChangePropagationJob.perform_later(work)
   end
 end
-

--- a/app/jobs/oregon_digital/swap_visibility_job.rb
+++ b/app/jobs/oregon_digital/swap_visibility_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Swaps the visibility of an object as a job
-class OregonDigital::SwapVisibilityJob < ContentEventJob 
+class OregonDigital::SwapVisibilityJob < ContentEventJob
   def perform(work, visibility)
     work.visibility = visibility
     work.save

--- a/app/jobs/oregon_digital/swap_visibility_job.rb
+++ b/app/jobs/oregon_digital/swap_visibility_job.rb
@@ -4,7 +4,7 @@
 class OregonDigital::SwapVisibilityJob < ContentEventJob
   def perform(work, visibility)
     work.visibility = visibility
-    work.save
+    Hyrax.persister.save(resource: work)
     Hyrax::VisibilityPropagator.for(source: work).propagate
     OregonDigital::PermissionChangePropagationJob.perform_later(work)
   end

--- a/app/services/hyrax/workflow/swap_visibility_to_private.rb
+++ b/app/services/hyrax/workflow/swap_visibility_to_private.rb
@@ -5,7 +5,7 @@ module Hyrax
     # Hooked into workflow actions. When a work is tombstoned it runs this module and swaps the visibility to private
     module SwapVisibilityToPrivate
       def self.call(target:, **)
-        model = ActiveFedora::Base.find(target.id)
+        model = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: target.id)
         OregonDigital::SwapVisibilityJob.perform_later(model, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE)
       end
     end

--- a/app/services/hyrax/workflow/swap_visibility_to_private.rb
+++ b/app/services/hyrax/workflow/swap_visibility_to_private.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module Hyrax
+  module Workflow
+    module SwapVisibilityToPrivate
+      def self.call(target:, **)
+        model = ActiveFedora::Base.find(target.id)
+        OregonDigital::SwapVisibilityJob.perform_later(model, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/swap_visibility_to_private.rb
+++ b/app/services/hyrax/workflow/swap_visibility_to_private.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
+
 module Hyrax
   module Workflow
+    # Hooked into workflow actions. When a work is tombstoned it runs this module and swaps the visibility to private
     module SwapVisibilityToPrivate
       def self.call(target:, **)
         model = ActiveFedora::Base.find(target.id)

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -12,6 +12,9 @@
       <hr style='border-width: 3px;'>
       <div class="row">
       <% if @presenter.solr_document['workflow_state_name_ssim'] && @presenter.solr_document['workflow_state_name_ssim'].first == 'tombstoned' %>
+        <% if can?(:review, @presenter.solr_document) %>
+          <%= render 'workflow_actions_widget', presenter: @presenter %>
+        <% end %>
         <%= render 'tombstoned_work', presenter: @presenter%>
       <% else %>
         <% if can?(:review, @presenter.solr_document) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
   get 'use' => 'oregon_digital/about#use'
   get 'recommend' => 'oregon_digital/about#recommend'
 
+  patch '/contentblock/update/:name', to: 'scholars_archive/content_blocks#update', as: 'update_content_blocks'
+
   concern :oai_provider, BlacklightOaiProvider::Routes.new
   concern :searchable, Blacklight::Routes::Searchable.new
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
   get 'use' => 'oregon_digital/about#use'
   get 'recommend' => 'oregon_digital/about#recommend'
 
-  patch '/contentblock/update/:name', to: 'scholars_archive/content_blocks#update', as: 'update_content_blocks'
+  patch '/contentblock/update/:name', to: 'oregon_digital/content_blocks#update', as: 'update_content_blocks'
 
   concern :oai_provider, BlacklightOaiProvider::Routes.new
   concern :searchable, Blacklight::Routes::Searchable.new

--- a/config/workflows/mediated_deposit_workflow.json
+++ b/config/workflows/mediated_deposit_workflow.json
@@ -35,7 +35,8 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::MetadataOnlyRecord"
+                        "Hyrax::Workflow::SwapVisibilityToPrivate",
+                        "Hyrax::Workflow::DeactivateObject"
                     ]
                 }, {
                     "name": "request_changes",
@@ -54,7 +55,7 @@
                     ]
                 }, {
                     "name": "approve",
-                    "from_states": [{"names": ["pending_review"], "roles": ["approving"]}],
+                    "from_states": [{"names": ["pending_review", "tombstoned"], "roles": ["approving"]}],
                     "transition_to": "deposited",
                     "notifications": [
                         {


### PR DESCRIPTION
- Swapping back from tombstoned now allowed.

- Route added allowing the saving of content block information for tombstone.

- Visibility shifted to private when tombstoned: Should remove from all places where private works are hidden unless you have permissions.