### PR TITLE
Remove curation_concern lookup, other edits.

### DIFF
--- a/app/views/oregon_digital/oembeds/_table.html.erb
+++ b/app/views/oregon_digital/oembeds/_table.html.erb
@@ -7,15 +7,15 @@
   <tbody>
   <% file_sets.each do |file_set| %>
     <% errors = @errors.find_by(document_id: file_set.id) %>
-    <% curation_concern = Hyrax.query_service.find_parents(resource: file_set).first %>
     <tr>
-      <td class="human-readable-type"><%= curation_concern.human_readable_type %></td>
-      <th class="title" scope="row"><%= link_to file_set, edit_oembed_path(file_set)  %></th>
+      <th class="title" scope="row"><%= link_to file_set, hyrax_file_set_path(file_set) %></th>
       <td class="oembed_link"><%= link_to file_set.solr_document['oembed_url_sim'].first, file_set.solr_document['oembed_url_sim'].first %></td>
+      <td class="edit"><%= link_to 'Edit', edit_oembed_path(file_set) %></td>
       <td class="oembed_status">
-        <%= errors.nil? ? content_tag(:span, "Good", class: "label label-success") : content_tag(:span, "Error", class: "label label-danger") %>
+        <%= errors.nil? ? content_tag(:span, "Good", class: "label label-success") : content_tag(:span, "ERROR", class: "label label-danger") %>
         <%= render 'oembed_list_errors', errors: errors if show_error_list && !errors.nil? %>
       </td>
+      <td><%= file_set.solr_document['date_modified_dtsi'].to_datetime.to_s(:long) %></td>
     </tr>
   <% end %>
   </tbody>

--- a/app/views/oregon_digital/oembeds/_table_headers.html.erb
+++ b/app/views/oregon_digital/oembeds/_table_headers.html.erb
@@ -1,4 +1,5 @@
-<th><%= t('.type') %></th>
 <th><%= t('.title') %></th>
 <th><%= t('.oembed_link') %></th>
+<th><%= t('.edit') %></th>
 <th><%= t('.oembed_status') %></th>
+<th><%= t('.last_modified') %></th>

--- a/app/views/oregon_digital/oembeds/index.html.erb
+++ b/app/views/oregon_digital/oembeds/index.html.erb
@@ -1,3 +1,5 @@
+<% provide :page_title, construct_page_title(t('.manage_oembeds')) %>
+
 <% provide :page_header do %>
   <h1><span class="fa fa-sitemap"></span><%= t('.manage_oembeds') %></h1>
 <% end %>

--- a/config/locales/oregon_digital.en.yml
+++ b/config/locales/oregon_digital.en.yml
@@ -82,10 +82,11 @@ en:
         manage_oembeds: 'Manage oEmbeds'
         oembed_edit: 'Edit oEmbed'
       table_headers:
-        oembed_link: 'oEmbed Link'
-        oembed_status: 'oEmbed Status'
+        oembed_link: 'oEmbed URL'
+        oembed_status: 'Status'
         title: 'Title'
-        type: 'Type of Item'
+        edit: 'Edit'
+        last_modified: 'Last Modified'
     notifications:
       oembed_error:
         message: 'The oEmbed URL attached to a work you deposited has encountered an error (either broken or non-allowlisted URI): %{messages}'


### PR DESCRIPTION
Fixes #3153 

The lookup for the parent work on each FileSet was causing the full object to load, which doesn't scale with hundreds of entries. Further, after recent updates for Valkyrie, the value returned was only ever `Work`. I opted to remove this entirely for now, to speed up page loads.

Also moved the Edit link out, made it explicit, where the link on title goes to the FileSet. Last Modified may help for future debugging, or it could also be changed to Depositor. Added page title on the index page, and cleaned up a few labels to be more consistent.

![image](https://github.com/user-attachments/assets/3f03aa0f-7541-4a72-a05c-4c75d5c758dd)
