### PR TITLE
Exclude default thumbnails. Reduce solr queries.

### DIFF
--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -3,13 +3,11 @@
     <h2 class="uppercase">Featured Collections</h2>
     <% unless @presenter.collections.to_a.empty? %>
       <% @presenter.collections.each do |collection| %>
-        <% solr_hits = Hyrax::SolrService.query("member_of_collection_ids_ssim:#{collection.id} AND file_set_ids_ssim:[* TO *]", rows: 3) %>
-        <% @member_docs = SolrDocument.find(solr_hits.map(&:id)) %>
+        <% solr_hits = Hyrax::SolrService.query("member_of_collection_ids_ssim:#{collection.id} AND file_set_ids_ssim:* AND -thumbnail_path_ss:*png", fl: 'id,title_sim,thumbnail_path_ss,has_model_ssim', rows: 3) %>
         <% @member_count = Hyrax::SolrService.new.count("member_of_collection_ids_ssim:#{collection.id}") %>
         <span class="featured-collection-row flex-container">
-        <% @members_filled = @member_docs.fill(nil, @member_docs.length..2)[0..2].reverse %>
-        <% @members_filled.each do |work| %>
-          <% if work == nil %>
+        <% solr_hits.each do |sh| %>
+          <% if sh == nil %>
             <div class="featured-collection-item">
               <%= image_tag(
                 'logo.png',
@@ -18,10 +16,12 @@
             </div>
           <% else %>
             <div class="featured-collection-item">
-              <%= render_thumbnail_tag(
-                  work,
-                  { class: 'img-thumbnail', alt: work.title_or_label }
-                ) %>
+              <%= link_to "/concern/#{sh['has_model_ssim'].first.downcase.pluralize}/#{(sh['id'])}" do %>
+                <%= image_tag(
+                sh['thumbnail_path_ss'],
+                  { class: 'img-thumbnail', alt: sh['title_sim'] }
+                  ) %>
+              <% end %>
             </div>
           <% end %>
         <% end %>


### PR DESCRIPTION
Fixes #3089 

Changed featured collections thumbnails solr query to exclude default thumbnail (png) from results.  Only return needed solr fields, and remove some SolrDocument calls. Changed thumbnail and link code to work from solr hit fields.