### PR TITLE
Revert "Solrize CVs with consistant https scheme"

### DIFF
--- a/lib/hyrax/controlled_vocabularies/location.rb
+++ b/lib/hyrax/controlled_vocabularies/location.rb
@@ -20,7 +20,7 @@ module Hyrax
         return [rdf_subject.to_s] if rdf_label.first.to_s.blank? || rdf_label_uri_same?
 
         fetch
-        [storage_uri.to_s, { label: "#{rdf_label.first}$#{storage_uri}" }]
+        [rdf_subject.to_s, { label: "#{rdf_label.first}$#{rdf_subject}" }]
       end
 
       # Overrides rdf_label to add location disambiguation when available.
@@ -131,12 +131,6 @@ module Hyrax
       end
 
       private
-
-      def storage_uri
-        standard_uri = URI.parse(rdf_subject.to_s)
-        standard_uri.scheme = 'https'
-        RDF::URI.new(standard_uri)
-      end
 
       # Identify if this is a county in the USA
       def us_county?

--- a/lib/oregon_digital/controlled_vocabularies/resource.rb
+++ b/lib/oregon_digital/controlled_vocabularies/resource.rb
@@ -74,17 +74,11 @@ module OregonDigital
       end
       # rubocop:enable AccessorMethodName
 
-      def storage_uri
-        standard_uri = URI.parse(rdf_subject.to_s)
-        standard_uri.scheme = 'https'
-        RDF::URI.new(standard_uri)
-      end
-
       # Return a tuple of url & label
       def solrize
         return [rdf_subject.to_s] if rdf_label.first.to_s.blank? || rdf_label_uri_same?
 
-        [storage_uri.to_s, { label: "#{language_label(get_language_label(rdf_label))}$#{storage_uri}" }]
+        [rdf_subject.to_s, { label: "#{language_label(get_language_label(rdf_label))}$#{rdf_subject}" }]
       end
 
       # Sanity check for valid rdf_subject. Subject should never be blank but in the event,
@@ -123,7 +117,7 @@ module OregonDigital
 
       # Return the URI as a string
       def to_s
-        respond_to?(:rdf_subject) ? solrize.first : super
+        respond_to?(:rdf_subject) ? rdf_subject.to_s : super
       end
 
       private

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/spar_media_type.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/spar_media_type.rb
@@ -5,7 +5,7 @@ module OregonDigital
     # Receives information pulled from the endpoint and can parse and generate queries
     class SparMediaType
       def self.expression
-        %r{^http[s]:\/\/w3id.org\/spar\/mediatype\/.*/.*}
+        %r{^https:\/\/w3id.org\/spar\/mediatype\/.*/.*}
       end
 
       def self.label(data)

--- a/spec/hyrax/controlled_vocabularies/location_spec.rb
+++ b/spec/hyrax/controlled_vocabularies/location_spec.rb
@@ -60,28 +60,28 @@ RSpec.describe Hyrax::ControlledVocabularies::Location do
     context 'with a valid label and subject' do
       before do
         allow(location).to receive(:rdf_label).and_return(['RDF_Label'])
-        allow(location).to receive(:rdf_subject).and_return('http://RDF.Subject.Org')
+        allow(location).to receive(:rdf_subject).and_return('RDF.Subject.Org')
       end
 
-      it { expect(location.solrize).to eq ['https://RDF.Subject.Org', { label: 'RDF_Label$https://RDF.Subject.Org' }] }
+      it { expect(location.solrize).to eq ['RDF.Subject.Org', { label: 'RDF_Label$RDF.Subject.Org' }] }
     end
 
     context 'without a label' do
       before do
         allow(location).to receive(:rdf_label).and_return([''])
-        allow(location).to receive(:rdf_subject).and_return('http://RDF.Subject.Org')
+        allow(location).to receive(:rdf_subject).and_return('RDF.Subject.Org')
       end
 
-      it { expect(location.solrize).to eq ['http://RDF.Subject.Org'] }
+      it { expect(location.solrize).to eq ['RDF.Subject.Org'] }
     end
 
     context 'when label and uri are the same' do
       before do
-        allow(location).to receive(:rdf_label).and_return(['http://RDF.Subject.Org'])
-        allow(location).to receive(:rdf_subject).and_return('http://RDF.Subject.Org')
+        allow(location).to receive(:rdf_label).and_return(['RDF.Subject.Org'])
+        allow(location).to receive(:rdf_subject).and_return('RDF.Subject.Org')
       end
 
-      it { expect(location.solrize).to eq ['http://RDF.Subject.Org'] }
+      it { expect(location.solrize).to eq ['RDF.Subject.Org'] }
     end
   end
 

--- a/spec/oregon_digital/controlled_vocabularies/institution_spec.rb
+++ b/spec/oregon_digital/controlled_vocabularies/institution_spec.rb
@@ -28,28 +28,28 @@ RSpec.describe OregonDigital::ControlledVocabularies::Institution do
     context 'with a valid label and subject' do
       before do
         allow(vocab_inst).to receive(:rdf_label).and_return([RDF::Literal.new('RDF_Label', language: I18n.locale)])
-        allow(vocab_inst).to receive(:rdf_subject).and_return('http://RDF.Subject.Org')
+        allow(vocab_inst).to receive(:rdf_subject).and_return('RDF.Subject.Org')
       end
 
-      it { expect(vocab_inst.solrize).to eq ['https://RDF.Subject.Org', { label: 'RDF_Label$https://RDF.Subject.Org' }] }
+      it { expect(vocab_inst.solrize).to eq ['RDF.Subject.Org', { label: 'RDF_Label$RDF.Subject.Org' }] }
     end
 
     context 'without a label' do
       before do
         allow(vocab_inst).to receive(:rdf_label).and_return([])
-        allow(vocab_inst).to receive(:rdf_subject).and_return('http://RDF.Subject.Org')
+        allow(vocab_inst).to receive(:rdf_subject).and_return('RDF.Subject.Org')
       end
 
-      it { expect(vocab_inst.solrize).to eq ['http://RDF.Subject.Org'] }
+      it { expect(vocab_inst.solrize).to eq ['RDF.Subject.Org'] }
     end
 
     context 'when label and uri are the same' do
       before do
-        allow(vocab_inst).to receive(:rdf_label).and_return([RDF::Literal.new('http://RDF.Subject.Org', language: I18n.locale)])
-        allow(vocab_inst).to receive(:rdf_subject).and_return('http://RDF.Subject.Org')
+        allow(vocab_inst).to receive(:rdf_label).and_return([RDF::Literal.new('RDF.Subject.Org', language: I18n.locale)])
+        allow(vocab_inst).to receive(:rdf_subject).and_return('RDF.Subject.Org')
       end
 
-      it { expect(vocab_inst.solrize).to eq ['http://RDF.Subject.Org'] }
+      it { expect(vocab_inst.solrize).to eq ['RDF.Subject.Org'] }
     end
   end
 end

--- a/spec/oregon_digital/controlled_vocabularies/resource_spec.rb
+++ b/spec/oregon_digital/controlled_vocabularies/resource_spec.rb
@@ -13,28 +13,28 @@ RSpec.describe OregonDigital::ControlledVocabularies::Resource do
     context 'with a valid label and subject' do
       before do
         allow(resource).to receive(:rdf_label).and_return(['RDF_Label'])
-        allow(resource).to receive(:rdf_subject).and_return('http://RDF.Subject.Org')
+        allow(resource).to receive(:rdf_subject).and_return('RDF.Subject.Org')
       end
 
-      it { expect(resource.solrize).to eq ['https://RDF.Subject.Org', { label: 'RDF_Label$https://RDF.Subject.Org' }] }
+      it { expect(resource.solrize).to eq ['RDF.Subject.Org', { label: 'RDF_Label$RDF.Subject.Org' }] }
     end
 
     context 'without a label' do
       before do
         allow(resource).to receive(:rdf_label).and_return([''])
-        allow(resource).to receive(:rdf_subject).and_return('http://RDF.Subject.Org')
+        allow(resource).to receive(:rdf_subject).and_return('RDF.Subject.Org')
       end
 
-      it { expect(resource.solrize).to eq ['http://RDF.Subject.Org'] }
+      it { expect(resource.solrize).to eq ['RDF.Subject.Org'] }
     end
 
     context 'when label and uri are the same' do
       before do
-        allow(resource).to receive(:rdf_label).and_return(['http://RDF.Subject.Org'])
-        allow(resource).to receive(:rdf_subject).and_return('http://RDF.Subject.Org')
+        allow(resource).to receive(:rdf_label).and_return(['RDF.Subject.Org'])
+        allow(resource).to receive(:rdf_subject).and_return('RDF.Subject.Org')
       end
 
-      it { expect(resource.solrize).to eq ['http://RDF.Subject.Org'] }
+      it { expect(resource.solrize).to eq ['RDF.Subject.Org'] }
     end
   end
 


### PR DESCRIPTION
Reverts OregonDigital/OD2#3056

Reverting this for now, since there's still problems with #1342.

We'll revisit next workcycle, but need to be sure this works reliably for new works, existing works, and via the form, console, and bulkrax.