### PR TITLE
Show ordered children

### DIFF
--- a/app/controllers/concerns/oregon_digital/work_relation_pagination_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/work_relation_pagination_behavior.rb
@@ -3,6 +3,7 @@
 module OregonDigital
   # Behavior for displaying relationships with pagination
   module WorkRelationPaginationBehavior
+    COUNT = 4
     # Include 'catalog' in the search path for views, while prefering
     # our local paths. Thus we are unable to just override `self.local_prefixes`
     def _prefixes
@@ -13,10 +14,11 @@ module OregonDigital
     # Finds a solr document matching the id and sets @presenter
     # @raise CanCan::AccessDenied if the document is not found or the user doesn't have access to it.
     def show
-      blacklight_config.per_page = [4]
+      blacklight_config.per_page = [COUNT]
       parent_results
       sibling_results
       child_results
+      ordered_child_results
       @search_builder_class = Hyrax::WorkSearchBuilder
       super
     end
@@ -41,11 +43,42 @@ module OregonDigital
       (@sibling_response, @sibling_doc_list) = search_results(params)
     end
 
-    # get all child documents
+    # get all child works for response
     def child_results
       @search_builder_class = OregonDigital::ChildrenOfWorkSearchBuilder
       params[:page] = params[:child_page]
-      (@child_response, @child_doc_list) = search_results(params)
+      (@child_response,) = search_results(params)
+    end
+
+    # hacky method for getting one page of child docs in order
+    def ordered_child_results
+      @search_builder_class = OregonDigital::OrderedChildrenOfWorkSearchBuilder
+      (_, @child_doc_list) = search_results(params)
+      @child_doc_list = sort_by_ordered(@child_doc_list, start(params[:child_page]))
+    end
+
+    def sort_by_ordered(doc_list, start_ind)
+      ordered_docs = []
+      query_for_ordered_ids.slice(start_ind, COUNT).each do |id|
+        ordered_docs << doc_list.find { |x| x['id'] == id }
+      end
+      ordered_docs.compact
+    end
+
+    def start(page)
+      return 0 if page.nil?
+
+      (page.to_i - 1) * COUNT
+    end
+
+    # copied from Hyrax::SolrDocument::OrderedMembers
+    def query_for_ordered_ids(limit: 10_000,
+                              proxy_field: 'proxy_in_ssi',
+                              target_field: 'ordered_targets_ssim')
+      Hyrax::SolrService
+        .query("#{proxy_field}:#{params['id']}", rows: limit, fl: target_field)
+        .flat_map { |x| x.fetch(target_field, nil) }
+        .compact
     end
   end
 end

--- a/app/search_builders/oregon_digital/ordered_children_of_work_search_builder.rb
+++ b/app/search_builders/oregon_digital/ordered_children_of_work_search_builder.rb
@@ -12,11 +12,12 @@ module OregonDigital
       super(options.first)
       @child_page = options.first.params['child_page']
       options.first.params['page'] = '1'
+      @count = blacklight_config.per_page.first
     end
 
     def ordered_child_works(solr_params)
       ids = query_for_ordered_ids || ['""']
-      ids = ids.slice(find_start(@child_page), 4)
+      ids = ids.slice(find_start(@child_page), @count)
       solr_params[:fq] ||= []
       solr_params[:fq] << "id:(#{ids.join(' OR ')})"
       solr_params[:fq] << '-has_model_ssim:*FileSet'
@@ -25,7 +26,7 @@ module OregonDigital
     def find_start(page)
       return 0 if page.nil?
 
-      return (page.to_i - 1) * 4
+      return (page.to_i - 1) * @count
     end
 
     # copied from Hyrax::SolrDocument::OrderedMembers

--- a/app/search_builders/oregon_digital/ordered_children_of_work_search_builder.rb
+++ b/app/search_builders/oregon_digital/ordered_children_of_work_search_builder.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal:true
+
+module OregonDigital
+  # Finds subset of ordered child works, i.e. for a given page
+  class OrderedChildrenOfWorkSearchBuilder < Hyrax::SearchBuilder
+    self.default_processor_chain += [:ordered_child_works]
+
+    attr_reader :work
+
+    def initialize(*options, work:)
+      @work = work
+      super(options.first)
+      @child_page = options.first.params['child_page']
+      options.first.params['page'] = '1'
+    end
+
+    def ordered_child_works(solr_params)
+      ids = query_for_ordered_ids || ['""']
+      ids = ids.slice(find_start(@child_page), 4)
+      solr_params[:fq] ||= []
+      solr_params[:fq] << "id:(#{ids.join(' OR ')})"
+      solr_params[:fq] << '-has_model_ssim:*FileSet'
+    end
+
+    def find_start(page)
+      return 0 if page.nil?
+
+      return (page.to_i - 1) * 4
+    end
+
+    # copied from Hyrax::SolrDocument::OrderedMembers
+    def query_for_ordered_ids(limit: 10_000,
+                              proxy_field: 'proxy_in_ssi',
+                              target_field: 'ordered_targets_ssim')
+      Hyrax::SolrService
+        .query("#{proxy_field}:#{@work.id}", rows: limit, fl: target_field)
+        .flat_map { |x| x.fetch(target_field, nil) }
+        .compact
+    end
+  end
+end

--- a/app/search_builders/oregon_digital/ordered_children_of_work_search_builder.rb
+++ b/app/search_builders/oregon_digital/ordered_children_of_work_search_builder.rb
@@ -18,7 +18,7 @@ module OregonDigital
     end
 
     def ordered_child_works(solr_params)
-      ids = query_for_ordered_ids || ['""']
+      ids = @work.ordered_member_ids || ['""']
       ids = ids.slice(find_start(@child_page), @count)
       solr_params[:fq] ||= []
       solr_params[:fq] << "id:(#{ids.join(' OR ')})"
@@ -29,16 +29,6 @@ module OregonDigital
       return 0 if page.nil?
 
       return (page.to_i - 1) * @count
-    end
-
-    # copied from Hyrax::SolrDocument::OrderedMembers
-    def query_for_ordered_ids(limit: 10_000,
-                              proxy_field: 'proxy_in_ssi',
-                              target_field: 'ordered_targets_ssim')
-      Hyrax::SolrService
-        .query("#{proxy_field}:#{@work.id}", rows: limit, fl: target_field)
-        .flat_map { |x| x.fetch(target_field, nil) }
-        .compact
     end
   end
 end

--- a/app/search_builders/oregon_digital/ordered_children_of_work_search_builder.rb
+++ b/app/search_builders/oregon_digital/ordered_children_of_work_search_builder.rb
@@ -11,6 +11,8 @@ module OregonDigital
       @work = work
       super(options.first)
       @child_page = options.first.params['child_page']
+      # page must be set to 1, otherwise search builder assumes
+      # that all docs have already been returned on the previous page
       options.first.params['page'] = '1'
       @count = blacklight_config.per_page.first
     end


### PR DESCRIPTION
fixes #2945 

Notes: staying within the search builder landscape, this is a moderately hacky way to get the documents in order: calculate which ids should be displayed on a given page and add a second search_builder that only requests those ids; then when the search builder returns the documents, put them in order (there are only 4 of them, so not so bad). The original search builder is retained to provide the total solr response, necessary for pagination.  WRT to pagination...the wonkiest bit is this detail in the ordered_children_of_work_search_builder: in order to get results back, the query must show that this is a first page request, otherwise the logic says that you are building page 2 but there are only 4 items, which would have been seen on page one, and therefore there are no more documents to view.