### PR TITLE
Skip creating bbox file if extracted text is empty & reset bbox on recreate

### DIFF
--- a/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
@@ -25,7 +25,7 @@ module OregonDigital
       configure_blacklight do |config|
         # configuration for Blacklight IIIF Content Search
         config.iiif_search = {
-          full_text_field: %w[all_text_bbox_tsimv hocr_content_tsimv all_text_bbox_timv hocr_content_timv],
+          full_text_field: %w[all_text_bbox_tsimv hocr_content_tsimv all_text_bbox_timv hocr_text_timv],
           object_relation_field: 'file_set_ids_ssim',
           supported_params: %w[q page],
           autocomplete_handler: 'iiif_suggest',

--- a/app/indexers/oregon_digital/file_set_indexer.rb
+++ b/app/indexers/oregon_digital/file_set_indexer.rb
@@ -10,6 +10,8 @@ module OregonDigital
         # Collapse possible extracted text with OCRd text for searching
         solr_doc['all_text_tsimv'] = find_all_text_value(solr_doc)
         solr_doc['hocr_text_tsimv'] = find_hocr_text(solr_doc)
+        solr_doc['all_text_timv'] = find_all_text_value(solr_doc)
+        solr_doc['hocr_text_timv'] = find_hocr_text(solr_doc)
         # Set bounding box information for blacklight_iiif_search
         solr_doc['all_text_bbox_tsimv'] = object.bbox_content unless object.bbox_content.nil?
         solr_doc['hocr_content_tsimv'] = object.hocr_content unless object.hocr_content.nil?

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -57,12 +57,12 @@ class FileSet < ActiveFedora::Base
   end
 
   def hocr_text
-    return @hocr_text unless @hocr_text.blank?
-
     # Use hocr derivative if available
-    # all_bbox_text = hocr.map(&:content).join("\n")
-    # all_text = Nokogiri::HTML(all_bbox_text).css('.ocrx_word').map(&:text).join(' ')
     all_text = ''
+    if hocr
+      all_bbox_text = hocr.map(&:content).join("\n")
+      all_text = Nokogiri::HTML(all_bbox_text).css('.ocrx_word').map(&:text).join(' ')
+    end
 
     @hocr_text ||= all_text.presence || SolrDocument.find(id).to_h.dig('hocr_text_tsimv')
   rescue Blacklight::Exceptions::RecordNotFound

--- a/app/services/oregon_digital/file_set_derivatives_service.rb
+++ b/app/services/oregon_digital/file_set_derivatives_service.rb
@@ -114,9 +114,12 @@ module OregonDigital
     end
 
     def create_extracted_text_bbox_content(filename, file_set: self.file_set)
+      # We have to reload the fileset to get the extracted_text data for some reason
       file_set.reload
-      OregonDigital::Derivatives::Document::PDFToTextRunner.create(filename,
-                                                                   outputs: [{ url: uri, container: 'bbox' }])
+      unless file_set.extracted_text&.content.blank?
+        OregonDigital::Derivatives::Document::PDFToTextRunner.create(filename,
+                                                                     outputs: [{ url: uri, container: 'bbox' }])
+      end
       # We have to reload the fileset to get the updated bbox data for some reason
       file_set.reload
     end

--- a/app/workers/re_extract_text_worker.rb
+++ b/app/workers/re_extract_text_worker.rb
@@ -14,6 +14,7 @@ class ReExtractTextWorker
     derivative_service = OregonDigital::FileSetDerivativesService.new(file_set)
 
     # Create extracted text bbox_content
+    file_set.bbox = nil
     Hydra::Derivatives::FullTextExtract.create(filename,
                                                outputs: [{ url: uri(file_set), container: 'extracted_text' }])
 


### PR DESCRIPTION
Bugfix for #3080 