### PR TITLE
Add a way to count the correct child works

### DIFF
--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -22,8 +22,9 @@
     </div>
   <% end %>
   <% if document.children? %>
+    <% @works = ActiveFedora::Base.find(document.id) %>
     <div class="metadata-row row">
-      Contains <%= document.children.count %> items
+      Contains <%= @works.child_works.count %> items
     </div>
   <% end %>
   <% if document.parents? %>


### PR DESCRIPTION
`FEATURE:` Fix update to match the search result to amount of child works in a complex object.