### PR TITLE
Solr doc children fix

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -90,5 +90,6 @@ Rails.application.configure do
   config.verify_services = [
     OregonDigital::VerifyDerivativesService
   ]
+  config.max_members_query = ENV.fetch('MAX_MEMBERS_QUERY', 5).to_i
 
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -128,4 +128,5 @@ Rails.application.configure do
   config.verify_services = [
     OregonDigital::VerifyDerivativesService
   ]
+  config.max_members_query = ENV.fetch('MAX_MEMBERS_QUERY', 100).to_i
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,5 @@ Rails.application.configure do
   config.verify_services = [
     OregonDigital::VerifyDerivativesService
   ]
+  config.max_members_query = ENV.fetch('MAX_MEMBERS_QUERY', 5).to_i
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe SolrDocument do
       OD2::Application.config.max_members_query = max_members_query
     end
 
-    it 'returns without throwing too many uris error' do
+    it 'returns without throwing too long uri error' do
       expect { sd.sort_members }.not_to raise_error
     end
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -22,22 +22,39 @@ RSpec.describe SolrDocument do
   end
 
   describe 'max_members_query' do
-    let(:max_members_query) { 100 }
-    let(:ids) do
-      i = []
-      (0..max_members_query).each do |num|
-        i << "abc#{num}"
-      end
-      i
-    end
-
     before do
       allow(sd).to receive(:member_ids).and_return(ids)
       OD2::Application.config.max_members_query = max_members_query
     end
 
-    it 'returns without throwing too long uri error' do
-      expect { sd.sort_members }.not_to raise_error
+    context 'when chunk size is low' do
+      let(:max_members_query) { 100 }
+      let(:ids) do
+        i = []
+        (0..max_members_query).each do |num|
+          i << "abc#{num}"
+        end
+        i
+      end
+
+      it 'returns without throwing an error' do
+        expect { sd.sort_members }.not_to raise_error
+      end
+    end
+
+    context 'when chunk size is high' do
+      let(:max_members_query) { 1000 }
+      let(:ids) do
+        i = []
+        (0..max_members_query).each do |num|
+          i << "abc#{num}"
+        end
+        i
+      end
+
+      it 'throws error' do
+        expect { sd.sort_members }.to raise_error(Blacklight::Exceptions::InvalidRequest)
+      end
     end
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -7,13 +7,10 @@ RSpec.describe SolrDocument do
   let(:docs) { [sd1, sd2] }
   let(:ids) { [sd1['id'], sd2['id']] }
 
-  before do
-    allow(described_class).to receive(:find).and_return(docs)
-  end
-
   describe 'process_chunk' do
     before do
       allow(sd).to receive(:member_ids).and_return(ids)
+      allow(described_class).to receive(:find).and_return(docs)
       OD2::Application.config.max_members_query = 2
       sd.sort_members
     end
@@ -21,6 +18,26 @@ RSpec.describe SolrDocument do
     it 'populates children and file_sets' do
       expect(sd.children).to eq [sd2]
       expect(sd.file_sets).to eq [sd1]
+    end
+  end
+
+  describe 'max_members_query' do
+    let(:max_members_query) { 100 }
+    let(:ids) do
+      i = []
+      (0..max_members_query).each do |num|
+        i << "abc#{num}"
+      end
+      i
+    end
+
+    before do
+      allow(sd).to receive(:member_ids).and_return(ids)
+      OD2::Application.config.max_members_query = max_members_query
+    end
+
+    it 'returns without throwing too many uris error' do
+      expect { sd.sort_members }.not_to raise_error
     end
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe SolrDocument do
+  let(:sd) { described_class.new }
+  let(:sd1) { described_class.new({ 'id' => 'bcde12345', 'has_model_ssim' => ['FileSet'] }) }
+  let(:sd2) { described_class.new({ 'id' => 'cdef23456', 'has_model_ssim' => ['Image'] }) }
+  let(:docs) { [sd1, sd2] }
+  let(:ids) { [sd1['id'], sd2['id']] }
+
+  before do
+    allow(described_class).to receive(:find).and_return(docs)
+  end
+
+  describe 'process_chunk' do
+    before do
+      allow(sd).to receive(:member_ids).and_return(ids)
+      OD2::Application.config.max_members_query = 2
+      sd.sort_members
+    end
+
+    it 'populates children and file_sets' do
+      expect(sd.children).to eq [sd2]
+      expect(sd.file_sets).to eq [sd1]
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe SolrDocument do
   end
 
   describe 'max_members_query' do
+    let(:ids) do
+      i = []
+      (0..1000).each do |num|
+        i << "abc#{num}"
+      end
+      i
+    end
+
     before do
       allow(sd).to receive(:member_ids).and_return(ids)
       OD2::Application.config.max_members_query = max_members_query
@@ -29,13 +37,6 @@ RSpec.describe SolrDocument do
 
     context 'when chunk size is low' do
       let(:max_members_query) { 100 }
-      let(:ids) do
-        i = []
-        (0..max_members_query).each do |num|
-          i << "abc#{num}"
-        end
-        i
-      end
 
       it 'returns without throwing an error' do
         expect { sd.sort_members }.not_to raise_error
@@ -44,13 +45,6 @@ RSpec.describe SolrDocument do
 
     context 'when chunk size is high' do
       let(:max_members_query) { 1000 }
-      let(:ids) do
-        i = []
-        (0..max_members_query).each do |num|
-          i << "abc#{num}"
-        end
-        i
-      end
 
       it 'throws error' do
         expect { sd.sort_members }.to raise_error(Blacklight::Exceptions::InvalidRequest)


### PR DESCRIPTION
fixes #3127 
behavior is only triggered when a COUS (compound of unusual size) is included in the search results, 
RSolr::Error::Http - 414 Request-URI Too Long
