### PR TITLE
Disables dropdown and adds text to make data more clear

### DIFF
--- a/app/views/hyrax/base/_currently_shared.html.erb
+++ b/app/views/hyrax/base/_currently_shared.html.erb
@@ -1,0 +1,47 @@
+<% permission_service = Hyrax::EditPermissionsService.build_service_object_from(form: f, ability: current_ability) %>
+
+<h2 class="h3 mt-4"><%= t('.currently_sharing') %></h2>
+
+<table class="table table-bordered">
+  <tr>
+    <th><%= t('.table_title_user') %></th>
+    <th><div class="col-sm-10"><%= t('.table_title_access') %></div></th>
+  </tr>
+  <tr id="file_permissions">
+    <td>
+      <%= label_tag :owner_access, class: "col-form-label" do %>
+        Depositor (<span id="file_owner" data-depositor="<%= permission_service.depositor %>"><%= link_to_profile permission_service.depositor %></span>)
+      <% end %>
+    </td>
+    <td>
+    <div class="col-sm-10">
+      <%= Hyrax.config.owner_permission_levels.keys[0] %>
+    </div>
+    </td>
+  </tr>
+  <%= f.fields_for :permissions do |permission_fields| %>
+    <% permission_service.with_applicable_permission(permission_hash: permission_fields.object.to_hash) do |permission| %>
+    <tr>
+      <td>
+        <%= permission_fields.label :agent_name, class: "col-form-label" do %>
+          <%= user_display_name_and_key(permission.name) %>
+          <%= permission.granted_by_html_hint %>
+        <% end %>
+        <%= "(#{permission.access.capitalize})" %>
+      </td>
+      <td>
+        <div class="col-sm-10">
+        <% if permission.can_edit? %>
+          <%= permission_fields.select :access, Hyrax.config.permission_levels, {}, class: 'form-control select_perm', disabled: true %>
+        <% else %>
+          <%= Hyrax.config.permission_levels.key(permission.access) %>
+        <% end %>
+        </div>
+        <% if permission.can_edit? %>
+          <button class="btn close remove_perm" data-index="<%= permission_fields.index %>">&times;</button>
+        <% end %>
+      </td>
+    </tr>
+    <% end %>
+  <% end %>
+</table>


### PR DESCRIPTION
Fixes #3062

Me and Ryan met about this ticket. Its more work than worth to actually clean up the data. However, we added some data to help explain why there are duplicate name/rows and what the permission for those dups are. We also disabled the dropdown because the permissions don't make sense changing access level when we are expressing permissions differently.

<img width="959" alt="Screenshot 2024-03-06 at 2 46 07 PM" src="https://github.com/OregonDigital/OD2/assets/6424683/4c365957-b436-4b10-afec-12701213a355">
