### PR TITLE
Revert "Update institution_picker.rb"

### DIFF
--- a/app/services/oregon_digital/institution_picker.rb
+++ b/app/services/oregon_digital/institution_picker.rb
@@ -40,11 +40,11 @@ module OregonDigital
       end
 
       def osu
-        ['https://id.loc.gov/authorities/names/n80017721']
+        ['http://id.loc.gov/authorities/names/n80017721']
       end
 
       def uo
-        ['https://id.loc.gov/authorities/names/n80126183']
+        ['http://id.loc.gov/authorities/names/n80126183']
       end
     end
   end

--- a/spec/services/oregon_digital/institution_picker_spec.rb
+++ b/spec/services/oregon_digital/institution_picker_spec.rb
@@ -3,10 +3,10 @@
 RSpec.describe OregonDigital::InstitutionPicker do
   let(:picker) { described_class }
   let(:collection) { ::Collection.new }
-  let(:osu_array) { ['https://id.loc.gov/authorities/names/n80017721'] }
-  let(:uo_array) { ['https://id.loc.gov/authorities/names/n80126183'] }
+  let(:osu_array) { ['http://id.loc.gov/authorities/names/n80017721'] }
+  let(:uo_array) { ['http://id.loc.gov/authorities/names/n80126183'] }
   let(:junk_array) { ['blah', 1] }
-  let(:both_array) { ['https://id.loc.gov/authorities/names/n80126183', 'https://id.loc.gov/authorities/names/n80017721'] }
+  let(:both_array) { ['http://id.loc.gov/authorities/names/n80126183', 'http://id.loc.gov/authorities/names/n80017721'] }
 
   describe '#institution_acronym' do
     context 'when osu array is present' do


### PR DESCRIPTION
Reverts OregonDigital/OD2#3193

Changing back until more of the http/https changes can get in, for #1342. Without those, there's no label for the Institutions fetched if Institution URIs are changed to `https`