### PR TITLE
Add oembed url field in edit oembed file form

### DIFF
--- a/app/views/hyrax/file_sets/_form.html.erb
+++ b/app/views/hyrax/file_sets/_form.html.erb
@@ -1,0 +1,22 @@
+<%= simple_form_for [main_app, curation_concern], html: { multipart: true, class: 'nav-safety' } do |f| %>
+  <fieldset class="required">
+    <span class="col-form-label">
+      <%= label_tag 'file_set[title][]', t('.title'),  class: "string optional" %>
+    </span>
+    <%= text_field_tag 'file_set[title][]', curation_concern.title.first, class: 'form-control', required: true %>
+    
+    <% if curation_concern.oembed_url.present? %>
+      <%= f.input :oembed_url, wrapper: :inline, input_html: { value: curation_concern.oembed_url || '' } %>
+    <% end %>
+  </fieldset>
+
+  <div class="row">
+    <div class="col-md-12 form-actions">
+      <%= f.submit(
+        (curation_concern.persisted? ? t('.save') : t('.attach_to', parent: @parent.human_readable_type)),
+        class: 'btn btn-primary'
+      ) %>
+      <%= link_to t('.cancel'), parent_path(@parent), class: 'btn btn-link' %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
Closes #3177 

Screenshots:
Edit form for oembed file:
<img width="816" alt="Edit form for oembed file" src="https://github.com/user-attachments/assets/82c1dd1c-d21d-427b-b39e-eef93346242d">


Edit form for non-oembed file:
<img width="816" alt="Edit form for non-oembed file" src="https://github.com/user-attachments/assets/8b413a92-b0f4-4b63-9ce5-638c266f3185">
