### PR TITLE
Remove method causing display Failure

### DIFF
--- a/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
@@ -213,7 +213,7 @@ module OregonDigital
         config.add_facet_field 'location_combined_label_sim', label: I18n.translate('simple_form.labels.defaults.location_combined'), index_range: 'A'..'Z', limit: 5
         config.add_facet_field 'workType_label_sim', label: I18n.translate('simple_form.labels.defaults.workType'), index_range: 'A'..'Z', limit: 5
         config.add_facet_field 'language_label_sim', label: I18n.translate('simple_form.labels.defaults.language'), index_range: 'A'..'Z', limit: 5
-        config.add_facet_field 'non_user_collections_label_ssim', label: 'Collection', index_range: 'A'..'Z', limit: 5
+        config.add_facet_field 'non_user_collections_label_ssim', label: 'Collection', helper_method: 'collection_title_modify', index_range: 'A'..'Z', limit: 5
         config.add_facet_field 'local_collection_name_label_sim', label: I18n.translate('simple_form.labels.defaults.local_collection'), index_range: 'A'..'Z', limit: 5
         config.add_facet_field 'institution_label_sim', label: 'Institution', index_range: 'A'..'Z', limit: 5
 

--- a/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
@@ -213,7 +213,7 @@ module OregonDigital
         config.add_facet_field 'location_combined_label_sim', label: I18n.translate('simple_form.labels.defaults.location_combined'), index_range: 'A'..'Z', limit: 5
         config.add_facet_field 'workType_label_sim', label: I18n.translate('simple_form.labels.defaults.workType'), index_range: 'A'..'Z', limit: 5
         config.add_facet_field 'language_label_sim', label: I18n.translate('simple_form.labels.defaults.language'), index_range: 'A'..'Z', limit: 5
-        config.add_facet_field 'non_user_collections_label_ssim', label: 'Collection', helper_method: 'collection_title_from_id', index_range: 'A'..'Z', limit: 5
+        config.add_facet_field 'non_user_collections_label_ssim', label: 'Collection', index_range: 'A'..'Z', limit: 5
         config.add_facet_field 'local_collection_name_label_sim', label: I18n.translate('simple_form.labels.defaults.local_collection'), index_range: 'A'..'Z', limit: 5
         config.add_facet_field 'institution_label_sim', label: 'Institution', index_range: 'A'..'Z', limit: 5
 

--- a/app/helpers/oregon_digital/hyrax_helper_behavior.rb
+++ b/app/helpers/oregon_digital/hyrax_helper_behavior.rb
@@ -22,10 +22,6 @@ module OregonDigital::HyraxHelperBehavior
     sanitize combine_hits_with_links(html_content, show_link)
   end
 
-  def collection_title_from_id(field, _show_link = true)
-    SolrDocument.find(field).title_or_label
-  end
-
   # METHOD: Modify the string of collection title so it can display correctly
   def collection_title_modify(field, _show_link = true)
     field.match?(/^\[.*\]$/) ? field.gsub(/^\[|\]$/, '') : field

--- a/app/helpers/oregon_digital/hyrax_helper_behavior.rb
+++ b/app/helpers/oregon_digital/hyrax_helper_behavior.rb
@@ -26,6 +26,11 @@ module OregonDigital::HyraxHelperBehavior
     SolrDocument.find(field).title_or_label
   end
 
+  # METHOD: Modify the string of collection title so it can display correctly
+  def collection_title_modify(field, _show_link = true)
+    field.match?(/^\[.*\]$/) ? field.gsub(/^\[|\]$/, '') : field
+  end
+
   # @return [String] the appropriate action url for our search form (depending on our current page)
   def search_form_action
     anchor = '#content'


### PR DESCRIPTION
`BUG:` Remove the `helper_method` causing it to not display on the facet search page. Add in a function to parse out the weird bracket in the label.

fixes #3187 