### PR TITLE
Update the display of collection breadcrumbs

### DIFF
--- a/app/controllers/oregon_digital/explore_collections_controller.rb
+++ b/app/controllers/oregon_digital/explore_collections_controller.rb
@@ -18,7 +18,9 @@ module OregonDigital
     end
 
     def page_title
-      "#{'Empty ' if @document_list.empty?}Search Results | #{@tab.titleize} Explore Collections"
+      # CONDITION: Add in a ternary case to upcase / titleize depend on value
+      @tab_title = (@tab == 'osu' || @tab == 'uo') ? @tab.upcase : @tab.titleize
+      "#{'Empty ' if @document_list.empty?}Search Results | Explore Collections / #{@tab_title}"
     end
 
     configure_blacklight do |config|
@@ -104,7 +106,7 @@ module OregonDigital
       all: 'all',
       osu: 'osu',
       uo: 'uo',
-      my: 'my'
+      my: 'my collections'
     }.freeze
   end
 end

--- a/app/controllers/oregon_digital/explore_collections_controller.rb
+++ b/app/controllers/oregon_digital/explore_collections_controller.rb
@@ -19,7 +19,7 @@ module OregonDigital
 
     def page_title
       # CONDITION: Add in a ternary case to upcase / titleize depend on value
-      @tab_title = (@tab == 'osu' || @tab == 'uo') ? @tab.upcase : @tab.titleize
+      @tab_title = (@tab == 'osu' || @tab == 'uo' ? @tab.upcase : @tab.titleize)
       "#{'Empty ' if @document_list.empty?}Search Results | Explore Collections / #{@tab_title}"
     end
 

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -312,10 +312,10 @@ en:
     controls:
       advanced: 'Advanced Search'
       explore: 'Explore Collections'
-      explore_all: 'Explore Collections/All'
-      explore_osu: 'Explore Collections/OSU'
-      explore_uo: 'Explore Collections/UO'
-      explore_my: 'Explore Collections/My Collections'
+      explore_all: 'Explore Collections / All'
+      explore_osu: 'Explore Collections / OSU'
+      explore_uo: 'Explore Collections / UO'
+      explore_my: 'Explore Collections / My Collections'
     users:
       index:
         activated: Active

--- a/spec/controllers/oregon_digital/explore_collections_controller_spec.rb
+++ b/spec/controllers/oregon_digital/explore_collections_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe OregonDigital::ExploreCollectionsController do
   describe '#build_breadcrumbs' do
     it 'adds breadcrumbs' do
       expect(controller).to receive(:add_breadcrumb).with('Home',  Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-      expect(controller).to receive(:add_breadcrumb).with('Explore Collections/All', 'all')
+      expect(controller).to receive(:add_breadcrumb).with('Explore Collections / All', 'all')
       get :all
     end
   end


### PR DESCRIPTION
`FEATURE:` Update the `breadcrumbs` and `page title` to be unison with each other to keep the consistency the same. Edit/modify is done for the `Explore Collections`.