### PR TITLE
Add in Content Mask for Collection

### DIFF
--- a/app/assets/stylesheets/oregon_digital/_work-show.scss
+++ b/app/assets/stylesheets/oregon_digital/_work-show.scss
@@ -341,12 +341,13 @@ dl.work-show {
   background-color: rgba(0,0,0, 0.4); /* Black w/opacity/see-through */
   color: white;
   font-weight: bold;
-  position: absolute;
-  top: 23%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 2;
-  width: 80%;
-  padding: 20px;
   text-align: center;
+
+  position: absolute;
+  width: 85%;
+  padding: 20px;
+  transform: translate(-50%, -50%);
+  left: 50%;
+  top: 25%;
+  z-index: 2;
 }

--- a/app/assets/stylesheets/oregon_digital/_work-show.scss
+++ b/app/assets/stylesheets/oregon_digital/_work-show.scss
@@ -334,3 +334,19 @@ dl.work-show {
   padding: 20px;
   text-align: center;
 }
+
+// CSS for the background-blur display for collection side
+.bg-collection {
+  background-color: rgb(0,0,0); /* Fallback color */
+  background-color: rgba(0,0,0, 0.4); /* Black w/opacity/see-through */
+  color: white;
+  font-weight: bold;
+  position: absolute;
+  top: 23%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+  width: 80%;
+  padding: 20px;
+  text-align: center;
+}

--- a/app/forms/oregon_digital/forms/collection_form.rb
+++ b/app/forms/oregon_digital/forms/collection_form.rb
@@ -8,7 +8,8 @@ module OregonDigital
     class CollectionForm < Hyrax::Forms::CollectionForm
       self.terms = %i[id title creator contributor description license publisher
                       date_created subject language has_finding_aid representative_id thumbnail_id
-                      related_url visibility collection_type_gid institution date repository local_contexts]
+                      related_url visibility collection_type_gid institution date repository local_contexts
+                      content_alert mask_content]
       self.required_fields = %i[id title]
 
       def initialize_field(key)
@@ -64,7 +65,7 @@ module OregonDigital
 
       def self.build_permitted_params
         params = super
-        %w[creator contributor institution repository publisher subject local_contexts].each do |prop|
+        %w[creator contributor institution repository publisher subject local_contexts content_alert mask_content].each do |prop|
           params << { "#{prop}_attributes" => %i[id _destroy] }
         end
         params << :license

--- a/app/models/concerns/oregon_digital/collection_metadata.rb
+++ b/app/models/concerns/oregon_digital/collection_metadata.rb
@@ -76,6 +76,7 @@ module OregonDigital
         index.as :stored_searchable, :facetable
       end
 
+      # Content Alert & Mask Content Predicate
       property :content_alert, predicate: RDF::Vocab::EBUCore.ContentAlert, multiple: false, basic_searchable: false do |index|
         index.as :stored_searchable
       end

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -78,11 +78,18 @@
     <div class="hyc-blacklight hyc-bl-results hyc-bl-search hyc-bl-collection">
       <div id="documents">
         <% # container for all documents in index view -%>
-        <div class="" id="thumbnails" data-behavior="masonry-gallery">
+        <div class="<%= 'blurred-image' if @collection.mask_content.include?('Item Show Page') %>" id="thumbnails" data-behavior="masonry-gallery">
           <div id="masonry-sizer"></div>
           <div id="masonry-gutter-sizer"></div>
           <%= render collection: controller.collection.representative_docs, as: :document, partial: 'showcase_tile', locals: {count: @member_docs.length} %>
         </div>
+
+        <% if @collection.mask_content.include?('Item Show Page') %>
+          <div class='bg-collection'>
+            <p><%= @collection.content_alert.blank? ? '' : @collection.content_alert %></p>
+            <button type="button" class='btn btn-primary' onclick="this.parentNode.style.display = 'none'; $('.blurred-image').removeClass('blurred-image')">I Understand</button>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -84,8 +84,9 @@
           <%= render collection: controller.collection.representative_docs, as: :document, partial: 'showcase_tile', locals: {count: @member_docs.length} %>
         </div>
 
+        <%# CONTENT ALERT: Area to display content alert if blurring happens on the collection %>
         <% if @collection.mask_content.include?('Item Show Page') %>
-          <div class='bg-collection'>
+          <div class="bg-collection">
             <p><%= @collection.content_alert.blank? ? '' : @collection.content_alert %></p>
             <button type="button" class='btn btn-primary' onclick="this.parentNode.style.display = 'none'; $('.blurred-image').removeClass('blurred-image')">I Understand</button>
           </div>

--- a/spec/forms/oregon_digital/forms/collection_form_spec.rb
+++ b/spec/forms/oregon_digital/forms/collection_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OregonDigital::Forms::CollectionForm do
   let(:ability) { Ability.new(create(:user)) }
   let(:repository) { double }
   let(:form) { described_class.new(collection, ability, repository) }
-  let(:expected_terms) { %i[id title creator contributor description license publisher date_created subject language has_finding_aid representative_id thumbnail_id related_url visibility collection_type_gid institution date repository local_contexts] }
+  let(:expected_terms) { %i[id title creator contributor description license publisher date_created subject language has_finding_aid representative_id thumbnail_id related_url visibility collection_type_gid institution date repository local_contexts content_alert mask_content] }
 
   describe '#terms' do
     let(:terms) { described_class.terms }


### PR DESCRIPTION
`FEATURE:` Add in the `Collection` content masking on the front-end and test on the message display.

`TO-DO:`
- [x] Add in the `terms` for it to accept in the `collection form`
- [x] Add in the display once the warning is selected
- [x] Make sure it cover and blur
- [x] Test to see if the display work as intended