### PR TITLE
Feature/header bootstrap upgrade

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -13,8 +13,11 @@ $medium-grey: #999999;
 $light-grey: #CCCCCC;
 $very-light-grey: #ECECEC;
 
-$brand-primary: $navy-blue;
-// $brand-primary: $apple-green;
+$primary: $navy-blue;
+
+$theme-colors: (
+    primary: $primary
+);
 
 // Change bootstrap grid breakpoints
 $grid-gutter-width: 30px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@
  *= require cookieconsent
 */
 
+@import "_variables";
 @import "bootstrap";
 @import "*";
 @import "blacklight/**/*";

--- a/app/assets/stylesheets/oregon_digital/_advanced.scss
+++ b/app/assets/stylesheets/oregon_digital/_advanced.scss
@@ -80,7 +80,7 @@
   }
 
   select {
-    border: 3px solid $brand-primary;
+    border: 3px solid $primary;
     padding: .25em;
     padding-right: .75em;
 

--- a/app/assets/stylesheets/oregon_digital/_breadcrumbs.scss
+++ b/app/assets/stylesheets/oregon_digital/_breadcrumbs.scss
@@ -12,8 +12,10 @@
 .breadcrumb {
   background: none;
   border: none;
+  margin-top: 0;
   margin-bottom: 0;
-  padding: 1em 0;
+  padding-bottom: 1em;
+  padding-top: 1.5em;
 }
 
 // Dashboard nav needs to act like main content

--- a/app/assets/stylesheets/oregon_digital/_buttons.scss
+++ b/app/assets/stylesheets/oregon_digital/_buttons.scss
@@ -41,8 +41,8 @@ input.link {
   &.btn-outline {
     background: unset;
     border-radius: 0 !important;
-    border: 3px solid $brand-primary;
-    color: $brand-primary;
+    border: 3px solid $primary;
+    color: $primary;
     margin: 0 5px;
     &:hover,
     &:focus {
@@ -64,8 +64,8 @@ input.link {
 }
 
 .btn-default {
-  color: $brand-primary;
-  border: 3px solid $brand-primary;
+  color: $primary;
+  border: 3px solid $primary;
 }
 
 /* increase checkbox size */

--- a/app/assets/stylesheets/oregon_digital/_header.scss
+++ b/app/assets/stylesheets/oregon_digital/_header.scss
@@ -182,6 +182,10 @@ header {
       }
     }
     #user-util-links {
+      li {
+        font-size: 0.875rem;
+      }
+      
       @media (max-width: breakpoint-max(sm)) {
         position: static;
         float: none;

--- a/app/assets/stylesheets/oregon_digital/_header.scss
+++ b/app/assets/stylesheets/oregon_digital/_header.scss
@@ -78,6 +78,12 @@ header {
     padding-bottom:15px
   }
 
+  #user_utility_links {
+    @media (min-width: breakpoint-min(lg)) {
+      margin-right: -15px;
+    }
+  }
+
   ul.nav {
     a.explore-collections {
       padding: 10px 15px;
@@ -144,7 +150,7 @@ header {
     box-shadow: 0 0 10px $dark-grey;
     border-width: 0 0 5px 0;
     padding: 1em 2em;
-    @media (max-width: breakpoint-min(sm)) {
+    @media (max-width: breakpoint-min(md)) {
       & {
         padding: .5em;
       }
@@ -152,6 +158,8 @@ header {
 
     .container-fluid {
       flex-wrap: wrap;
+      padding-left: 15px;
+      padding-right: 15px;
     }
   }
 
@@ -187,6 +195,7 @@ header {
         li {
           font-size: 16px;
         }
+        
         .my-account-option {
           margin: .25em 0;
         }

--- a/app/assets/stylesheets/oregon_digital/_header.scss
+++ b/app/assets/stylesheets/oregon_digital/_header.scss
@@ -80,6 +80,7 @@ header {
 
   ul.nav {
     a.explore-collections {
+      padding: 10px 15px;
       padding-bottom: 2px;
       font-weight: 700;
       @media (max-width: breakpoint-max(sm)) {

--- a/app/assets/stylesheets/oregon_digital/_header.scss
+++ b/app/assets/stylesheets/oregon_digital/_header.scss
@@ -7,17 +7,22 @@ header {
     // Move searchbar back down
     margin-top: 0;
   }
-  .navbar-toggle {
+  .navbar-toggler#main-nav-toggler {
+    border-color: transparent;
+
     &:focus {
       outline: revert;
     }
-    .icon-bar {
-      background-color: $navy-blue;
+    .navbar-toggler-icon {
+      display: inline-block;
     }
   }
   .navbar-header {
-    display: grid;
-    grid-template-columns: 1fr auto;
+    display: flex;
+    flex-grow: 1;
+    justify-content: space-between;
+    margin-right: -15px;
+    margin-left: -15px;
   }
   .navbar-header:before {
     display: unset;
@@ -68,11 +73,16 @@ header {
     }
   }
 
+  .navbar-nav > li > a {
+    padding-top:15px;
+    padding-bottom:15px
+  }
+
   ul.nav {
     a.explore-collections {
       padding-bottom: 2px;
       font-weight: 700;
-      @media (max-width: breakpoint-max(xs)) {
+      @media (max-width: breakpoint-max(sm)) {
         display: inline-block;
         font-size: 20px;
         margin-bottom: 2em;
@@ -82,7 +92,7 @@ header {
       padding: 0 2em;
     }
     form {
-      @media (max-width: breakpoint-max(xs)) {
+      @media (max-width: breakpoint-max(sm)) {
         padding-bottom: 2em;
       }
 
@@ -91,18 +101,18 @@ header {
         font-weight: 700;
         padding: 0;
 
-        @media (min-width: breakpoint-min(sm)) {
+        @media (min-width: breakpoint-min(md)) {
           & {
             float: right;
           }
         }
-        @media (max-width: breakpoint-max(xs)) {
+        @media (max-width: breakpoint-max(sm)) {
           font-size: 1.25em;
         }
       }
       .input-group {
         margin: auto;
-        @media (max-width: breakpoint-max(sm)) {
+        @media (max-width: breakpoint-max(lg)) {
           width: 75%;
         }
 
@@ -138,10 +148,18 @@ header {
         padding: .5em;
       }
     }
+
+    .container-fluid {
+      flex-wrap: wrap;
+    }
   }
 
   #top-navbar-collapse {
     letter-spacing: 2px;
+
+    @media (max-width: breakpoint-max(lg)) {
+      justify-content: flex-start !important;
+    }
 
     .divider {
       height: 1px;
@@ -150,12 +168,12 @@ header {
     }
 
     #user-dropdown {
-      @media (max-width: breakpoint-max(xs)) {
+      @media (max-width: breakpoint-max(sm)) {
         display: none;
       }
     }
     #user-util-links {
-      @media (max-width: breakpoint-max(xs)) {
+      @media (max-width: breakpoint-max(sm)) {
         position: static;
         float: none;
         width: auto;
@@ -171,12 +189,6 @@ header {
         .my-account-option {
           margin: .25em 0;
         }
-      }
-    }
-
-    .navbar-left-sm {
-      @media (max-width: breakpoint-max(sm)) and (min-width: breakpoint-min(sm)) {
-        float: left !important;
       }
     }
   }

--- a/app/builders/hyrax/bootstrap_breadcrumbs_builder.rb
+++ b/app/builders/hyrax/bootstrap_breadcrumbs_builder.rb
@@ -16,8 +16,8 @@ class Hyrax::BootstrapBreadcrumbsBuilder < BreadcrumbsOnRails::Breadcrumbs::Buil
   def render
     return '' if @elements.blank?
 
-    @context.tag.nav(breadcrumbs_options) do
-      @context.tag.ol do
+    @context.content_tag(:nav, breadcrumbs_options) do
+      @context.content_tag(:ol) do
         safe_join(@elements.uniq.collect { |e| render_element(e) })
       end
     end
@@ -27,7 +27,7 @@ class Hyrax::BootstrapBreadcrumbsBuilder < BreadcrumbsOnRails::Breadcrumbs::Buil
     html_class = 'active' if @context.current_page?(compute_path(element)) || element.options['aria-current'] == 'page'
     element.options['aria-current'] = 'page' if html_class
 
-    @context.tag.li(class: html_class) do
+    @context.content_tag(:li, class: html_class) do
       @context.link_to(@context.truncate(compute_name(element), length: 30, separator: ' '), compute_path(element), element.options)
     end
   end

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,6 +1,6 @@
 <a id="logo" class="navbar-brand" href="<%= hyrax.root_path %>" data-no-turbolink="true">
   <%= image_tag('logo.png', height: '64', width: '64', alt: '', class: 'logo') %>
   <div class="institution_name"><span class="h1 application-title"><%= application_name %></span>
-    <span class="tagline hidden-xs"><%= 'Unique Cultural Heritage Collections' %></span>
+    <span class="tagline d-none d-md-block"><%= 'Unique Cultural Heritage Collections' %></span>
   </div>
 </a>

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,19 +1,16 @@
 <!-- OVERRIDDEN FROM HYRAX TO PUSH THROUGH THE CHANGES TO _user_util_links -->
 <header class="header dropshadow-align" aria-label="header">
-  <nav id="masthead" class="navbar navbar-static-top">
+  <nav id="masthead" class="navbar navbar-light navbar-expand-md fixed-top">
     <div class="container-fluid">
-      <!-- Brand and toggle get grouped for better mobile display -->
-      <div class="navbar-header">
-        <%= render '/logo' %>
-        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
-          <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-        </button>
-      </div>
 
-      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+      <div class="navbar-header"> 
+        <%= render '/logo' %>
+        <button class="navbar-toggler" id="main-nav-toggler" type="button" data-toggle="collapse" data-target="#top-navbar-collapse" aria-controls="top-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+      </div> 
+
+      <div class="collapse navbar-collapse justify-content-end" id="top-navbar-collapse">
         <%= render '/user_util_links' %>
       </div>
     </div>

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -8,24 +8,23 @@
   <li class="divider"></li>
   <% if user_signed_in? %>
     <li class="dropdown">
-      <%= link_to hyrax.dashboard_profile_path(current_user), id: 'user-dropdown', class: ['btn', 'btn-outline'],role: 'button', data: { toggle: 'dropdown' }, aria: { expanded: false, controls: 'user-util-links' } do %>
+      <%= link_to hyrax.dashboard_profile_path(current_user), id: 'user-dropdown', class: ['btn', 'btn-outline', 'dropdown-toggle'],role: 'button', data: { toggle: 'dropdown' }, aria: { expanded: false, controls: 'user-util-links' } do %>
         <span class="fa fa-user" aria-hidden="true"></span>
-        <span class="hidden-xs">&nbsp;My Account</span>
-        <span class="caret-dropdown"></span>
+        <span class="d-none d-sm-inline-block">&nbsp;My Account</span>
       <% end %>
       <ul id="user-util-links" class="dropdown-menu dropdown-menu-right text-center">
         <% if user_signed_in? %>
-          <li class="my-account-option"><%= link_to current_user.email, hyrax.user_path(current_user), tabindex: -1 %></li>
+          <li class="my-account-option dropdown-item"><%= link_to current_user.email, hyrax.user_path(current_user), tabindex: -1 %></li>
         <% end %>
         <% if (can? :create, ActiveFedora::Base) || current_user&.sipity_agent&.workflow_responsibilities&.count&.positive? %>
-          <li class="my-account-option"><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path, tabindex: -1 %></li>
+          <li class="my-account-option dropdown-item"><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path, tabindex: -1 %></li>
         <% end %>
-        <li class="my-account-option"><%= link_to 'My Collections', Rails.application.routes.url_helpers.my_collections_path, tabindex: -1 %></li>
+        <li class="my-account-option dropdown-item"><%= link_to 'My Collections', Rails.application.routes.url_helpers.my_collections_path, tabindex: -1 %></li>
         <% unless OregonDigital::UserAttributeService.new(current_user).institutional_user? %>
-          <li class="my-account-option"><%= link_to "Change your password", edit_registration_path(current_user), tabindex: -1 %></li>
+          <li class="my-account-option dropdown-item"><%= link_to "Change your password", edit_registration_path(current_user), tabindex: -1 %></li>
         <% end %>
         <li class="divider"></li>
-        <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path, tabindex: -1 %></li>
+        <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path, class: ['dropdown-item'], tabindex: -1 %></li>
       </ul>
     </li><!-- /.btn-group -->
   <% else %>

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,4 +1,4 @@
-<ul id="user_utility_links" class="nav navbar-nav navbar-right navbar-left-sm text-center center-navbar">
+<ul id="user_utility_links" class="nav navbar-nav text-center">
   <li>
     <%= link_to 'Explore Collections', Rails.application.routes.url_helpers.all_collections_path, class: 'explore-collections visible-all-inline-block lato-b' %>
   </li>
@@ -8,7 +8,7 @@
   <li class="divider"></li>
   <% if user_signed_in? %>
     <li class="dropdown">
-      <%= link_to hyrax.dashboard_profile_path(current_user), id: 'user-dropdown', class: ['btn', 'btn-outline', 'dropdown-toggle'],role: 'button', data: { toggle: 'dropdown' }, aria: { expanded: false, controls: 'user-util-links' } do %>
+      <%= link_to hyrax.dashboard_profile_path(current_user), id: 'user-dropdown', class: ['btn', 'btn-sm', 'btn-outline', 'dropdown-toggle'],role: 'button', data: { toggle: 'dropdown' }, aria: { expanded: false, controls: 'user-util-links' } do %>
         <span class="fa fa-user" aria-hidden="true"></span>
         <span class="d-none d-sm-inline-block">&nbsp;My Account</span>
       <% end %>

--- a/app/views/shared/_header_search.html.erb
+++ b/app/views/shared/_header_search.html.erb
@@ -15,6 +15,6 @@
 
   </div><!-- /.form-group -->
   <%= link_to BlacklightAdvancedSearch::Engine.routes.url_helpers.advanced_search_path, class: 'advanced-link' do %>
-    Advanced <span class="hidden visible-xs-inline-block">Search</span>
+    Advanced <span class="d-sm-inline-block d-md-none">Search</span>
   <% end %>
 <% end %>


### PR DESCRIPTION
Closes #3214 

## Changes
- Collapse toggle now only appears at responsive break point
- Dropdown toggle has hamburger icon and is no longer styled as default button
  - New bootstrap hamburger icon does not allow for recolors. Maybe should look into Font Awesome hamburger icon?
- Fixes navbar layout at responsive breakpoints
- Updates breadcrumb builder so that it maintains the styling from production
- Sets primary theme color to production "brand-primary" color
- Various class name changes

## Screenshots
### Header at full width
<img width="1497" alt="Oregon Digital header" src="https://github.com/user-attachments/assets/c7a2fb3a-f1f7-4461-96f0-cf975b520354" />


### Mobile header
#### Expanded
<img width="410" alt="Oregon Digital expanded mobile header" src="https://github.com/user-attachments/assets/9773030f-101a-4501-aa53-b8361e33e06f" />

#### Collapsed

<img width="405" alt="Oregon Digital collapsed mobile header" src="https://github.com/user-attachments/assets/1bbbe5c8-ab3e-461c-894e-fe8f31f462be" />

