### PR TITLE
Fix dark image derivatives in Universal Viewer

### DIFF
--- a/app/services/oregon_digital/file_set_derivatives_service.rb
+++ b/app/services/oregon_digital/file_set_derivatives_service.rb
@@ -187,7 +187,7 @@ module OregonDigital
 
     def other_to_png(source, dest)
       image = MiniMagick::Image.open(source)
-      image.depth(8).format('png').write(dest)
+      image.strip.depth(8).format('png').write(dest)
 
       # The above code generates a temp file which we don't need beyond the
       # .write() call, so we explicitly destroy the image object


### PR DESCRIPTION
fixes #2489 

Screenshot with corrected colors:
![Image in universal viewer with corrected colors](https://github.com/OregonDigital/OD2/assets/54194852/7b9f061c-3dbf-4151-bde0-1f8765867f9d)

Screenshot before fix:
![Dark image in universal viewer](https://github.com/OregonDigital/OD2/assets/54194852/824e6660-ada3-4fd2-8291-c96b4853b05d)
