### PR TITLE
Fix wikidata URI json id for subject and publisher fields

### DIFF
--- a/app/authorities/qa/authorities/publisher.rb
+++ b/app/authorities/qa/authorities/publisher.rb
@@ -8,5 +8,15 @@ module Qa::Authorities
     def controlled_vocabulary
       OregonDigital::ControlledVocabularies::Publisher
     end
+
+    # WikiData doesn't support a native .jsonld implementation, so we shim in the id here
+    # And parse the label as regular JSON
+    def json(url)
+      json = super
+      return json unless controlled_vocabulary.query_to_vocabulary(url) == OregonDigital::ControlledVocabularies::Vocabularies::Wikidata
+
+      json['@id'] = url
+      json
+    end
   end
 end

--- a/app/authorities/qa/authorities/subject.rb
+++ b/app/authorities/qa/authorities/subject.rb
@@ -18,5 +18,15 @@ module Qa::Authorities
     def find_term(response, q)
       { q: q, response: super }
     end
+
+    # WikiData doesn't support a native .jsonld implementation, so we shim in the id here
+    # And parse the label as regular JSON
+    def json(url)
+      json = super
+      return json unless controlled_vocabulary.query_to_vocabulary(url) == OregonDigital::ControlledVocabularies::Vocabularies::Wikidata
+
+      json['@id'] = url
+      json
+    end
   end
 end


### PR DESCRIPTION
fixes #2996 

Updates subject and publisher fields so that Wikidata URIs save to a resource and the appropriate labels show up on the work. The URIs already saved for the creators and scientifics fields.

Screenshots of various Wikidata URIs successfully saving to the subject and publisher fields:
<img width="916" alt="Labels for an Oregon Digital resource with several labels under the Subject and Publisher fields" src="https://github.com/user-attachments/assets/cba8415b-e3cb-455b-a25e-7165c62373fa">
<img width="921" alt="External URIs for Wikidata labels" src="https://github.com/user-attachments/assets/ecd27bba-e608-448f-8362-9034cca43db9">

Additional screenshots of the URIs saving to a creator and scientific field:
<img width="355" alt="Wikidata labels for creator and scientific fields" src="https://github.com/user-attachments/assets/330548f9-4a36-4509-a291-ba4caf1ceabd">

