### PR TITLE
Block https loc

### DIFF
--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/getty_aat.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/getty_aat.rb
@@ -5,7 +5,7 @@ module OregonDigital
     # Receives information pulled from the endpoint and can parse and generate queries
     class GettyAat < GettyBase
       def self.expression
-        %r{^http[s]?:\/\/vocab.getty.edu\/aat\/.*}
+        %r{^http:\/\/vocab.getty.edu\/aat\/.*}
       end
     end
   end

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/getty_tgn.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/getty_tgn.rb
@@ -5,7 +5,7 @@ module OregonDigital
     # Receives information pulled from the endpoint and can parse and generate queries
     class GettyTgn < GettyBase
       def self.expression
-        %r{^http[s]?:\/\/vocab.getty.edu\/tgn\/.*}
+        %r{^http:\/\/vocab.getty.edu\/tgn\/.*}
       end
     end
   end

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/getty_ulan.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/getty_ulan.rb
@@ -5,7 +5,7 @@ module OregonDigital
     # Receives information pulled from the endpoint and can parse and generate queries
     class GettyUlan < GettyBase
       def self.expression
-        %r{^http[s]?:\/\/vocab.getty.edu\/ulan\/.*}
+        %r{^http:\/\/vocab.getty.edu\/ulan\/.*}
       end
     end
   end

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/loc_ethnographic_terms.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/loc_ethnographic_terms.rb
@@ -5,7 +5,7 @@ module OregonDigital
     # Receives information pulled from the endpoint and can parse and generate queries
     class LocEthnographicTerms
       def self.expression
-        %r{^http[s]?:\/\/id.loc.gov\/vocabulary\/ethnographicTerms\/.*}
+        %r{^http:\/\/id.loc.gov\/vocabulary\/ethnographicTerms\/.*}
       end
 
       def self.label(data)

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/loc_genre_forms.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/loc_genre_forms.rb
@@ -5,7 +5,7 @@ module OregonDigital
     # Receives information pulled from the endpoint and can parse and generate queries
     class LocGenreForms
       def self.expression
-        %r{^http[s]?:\/\/id.loc.gov\/authorities\/genreForms\/.*}
+        %r{^http:\/\/id.loc.gov\/authorities\/genreForms\/.*}
       end
 
       def self.label(data)

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/loc_graphic_materials.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/loc_graphic_materials.rb
@@ -5,7 +5,7 @@ module OregonDigital
     # Receives information pulled from the endpoint and can parse and generate queries
     class LocGraphicMaterials
       def self.expression
-        %r{^http[s]?:\/\/id.loc.gov\/vocabulary\/graphicMaterials\/.*}
+        %r{^http:\/\/id.loc.gov\/vocabulary\/graphicMaterials\/.*}
       end
 
       def self.label(data)

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/loc_names.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/loc_names.rb
@@ -5,7 +5,7 @@ module OregonDigital
     # Receives information pulled from the endpoint and can parse and generate queries
     class LocNames
       def self.expression
-        %r{^http[s]?:\/\/id.loc.gov\/authorities\/names\/.*}
+        %r{^http:\/\/id.loc.gov\/authorities\/names\/.*}
       end
 
       def self.label(data)

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/loc_orgs.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/loc_orgs.rb
@@ -5,7 +5,7 @@ module OregonDigital
     # Receives information pulled from the endpoint and can parse and generate queries
     class LocOrgs
       def self.expression
-        %r{^http[s]?:\/\/id.loc.gov\/vocabulary\/organizations\/.*}
+        %r{^http:\/\/id.loc.gov\/vocabulary\/organizations\/.*}
       end
 
       def self.label(data)

--- a/lib/oregon_digital/controlled_vocabularies/vocabularies/loc_subjects.rb
+++ b/lib/oregon_digital/controlled_vocabularies/vocabularies/loc_subjects.rb
@@ -5,7 +5,7 @@ module OregonDigital
     # Receives information pulled from the endpoint and can parse and generate queries
     class LocSubjects
       def self.expression
-        %r{^http[s]?:\/\/id.loc.gov\/authorities\/subjects\/.*}
+        %r{^http:\/\/id.loc.gov\/authorities\/subjects\/.*}
       end
 
       def self.label(data)


### PR DESCRIPTION
fixes #3238 
block uris using https for LOC and Getty. Attempting to create a new vocab with one will result in  OregonDigital::ContolledVocabularies::ControlledVocabularyError: Term not in controlled vocabulary.