### PR TITLE
Update AZ facet filters to correct search state

### DIFF
--- a/app/views/catalog/_facet_index_navigation.html.erb
+++ b/app/views/catalog/_facet_index_navigation.html.erb
@@ -1,13 +1,13 @@
 <nav id="az-index" aria-label="'A' to 'Z' <%= @facet.label %> filter">
   <ol class="pagination pagination-sm justify-content-center">
     <li class="page-item <%= 'active' if @pagination.prefix.blank? %>" >
-      <a class="page-link" data-href="<%= url_for(@pagination.params_for_resort_url('index', @search_state.to_h.except(@pagination.request_keys[:prefix]))) %>" data-ajax-modal="preserve" aria-controls="facet_list_header">
+      <a class="page-link" data-href="<%= url_for(@pagination.params_for_resort_url('index', search_state.to_h.except(@pagination.request_keys[:prefix]))) %>" data-ajax-modal="preserve" aria-controls="facet_list_header">
         <%= t('blacklight.search.facets.all') %>
       </a>
     </li>
     <% @facet.index_range.each do |letter| %>
       <li class="page-item  <%= 'active' if @pagination.prefix == letter %>">
-        <a class="page-link" data-href="<%= url_for(@pagination.params_for_resort_url('index', @search_state.to_h.merge(@pagination.request_keys[:prefix] => letter))) %>" data-ajax-modal="preserve" aria-controls="facet_sorted_list">
+        <a class="page-link" data-href="<%= url_for(@pagination.params_for_resort_url('index', search_state.to_h.merge(@pagination.request_keys[:prefix] => letter))) %>" data-ajax-modal="preserve" aria-controls="facet_sorted_list">
           <%= letter  %>
         </a>
       </li>


### PR DESCRIPTION
fixes #3023 

Topic facet before clicking a letter in the menu (within a topic):
![A-Z topic facet all filtered](https://github.com/OregonDigital/OD2/assets/54194852/d607dabe-e6de-417e-915f-cd24dc4ef70d)

Topic facet after clicking a letter in the menu (within a topic):
![A-Z topic facet topics starting with c filtered](https://github.com/OregonDigital/OD2/assets/54194852/c3965d1b-267c-4cad-8d2c-ed0088a2cd36)

Topic facet after clicking a letter in the menu (all topics):
![A-Z topic facet topics starting with c unfiltered](https://github.com/OregonDigital/OD2/assets/54194852/b3da4d76-adec-4a43-9e0a-4210ea3f2521)
