### PR TITLE
Update bootstrap/CSS for Explore Collections table view and search widgets

### DIFF
--- a/app/assets/stylesheets/oregon_digital/_search.scss
+++ b/app/assets/stylesheets/oregon_digital/_search.scss
@@ -50,7 +50,8 @@
   border-radius: 5px !important;
   border: none;
   box-shadow: none;
-  padding: .1em .25em;
+  padding: .2em .25em;
+  padding-top: 0;
   font-size: 18pt;
   &.active {
     color: $navy-blue;
@@ -114,7 +115,7 @@
     }
   }
   #sort-dropdown {
-    margin-right: 1.5em;
+    margin-right: 1.5em !important;
   }
 
   @media (max-width: breakpoint-min(md)) {

--- a/app/assets/stylesheets/oregon_digital/explore_collections/_showcase.scss
+++ b/app/assets/stylesheets/oregon_digital/explore_collections/_showcase.scss
@@ -54,6 +54,8 @@ form#explore-collection-search {
   .explore-collections-search-widgets {
     @media (max-width: breakpoint-max(lg)) {
       & {
+        display: flex;
+        flex-direction: column;
         float: left !important;
       }
     }
@@ -66,8 +68,18 @@ form#explore-collection-search {
       display: inline-block;
 
       #per_page-dropdown {
-        margin-right: 1.5em;
+        margin-right: 1.5em !important;
         margin-top: 0;
+      }
+
+      .btn-group .dropdown-toggle:focus {
+        outline: 2px auto Highlight;
+        outline: 5px auto -webkit-focus-ring-color;
+        outline: -2px;
+      }
+
+      .dropdown-item {
+        font-size: 14px;
       }
     }
   }

--- a/app/assets/stylesheets/oregon_digital/explore_collections/_table_view.scss
+++ b/app/assets/stylesheets/oregon_digital/explore_collections/_table_view.scss
@@ -2,7 +2,7 @@ table#documents-table {
   width: 100%;
   thead th {
     padding: 2em 0;
-    @media (max-width: breakpoint-max(sm)) {
+    @media (max-width: breakpoint-max(lg)) {
       & {
         position: absolute;
         width: 1px;
@@ -21,7 +21,10 @@ table#documents-table {
     td {
       padding: 0.25em 0;
     }
-    @media (max-width: breakpoint-max(sm)) {
+    b {
+      font-weight: bold;
+    }
+    @media (max-width: breakpoint-max(lg)) {
       &, th, td {
         display: block;
       }
@@ -33,6 +36,7 @@ table#documents-table {
         margin-top: 1.5em;
       }
       th {
+        max-width: 100%;
         font-size: 30px;
         padding: 0;
       }

--- a/app/views/oregon_digital/explore_collections/_index_tables.html.erb
+++ b/app/views/oregon_digital/explore_collections/_index_tables.html.erb
@@ -13,7 +13,7 @@
   </td>
   <% end %>
   <td>
-    <%= controller.total_viewable_items(document.id) %> <span class="hidden-md hidden-lg">items</span>
+    <%= controller.total_viewable_items(document.id) %> <span class="d-xl-none d-inline-block">items</span>
   </td>
   <% if controller.tab == controller.class::TABS[:my] %>
   <td>

--- a/app/views/oregon_digital/explore_collections/_per_page_widget.html.erb
+++ b/app/views/oregon_digital/explore_collections/_per_page_widget.html.erb
@@ -3,12 +3,12 @@
 <div id="<%= widget_id %>" class="h4">
   <%= t('blacklight.search.per_page.title') %>
   <div class="btn-group">
-    <button type="button" id="<%= widget_id %>-button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-controls="<%= widget_id %>-list" aria-expanded="false" aria-haspopup="true" aria-label="Results per page (<%= current_per_page %>)">
-      <%= t(:'blacklight.search.per_page.button_label', :count => current_per_page) %> <span class="caret-dropdown"></span>
+    <button type="button" id="<%= widget_id %>-button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-controls="<%= widget_id %>-list" aria-expanded="false" aria-haspopup="true" aria-label="Results per page (<%= current_per_page %>)">
+      <%= t(:'blacklight.search.per_page.button_label', :count => current_per_page) %>
     </button>
     <ul id="<%= widget_id %>-list" class="dropdown-menu" role="menu" aria-labelledby="<%= widget_id %>-button">
       <%- per_page_options_for_select.each do |(label, count)| %>
-        <li role="none"><%= link_to(label, url_for(search_state.params_for_search(per_page: count)), role: 'menuitem', tabindex: -1) %></li>
+        <li role="none"><%= link_to(label, url_for(search_state.params_for_search(per_page: count)),class: 'dropdown-item',  role: 'menuitem', tabindex: -1) %></li>
       <%- end -%>
     </ul>
   </div>

--- a/app/views/oregon_digital/explore_collections/_sort_widget.html.erb
+++ b/app/views/oregon_digital/explore_collections/_sort_widget.html.erb
@@ -3,12 +3,12 @@
   <%= t('blacklight.search.sort.title') %>
   <span class="sr-only" id="search-sort"> Sort results by </span>
   <div class="btn-group">
-    <button type="button" id="search-sort-button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-controls="search-sort-list" aria-expanded="false" aria-haspopup="true" aria-label="Sort by">
-      <%= t('blacklight.search.sort.button_label', :field =>sort_field_label(current_sort_field.key)) %> <span class="caret-dropdown"></span>
+    <button type="button" id="search-sort-button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-controls="search-sort-list" aria-expanded="false" aria-haspopup="true" aria-label="Sort by">
+      <%= t('blacklight.search.sort.button_label', :field =>sort_field_label(current_sort_field.key)) %>
     </button>
     <ul id="search-sort-list" class="dropdown-menu" role="menu" aria-labelledby="search-sort-button">
       <%- active_sort_fields.each do |sort_key, field_config| %>
-        <li role="none"><%= link_to(sort_field_label(sort_key), url_for(search_state.params_for_search(sort: sort_key)), role: 'menuitem', tabindex: -1) %></li>
+        <li role="none"><%= link_to(sort_field_label(sort_key), url_for(search_state.params_for_search(sort: sort_key)), class: 'dropdown-item', role: 'menuitem', tabindex: -1) %></li>
       <%- end -%>
     </ul>
   </div>


### PR DESCRIPTION
Related to #3216 

## Changes
- Update view icon padding
- Update widget spacing and sizing
- Fix responsive breakpoints for search widgets and table view
- Reduce font weight of collection names in table view
- Update sort/show dropdown outline color on focus
- Replace missing dropdown caret icons in sort/show dropdowns

## Screenshots
![Full window explore collections page in table view](https://github.com/user-attachments/assets/e04e85ce-a9aa-4105-8ad6-7bb77ced3197)
![Mobile explore collections page in table view](https://github.com/user-attachments/assets/2d6b0ce2-a127-4a1c-af88-19c8252377d6)
