### PR TITLE
Revert "Update only institution behavior"

### DIFF
--- a/app/search_builders/oregon_digital/only_osu_collections_behavior.rb
+++ b/app/search_builders/oregon_digital/only_osu_collections_behavior.rb
@@ -8,7 +8,7 @@ module OregonDigital
     included do
       def show_only_osu_collections(solr_parameters)
         clauses = [
-          '(_query_:"{!raw f=institution_sim}https://id.loc.gov/authorities/names/n80017721")'
+          '(_query_:"{!raw f=institution_sim}http://id.loc.gov/authorities/names/n80017721")'
         ]
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += ["(#{clauses.join(' AND ')})"]

--- a/app/search_builders/oregon_digital/only_uo_collections_behavior.rb
+++ b/app/search_builders/oregon_digital/only_uo_collections_behavior.rb
@@ -8,7 +8,7 @@ module OregonDigital
     included do
       def show_only_uo_collections(solr_parameters)
         clauses = [
-          '(_query_:"{!raw f=institution_sim}https://id.loc.gov/authorities/names/n80126183")'
+          '(_query_:"{!raw f=institution_sim}http://id.loc.gov/authorities/names/n80126183")'
         ]
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] += ["(#{clauses.join(' AND ')})"]


### PR DESCRIPTION
Reverts OregonDigital/OD2#3194

Changing back until more of the http/https changes can get in, for #1342. Without those, there's no label for the Institutions fetched if Institution URIs are changed to `https`