### PR TITLE
Add in label parser method to help display

### DIFF
--- a/app/inputs/label_and_uri_controlled_vocabulary_input.rb
+++ b/app/inputs/label_and_uri_controlled_vocabulary_input.rb
@@ -5,8 +5,14 @@ class LabelAndUriControlledVocabularyInput < ControlledVocabularyInput
   private
 
   def build_options_for_existing_row(attribute_name, index, _value, options)
+    # FETCH: Get the label$uri out from parser => [{label: , uri: }]
     solr_document_label_uri = SolrDocument.find(object.model.id).send(:label_uri_helpers, attribute_name)[index]
-    options[:value] = "#{solr_document_label_uri['label']} (#{solr_document_label_uri['uri']})" || "Unable to fetch label for #{solr_document_label_uri['uri']}"
+
+    # CHECK: If the label is blank, use a default message instead
+    label = !solr_document_label_uri['label'].empty? ? solr_document_label_uri['label'] : 'Unable to fetch label'
+
+    # SET: Set the value to the corresponding area
+    options[:value] = "#{label} (#{solr_document_label_uri['uri']})"
     options[:readonly] = true
   end
 end

--- a/app/inputs/label_and_uri_controlled_vocabulary_input.rb
+++ b/app/inputs/label_and_uri_controlled_vocabulary_input.rb
@@ -4,7 +4,7 @@
 class LabelAndUriControlledVocabularyInput < ControlledVocabularyInput
   private
 
-  def build_options_for_existing_row(attribute_name, index, value, options)
+  def build_options_for_existing_row(attribute_name, index, _value, options)
     solr_document_label_uri = SolrDocument.find(object.model.id).send(:label_uri_helpers, attribute_name)[index]
     options[:value] = "#{solr_document_label_uri['label']} (#{solr_document_label_uri['uri']})" || "Unable to fetch label for #{solr_document_label_uri['uri']}"
     options[:readonly] = true

--- a/app/inputs/label_and_uri_controlled_vocabulary_input.rb
+++ b/app/inputs/label_and_uri_controlled_vocabulary_input.rb
@@ -5,9 +5,8 @@ class LabelAndUriControlledVocabularyInput < ControlledVocabularyInput
   private
 
   def build_options_for_existing_row(attribute_name, index, value, options)
-    solr_document_label = SolrDocument.find(object.model.id).send("#{attribute_name}_label")[index]
-    value_uri = value.rdf_subject
-    options[:value] = "#{solr_document_label} (#{value_uri})" || "Unable to fetch label for #{value.rdf_subject}"
+    solr_document_label_uri = SolrDocument.find(object.model.id).send(:label_uri_helpers, attribute_name)[index]
+    options[:value] = "#{solr_document_label_uri['label']} (#{solr_document_label_uri['uri']})" || "Unable to fetch label for #{solr_document_label_uri['uri']}"
     options[:readonly] = true
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -140,10 +140,10 @@ class SolrDocument
     self['oai_collections_ssim']
   end
 
-  # Uncomment out later for work on 'label$uri'
-  # def subject_label
-  #   OregonDigital::LabelParserService.parse_label_uris(self['subject_parsable_label_ssim'])
-  # end
+  # METHOD: Fetch the ssim for 'label$uri'
+  def label_uri_helpers(attribute_name)
+    OregonDigital::LabelParserService.parse_label_uris(self["#{attribute_name}_parsable_label_ssim"])
+  end
 
   solrized_methods Generic.generic_properties
   solrized_methods Document.document_properties


### PR DESCRIPTION
`UPDATE PART: 2` Add in the helper method to parse out and display on form correctly if `uris` are deprecated.

`TASK PROGRESS:`

- [x] Create a helper method in `solr_document.rb`
- [x] Change the method of fetch to reflect the new Solr field