### PR TITLE
Cleanup on Display labels & uris

### DIFF
--- a/app/controllers/concerns/oregon_digital/presents_data_sources.rb
+++ b/app/controllers/concerns/oregon_digital/presents_data_sources.rb
@@ -16,11 +16,11 @@ module OregonDigital
     def build_display_properties
       index = 1
       # FETCH: Get the label$uri from SolrDocument
-      cv_label_uris = SolrDocument.find(presenter.id)
+      solr_doc = SolrDocument.find(presenter.id)
 
       Generic::ORDERED_PROPERTIES.each do |prop|
         if prop[:is_controlled]
-          index = build_controlled_prop(index, prop, cv_label_uris)
+          index = build_controlled_prop(index, prop, solr_doc)
         else
           presenter_value = presenter.attribute_to_html(prop[:name].to_sym, html_dl: true, label: t("simple_form.labels.defaults.#{prop[:name_label].nil? ? prop[:name] : prop[:name_label]}"))
           @props << prop unless presenter_value.nil? || presenter_value.empty?
@@ -29,9 +29,9 @@ module OregonDigital
     end
     # rubocop:enable Metrics/AbcSize
 
-    def build_controlled_prop(index, prop, cv_label_uris)
-      # GET: Get the 'label$uri' from specific controlled vocab
-      parse_cv = cv_label_uris.label_uri_helpers(prop[:name].gsub('_label', ''))
+    def build_controlled_prop(index, prop, solr_doc)
+      # GET: Get the 'label$uri' from specific controlled vocab from solr_doc
+      parse_cv = solr_doc.label_uri_helpers(prop[:name].gsub('_label', ''))
 
       # CHECK: Return index if either parse_cv is empty or nil
       return index if parse_cv.nil? || parse_cv.empty?

--- a/app/controllers/concerns/oregon_digital/presents_data_sources.rb
+++ b/app/controllers/concerns/oregon_digital/presents_data_sources.rb
@@ -12,6 +12,7 @@ module OregonDigital
       super
     end
 
+    # rubocop:disable Metrics/AbcSize
     def build_display_properties
       index = 1
       # FETCH: Get the label$uri from SolrDocument
@@ -26,6 +27,7 @@ module OregonDigital
         end
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def build_controlled_prop(index, prop, cv_label_uris)
       # GET: Get the 'label$uri' from specific controlled vocab

--- a/app/models/concerns/oregon_digital/metadata_download.rb
+++ b/app/models/concerns/oregon_digital/metadata_download.rb
@@ -35,10 +35,10 @@ module OregonDigital
 
     def from_controlled_field(label)
       # FETCH: Get the SolrDocument that store the label$uri
-      cv_values = SolrDocument.find(id)
+      solr_doc = SolrDocument.find(id)
 
       # GET: Get the parse value out of the label$uri
-      parse_cv_values = cv_values.label_uri_helpers(label)
+      parse_cv_values = solr_doc.label_uri_helpers(label)
 
       # MAP: Map out the value and return a string of labels
       parse_cv_values.map { |cv| !cv['label'].empty? ? cv['label'] : "No label found [#{cv['uri']}]" }.join('|')

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,10 +1,9 @@
 <%# FETCH: Fetch the label$uri by finding it in SolrDocument %>
-<% cv_label_uris = SolrDocument.find(presenter.id) %>
+<% solr_doc = SolrDocument.find(presenter.id) %>
 <% @props.each do |prop| %>
   <% if prop[:is_controlled] %>
-    <% zipped = presenter.zipped_values(prop[:name]) %>
     <%# GET: Get the 'label$uri' from specific controlled vocab %>
-    <% parse_cv = cv_label_uris.label_uri_helpers(prop[:name].gsub('_label', '')) %>
+    <% parse_cv = solr_doc.label_uri_helpers(prop[:name].gsub('_label', '')) %>
     <%# CONVERT: Then get it into a hash to fit with the form method %>
     <% hash_cv = parse_cv.map { |cv| [cv['label'], cv['uri']] }.to_h %>
     <% @presenter_value = presenter.attribute_to_html(prop[:name].to_sym, indices: prop[:indices], render_as: :search_and_external_link, links: hash_cv, html_dl: true, label: t("simple_form.labels.defaults.#{prop[:name]}"))%>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,7 +1,13 @@
+<%# FETCH: Fetch the label$uri by finding it in SolrDocument %>
+<% cv_label_uris = SolrDocument.find(presenter.id) %>
 <% @props.each do |prop| %>
   <% if prop[:is_controlled] %>
     <% zipped = presenter.zipped_values(prop[:name]) %>
-    <% @presenter_value = presenter.attribute_to_html(prop[:name].to_sym, indices: prop[:indices], render_as: :search_and_external_link, links: zipped, html_dl: true, label: t("simple_form.labels.defaults.#{prop[:name]}"))%>
+    <%# GET: Get the 'label$uri' from specific controlled vocab %>
+    <% parse_cv = cv_label_uris.label_uri_helpers(prop[:name].gsub('_label', '')) %>
+    <%# CONVERT: Then get it into a hash to fit with the form method %>
+    <% hash_cv = parse_cv.map { |cv| [cv['label'], cv['uri']] }.to_h %>
+    <% @presenter_value = presenter.attribute_to_html(prop[:name].to_sym, indices: prop[:indices], render_as: :search_and_external_link, links: hash_cv, html_dl: true, label: t("simple_form.labels.defaults.#{prop[:name]}"))%>
     <% unless @presenter_value.nil? || @presenter_value.empty? %>
       <%= @presenter_value %>
     <% end %>

--- a/app/views/hyrax/base/_data_sources.html.erb
+++ b/app/views/hyrax/base/_data_sources.html.erb
@@ -8,14 +8,15 @@
     </tr>
   </thead>
   <tbody>
+  <% controlled_label_uris = SolrDocument.find(presenter.id) %>
   <% @props.each do |prop| %>
     <% if prop[:is_controlled] %>
-        <% zipped = presenter.zipped_values(prop[:name]) %>
-        <% zipped.each do |label, uri| %>
+        <% parse_values = controlled_label_uris.label_uri_helpers(prop[:name].gsub('_label', '')) %>
+        <% parse_values.each do |value| %>
         <tr>
-          <td> <%= prop[:indices][uri] %> </td>
-          <th scope="row"> <%= label %> </th>
-          <td> <%= link_to uri, uri %> </td>
+          <td> <%= prop[:indices][value['uri']] %> </td>
+          <th scope="row"> <%= !value['label'].empty? ? value['label'] : 'No label found' %> </th>
+          <td> <%= link_to value['uri'], value['uri'] %> </td>
         </tr>
         <% end %>
     <% end %>

--- a/app/views/hyrax/base/_data_sources.html.erb
+++ b/app/views/hyrax/base/_data_sources.html.erb
@@ -8,10 +8,10 @@
     </tr>
   </thead>
   <tbody>
-  <% controlled_label_uris = SolrDocument.find(presenter.id) %>
+  <% cv_label_uris = SolrDocument.find(presenter.id) %>
   <% @props.each do |prop| %>
     <% if prop[:is_controlled] %>
-        <% parse_values = controlled_label_uris.label_uri_helpers(prop[:name].gsub('_label', '')) %>
+        <% parse_values = cv_label_uris.label_uri_helpers(prop[:name].gsub('_label', '')) %>
         <% parse_values.each do |value| %>
         <tr>
           <td> <%= prop[:indices][value['uri']] %> </td>

--- a/app/views/hyrax/base/_data_sources.html.erb
+++ b/app/views/hyrax/base/_data_sources.html.erb
@@ -8,10 +8,10 @@
     </tr>
   </thead>
   <tbody>
-  <% cv_label_uris = SolrDocument.find(presenter.id) %>
+  <% solr_doc = SolrDocument.find(presenter.id) %>
   <% @props.each do |prop| %>
     <% if prop[:is_controlled] %>
-        <% parse_values = cv_label_uris.label_uri_helpers(prop[:name].gsub('_label', '')) %>
+        <% parse_values = solr_doc.label_uri_helpers(prop[:name].gsub('_label', '')) %>
         <% parse_values.each do |value| %>
         <tr>
           <td> <%= prop[:indices][value['uri']] %> </td>

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -37,17 +37,6 @@ RSpec.describe Collection do
     end
   end
 
-  describe '#controlled_property_to_csv_value' do
-    before do
-      allow(term).to receive(:fetch)
-      allow(term).to receive(:solrize).and_return(['http://opaquenamespace.org/ns/TestVocabulary/TestTerm', { label: 'TestTerm$http://opaquenamespace.org/ns/TestVocabulary/TestTerm' }])
-    end
-
-    it 'formats a controlled property' do
-      expect(model.send(:controlled_property_to_csv_value, term)).to eq('TestTerm')
-    end
-  end
-
   describe '#metadata_row' do
     it 'provides an array' do
       expect(model.metadata_row([:title], [])).to be_kind_of(Array)

--- a/spec/models/generic_spec.rb
+++ b/spec/models/generic_spec.rb
@@ -25,17 +25,6 @@ RSpec.describe Generic do
     end
   end
 
-  describe '#controlled_property_to_csv_value' do
-    before do
-      allow(term).to receive(:fetch)
-      allow(term).to receive(:solrize).and_return(['http://opaquenamespace.org/ns/TestVocabulary/TestTerm', { label: 'TestTerm$http://opaquenamespace.org/ns/TestVocabulary/TestTerm' }])
-    end
-
-    it 'formats a controlled property' do
-      expect(model.send(:controlled_property_to_csv_value, term)).to eq('TestTerm')
-    end
-  end
-
   describe '#metadata_row' do
     it 'provides an array' do
       expect(model.metadata_row([:title], [])).to be_kind_of(Array)

--- a/spec/services/oregon_digital/collection_streamer_spec.rb
+++ b/spec/services/oregon_digital/collection_streamer_spec.rb
@@ -6,6 +6,10 @@ describe OregonDigital::CollectionStreamer do
   let(:streamer) { service_class.new('ability', collection, false) }
 
   describe '#stream' do
+    before do
+      allow(collection).to receive(:metadata_row).and_return([])
+    end
+
     it 'assembles a zip out of chunks' do
       chunk_count = 0
       service_class.stream_col('ability', collection) do

--- a/spec/services/oregon_digital/file_set_streamer_spec.rb
+++ b/spec/services/oregon_digital/file_set_streamer_spec.rb
@@ -5,6 +5,10 @@ describe OregonDigital::FileSetStreamer do
   let(:work) { build(:work) }
 
   describe '#stream' do
+    before do
+      allow(work).to receive(:metadata_row).and_return([])
+    end
+
     it 'assembles a zip out of chunks' do
       chunk_count = 0
       service_class.stream(work) do


### PR DESCRIPTION
`UPDATE:` Continue to update more on the display usage of the new `label$uri`

`TASKS:` To-Do lists

- [x] Update the `data_source.html.erb` to not use the `zipped_values` method and use the new `label$uri` method
- [x] Update the `OregonDigital::MetadataDownload#metadata_row` to get the new metadata without doing much fetching and cleanup as well
- [x] Update the `OregonDigital::PresentsDataSources` as well
- [x] Update the `_attribute_row.html.erb` to not use the `zipped_value`
- [x] ~(Future Task?) TBD (Spot any new file that may use `fetch` or `zipped_values` to display)~