### PR TITLE
Skip saving BBOX if solr/tika returned bad extracted text

### DIFF
--- a/app/services/oregon_digital/file_set_derivatives_service.rb
+++ b/app/services/oregon_digital/file_set_derivatives_service.rb
@@ -75,10 +75,10 @@ module OregonDigital
       page_count = OregonDigital::Derivatives::Image::Utils.page_count(filename)
       # Use tesseract to populate #hocr on filesets if
       0.upto(page_count - 1) do |pagenum|
-        Rails.logger.debug("HOCR: page #{pagenum}/#{page_count - 1}") if file_set.extracted_text&.content.blank?
+        Rails.logger.debug("HOCR: page #{pagenum}/#{page_count - 1}") if file_set.bbox&.content.blank?
         OregonDigital::Derivatives::Image::Utils.tmp_file('png') do |out_path|
           manual_convert(filename, pagenum, out_path)
-          create_hocr_content(out_path) if file_set.extracted_text&.content.blank?
+          create_hocr_content(out_path) if file_set.bbox&.content.blank?
           create_zoomable_page(out_path, pagenum)
         end
       end
@@ -116,7 +116,7 @@ module OregonDigital
     def create_extracted_text_bbox_content(filename, file_set: self.file_set)
       # We have to reload the fileset to get the extracted_text data for some reason
       file_set.reload
-      unless file_set.extracted_text&.content.blank?
+      unless file_set.bbox&.content.blank?
         OregonDigital::Derivatives::Document::PDFToTextRunner.create(filename,
                                                                      outputs: [{ url: uri, container: 'bbox' }])
       end

--- a/app/services/oregon_digital/verify_derivatives_service.rb
+++ b/app/services/oregon_digital/verify_derivatives_service.rb
@@ -116,7 +116,7 @@ module OregonDigital
       @work_info ||=
         {
           has_thumbnail: all_derivatives(file_set).select { |b| b.match 'thumbnail' }.present?,
-          # has_extracted_text: file_set.extracted_text.present?,
+          # has_extracted_text: file_set.bbox.present?,
           page_count: derivatives_for_reference(file_set, 'jp2').count
         }
     end

--- a/app/workers/re_extract_text_worker.rb
+++ b/app/workers/re_extract_text_worker.rb
@@ -21,7 +21,7 @@ class ReExtractTextWorker
     derivative_service.create_extracted_text_bbox_content(filename)
 
     # OCR if we didn't get extracted bbox content
-    if file_set.extracted_text&.content.blank?
+    if file_set.bbox&.content.blank?
       # Reset the hocr content
       file_set.hocr = []
       # We need the individual pages as PNGs to redo the OCR, but we can skip it if we were able to extract the exact text

--- a/lib/oregon_digital/derivatives/document/pdf_to_text_processor.rb
+++ b/lib/oregon_digital/derivatives/document/pdf_to_text_processor.rb
@@ -37,6 +37,9 @@ module OregonDigital::Derivatives::Document
       OregonDigital::Derivatives::Image::Utils.tmp_file('ocr') do |out_path|
         self.class.encode(source_path, out_path)
         file_content = File.read(out_path)
+        # Skip saving bbox content if there's no bbox words
+        break unless Nokogiri::HTML(file_content).css('word').count.positive?
+
         scaled_content = scale_bbox(file_content)
         output_file_service.call(scaled_content, directives)
       end


### PR DESCRIPTION
Bad extracted text return was preventing Tesseract from running on PDFs that needed OCR