### PR TITLE
Review queue width tweaks and cleanup.

### DIFF
--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -13,6 +13,8 @@
 <%# OVERRIDE FROM HYRAX to add h1 to search results page %>
 <%- if controller.controller_name == "catalog" %>
   <h1 class="sr-only"><%= t('blacklight.search.search_results') %></h1>
+<%- elsif controller.controller_name == 'workflows' %>
+  <h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
 <%- else %>
   <%= render 'sort_and_per_page' %>
   <h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>

--- a/app/views/hyrax/admin/workflows/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/admin/workflows/_sort_and_per_page.html.erb
@@ -1,9 +1,9 @@
 <!-- OVERRIDE FROM HYRAX TO ADD SAVE BUTTON AND MODAL -->
 
 <div id="sortAndPerPage" class="row sort-pagination d-md-flex justify-content-between" role="navigation" aria-label="<%= t('blacklight.search.per_page.aria_label')%>">
-  <%= render_results_collection_tools wrapping_class: "search-widgets col-md-6 col-xs-12 text-right", constraint: false %>
+  <%= render_results_collection_tools wrapping_class: "search-widgets col-md-4 col-xs-12 text-right", constraint: false %>
 
-  <div class="save-widgets col-md-6 col-xs-12 text-right">
+  <div class="save-widgets col-md-4 col-xs-12 text-right">
     <%= button_tag( class: 'select-button',
                     onclick: 'javascript:selectAllSearchResults()',
                     'aria-controls' => 'select-chosen' ) do %>
@@ -16,7 +16,7 @@
                       <span aria-hidden='true'><%= t('hyrax.dashboard.my.action.none') %></span>
                       <span class="sr-only"> Deselect all works for adding</span>
                     <% end %>
-    <%= button_tag( class: 'bulk-review-button',
+    <%= button_tag( class: 'bulk-review-button btn-default',
                     onclick: 'javascript:bulkReview(event)') do %>
                       <span aria-hidden='true'><%= t('hyrax.dashboard.my.action.review_selected') %></span>
                       <span class="sr-only"> Review Selected </span>

--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -1,19 +1,19 @@
+<% provide :page_title, construct_page_title(t('.header')) %>
+
 <% provide :page_header do %>
   <h1><span class="glyphicon glyphicon-ok-circle"></span> <%= t('.header') %></h1>
 <% end %>
 
 <div class="row">
   <div class="col-md-12">
+    <%= render 'constraints' %>
+
+    <div id="sidebar" class="col-md-3 col-sm-4">
+      <%= render 'search_sidebar' %>
+    </div>
+
     <div id="content" class="col-md-9 col-sm-8">
-      <%= render 'constraints' %>
-
-      <div id="sidebar" class="col-md-3 col-sm-4">
-        <%= render 'search_sidebar' %>
-      </div>
-
-      <div id="content" class="col-md-9 col-sm-8">
-        <%= render 'search_results' %>
-      </div>
+      <%= render 'search_results' %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #1744 

![image](https://github.com/OregonDigital/OD2/assets/2293544/de3a91f5-4d02-46d3-bac3-461fb5deac80)

if workflows controller, don't include second sort_and_per_page partial
adjust column widths for search and save widgets to usually have both on 1 line
add button class to action button to match catalog controller
set page title to Review Submissions
remove extra 'content' div that was constraining width, adjust Filters and content column widths