### PR TITLE
Feature/search bootstrap update

### DIFF
--- a/app/assets/stylesheets/blacklight/facet_overrides.scss
+++ b/app/assets/stylesheets/blacklight/facet_overrides.scss
@@ -1,11 +1,16 @@
-.panel-heading.collapse-toggle .panel-title.collapsed:after {
+.panel-heading.collapse-toggle .panel-title:after {
   /* symbol for "collapsed" panels */
-  content: "\e080";
+  color: grey;
   /* adjust as needed, taken from bootstrap.css */
 }
 .collapse-toggle.panel-heading {
   cursor: unset;
   padding: 0;
+}
+
+.facet-field-heading button {
+  font-size: 16px;
+  font-weight: 600;
 }
 
 .panel-header {

--- a/app/assets/stylesheets/oregon_digital/_search.scss
+++ b/app/assets/stylesheets/oregon_digital/_search.scss
@@ -10,14 +10,14 @@
   background-color: $very-light-grey;
   height: 0.75em;
 
-  @media (min-width: breakpoint-min(sm)) {
+  @media (min-width: breakpoint-min(md)) {
     & {
       margin-top: 1em;
     }
   }
 }
 
-@media (max-width: breakpoint-min(sm)) {
+@media (max-width: breakpoint-min(md)) {
   #appliedParams.explore-collection,
   #appliedParamsConstraint.explore-collection {
     position: absolute;
@@ -45,7 +45,7 @@
   position: relative;
 }
 
-.view-type .btn-default {
+.view-type .btn-outline-secondary {
   background-color: $very-light-grey;
   border-radius: 5px !important;
   border: none;
@@ -53,9 +53,9 @@
   padding: .2em .25em;
   padding-top: 0;
   font-size: 18pt;
+  color: $navy-blue !important;
   &.active {
-    color: $navy-blue;
-    background-color: $contrast-orange;
+    background-color: $contrast-orange !important;
   }
   &.view-type-gallery,
   &.view-type-masonry {
@@ -74,7 +74,7 @@
     padding-right: 1em;
   }
 
-  @media (max-width: breakpoint-min(sm)) {
+  @media (max-width: breakpoint-min(md)) {
     margin-bottom: 1em;
   }
 }
@@ -83,7 +83,7 @@
   margin-top: 2em;
 
   + .flex-container {
-    @media (max-width: breakpoint-min(sm)) {
+    @media (max-width: breakpoint-min(md)) {
       flex-direction: column;
     }
   }
@@ -97,8 +97,16 @@
     .btn {
       background-color: $very-light-grey;
     }
+
+    .dropdown-menu {
+      li > .dropdown-item {
+        padding: 3px 20px;
+        font-size: 14px;
+      }
+    }
+
   }
-  .save-widgets {
+  .save-widgets button {
     color: $navy-blue;
     font-size: 14pt;
   }
@@ -118,20 +126,25 @@
     margin-right: 1.5em !important;
   }
 
-  @media (max-width: breakpoint-min(md)) {
+  @media (max-width: breakpoint-min(lg)) {
     .search-widgets {
       text-align: right;
     }
   }
 
-  @media (max-width: breakpoint-min(sm)) {
+  @media (max-width: breakpoint-min(md)) {
     #sort-dropdown {
-      margin-right: 0;
+      margin-right: 0 !important;
     }
     #search-sort-button,
     button.submits-batches.submits-batches-add {
       min-width: 13em;
       text-align: left !important;
+
+      &::after {
+        float: right;
+        margin-top: 0.5em;
+      }
     }
   }
 }
@@ -142,21 +155,23 @@
   font-style: italic;
   height: 54px;
 
-  @media (max-width: breakpoint-min(md)) {
+  @media (max-width: breakpoint-min(lg)) {
     text-align: center;
   }
 }
 
 .panel.facet_limit {
-  background: none;
+  background: $very-light-grey;
   border: 2px solid $navy-blue;
   border-radius: 0;
+  margin-top: 5px;
 
   .panel-heading {
-    background: none;;
+    background: none;
   }
   .panel-body {
     background-color: white;
+    padding: 15px;
   }
 }
 
@@ -168,7 +183,16 @@
     padding: 1em;
   }
 
-  @media (max-width: breakpoint-min(sm)) {
+  .facets-toggle {
+    display: none;
+  }
+
+  .top-panel-heading {
+    background: none;
+    border-bottom: 0;
+  }
+
+  @media (max-width: breakpoint-min(md)) {
     background: none;
     #facet-panel-collapse {
       display: block;
@@ -181,9 +205,6 @@
     .top-panel-heading {
       border: 0;
       border-top: 2px solid $light-grey;
-    }
-    .facets-toggle {
-      display: none;
     }
   }
 
@@ -208,8 +229,9 @@
   form {
     .input-group {
       margin: 1em;
-      margin-bottom: 6em;
+      margin-bottom: 2.25em;
       display: block;
+      width: inherit;
 
       button {
         position: absolute;
@@ -221,7 +243,6 @@
         height: calc(100% - 16px);
         margin-top: 8px;
         margin-bottom: 8px;
-        border-right: 1px solid $light-grey;
       }
       input {
         background-color: white;
@@ -237,6 +258,8 @@
 
 .search-result-wrapper {
   border-bottom: 0px solid $very-light-grey !important;
+  margin-bottom: 30px;
+  overflow: hidden;
 
   &:first-child {
     border-top: 2px solid $very-light-grey;
@@ -265,6 +288,10 @@
     }
     span {
       vertical-align: top;
+
+      span {
+        margin-left: 2px;
+      }
     }
     i,
     .children {
@@ -272,13 +299,19 @@
     }
   }
 
-  .search-results-title-row .search-result-title {
-    display: inline-block;
-    margin: 0;
+  .search-results-title-row {
+    padding: 0 0 15px;
+
+    .search-result-title {
+      display: inline-block;
+      margin: 0;
+    }
+
+    .badge {
+      margin-left: 15px;
+    }
   }
-  .search-results-title-row .label {
-    margin-left: 15px;
-  }
+  
 
   dl dd ul {
     padding-left: 0;
@@ -519,7 +552,7 @@ ul.pagination {
     }
   }
 
-  @media (max-width: breakpoint-min(sm)) {
+  @media (max-width: breakpoint-min(md)) {
     h3 {
       margin: 1em 0;
     }

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -14,7 +14,7 @@
     <%= render_constraints(params) %>
   </div>
 
-  <div class="d-md-none">
+  <div class="d-lg-none">
     <%= render 'per_page_widget', size: 'xs' %>
   </div>
 
@@ -22,8 +22,8 @@
 
 <div class="constraints-divider"></div>
 
-<div class="results-constraints-wrapper">
+<div class="results-constraints-wrapper d-flex flex-wrap justify-content-between">
   <h2 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h2>
-  <div class="result-count mw-lg-b col-md-3 col-sm-4"> <strong>Showing <%= ((@response.current_page * @response.limit_value) - (@response.limit_value)) + 1 %> to <%= ([@response.total_count, @response.current_page * @response.limit_value].min) %> of <%= @response.total_count %> item(s) </strong></div>
+  <div class="result-count mw-lg-b col-lg-3 col-md-4"> <strong>Showing <%= ((@response.current_page * @response.limit_value) - (@response.limit_value)) + 1 %> to <%= ([@response.total_count, @response.current_page * @response.limit_value].min) %> of <%= @response.total_count %> item(s) </strong></div>
   <%= render 'sort_and_per_page' %>
 </div>

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,7 +1,7 @@
 <!-- OVERRIDE FROM HYRAX TO ADD CHECKBOX INPUT TO HOOK UP SAVE FUNCTIONALITY -->
 <% if can?(:read, document) %>
   <li id="document_<%= document.to_param %>" class="document <%= render_document_class document %>" itemscope itemtype="<%= document.itemtype %>">
-    <div class="row search-result-wrapper">
+    <div class="row search-result-wrapper d-block">
         <p class="pull-left">
           <% unless document.collection? %>
           <input type="checkbox" name="batch_document_ids[]" id=<%="batch_document_#{document.id}"%> value=<%= document.id %> class="batch_document_selector" onclick="max_checked(this)" aria-label="Select <%= document.title_or_label %> for saving">

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -2,7 +2,7 @@
 <% if has_facet_values?  %>
 <div id="facets" class="facets sidenav">
 
-  <div class="top-panel-heading panel-heading">
+  <div class="top-panel-heading card-header">
     <button type="button" class="facets-toggle" data-toggle="collapse" data-target="#facet-panel-collapse">
       <span class="sr-only">Toggle facets</span>
       <span class="icon-bar"></span>
@@ -26,7 +26,7 @@
 
     <%# RENDER: Render the primary facets and add a dropdown for the remaining secondary facets %>
     <%= render_facet_partials(@prime_facets) %>
-    <button type="button" class="btn btn-default btn-block secondary-facets" data-toggle="collapse" aria-haspopup="true" aria-expanded="false" href="#dropdown-secondary-facets">
+    <button type="button" class="btn btn-sm btn-secondary btn-block secondary-facets" data-toggle="collapse" aria-haspopup="true" aria-expanded="false" href="#dropdown-secondary-facets">
       <%= t('blacklight.facets.more_option') %>
     </button>
     

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,4 +1,4 @@
-<div itemscope itemtype="http://schema.org/CreativeWork" class=" masonry document col-xs-6 col-md-3 ">
+<div itemscope itemtype="http://schema.org/CreativeWork" class=" masonry document col-6 col-lg-3 ">
   <div class="thumbnail">
 
     <% document_url = document.collection? ? hyrax.collection_path(document.id) : Rails.application.routes.url_helpers.polymorphic_path(document) %>

--- a/app/views/catalog/_index_header_list_collection.html.erb
+++ b/app/views/catalog/_index_header_list_collection.html.erb
@@ -1,4 +1,4 @@
-<div class="search-results-title-row col-xs-9 col-sm-7 col-md-7">
+<div class="search-results-title-row col-9 col-md-7 col-lg-7 float-left d-flex align-items-center">
   <% if document.has_highlight_field?('title_tesim') %>
     <h3 class="search-result-title"><%= link_to document.highlight_field('title_tesim').first, [hyrax, document] %></h3>
   <% else %>

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,4 +1,4 @@
-<div class="search-results-title-row col-xs-9 col-sm-7 col-md-7">
+<div class="search-results-title-row col-sm-9 col-md-7 col-lg-7 float-left">
   <% if document.has_highlight_field?('title_tesim') %>
     <h3 class="search-result-title"><%= link_to document.highlight_field('title_tesim').first, Rails.application.routes.url_helpers.polymorphic_path(document) %></h3>
   <% else %>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,5 +1,5 @@
 <!-- OVERRIDE FROM HYRAX -->
-<div class="col-xs-9 col-sm-7 col-md-7">
+<div class="col-9 col-md-7 col-lg-7 float-left">
   <div class="metadata-row row">
   <% doc_presenter = index_presenter(document) %>
   <% index_fields(document).each do |field_name, field| -%>
@@ -53,7 +53,7 @@
 <!-- ADD SAVE BUTTON AND MODAL -->
 <% unless document.collection? %>
   <%= button_tag t('hyrax.dashboard.my.action.save'),
-                  class: 'btn btn-default submits-batches submits-batches-add pull-right',
+                  class: 'btn btn-sm btn-secondary submits-batches submits-batches-add pull-right',
                   data: { toggle: "modal", target: "#collection-list-container", id: document.id },
                   :onclick => "javascript:updateSaveCheckboxes(this)" %>
 <% end %>

--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -4,12 +4,12 @@
   <%= t('blacklight.search.per_page.title') %>
   <span class="sr-only" id="search-per-page-<%= size %>"> Number of results per page </span>
   <div class="btn-group">
-    <button type="button" id="search-per-page-button-<%= size %>" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-controls="search-per-page-list-<%= size %>" aria-expanded="false" aria-haspopup="true" aria-label="Results per page (<%= current_per_page %>)">
-      <%= t(:'blacklight.search.per_page.button_label', :count => current_per_page) %> <span class="caret-dropdown"></span>
+    <button type="button" id="search-per-page-button-<%= size %>" class="btn btn-sm btn-secondary dropdown-toggle" data-toggle="dropdown" aria-controls="search-per-page-list-<%= size %>" aria-expanded="false" aria-haspopup="true" aria-label="Results per page (<%= current_per_page %>)">
+      <%= t(:'blacklight.search.per_page.button_label', :count => current_per_page) %>
     </button>
     <ul id="search-per-page-list-<%= size %>" class="dropdown-menu" role="menu" aria-labelledby="search-per-page-button-<%= size %>">
       <%- per_page_options_for_select.each do |(label, count)| %>
-        <li role="none"><%= link_to(label, url_for(search_state.params_for_search(per_page: count)), role: 'menuitem', tabindex: -1) %></li>
+        <li role="none"><%= link_to(label, url_for(search_state.params_for_search(per_page: count)), class: 'dropdown-item', role: 'menuitem', tabindex: -1) %></li>
       <%- end -%>
     </ul>
   </div>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -5,12 +5,15 @@
   <%= hidden_field_tag :search_field, 'all_fields', id: 'facet_search_field' %>
   <div class="form-group">
     <div class="input-group">
+      <div class="prepend">
+        <button type="submit" class="input-group-text" id="facet-search-submit-facet">
+          <i class="fa fa-search" aria-hidden="true"></i>
+          <span class="sr-only">Search</span>
+        </button>
+      </div><!-- /. prepend -->
       <label class="sr-only" for="facet-search-field-facet">Search within the results</label>
-      <%= text_field_tag 'q[]', nil , class: "q form-control lato-b facet-search", id: "facet-search-field-facet", placeholder: "Search within" %>
-      <button type="submit" class="" id="facet-search-submit-facet">
-        <i class="fa fa-search" aria-hidden="true"></i>
-        <span class="sr-only">Search</span>
-      </button>
+      <%= text_field_tag 'q[]', nil , class: "q form-control lato-b facet-search w-100", id: "facet-search-field-facet", placeholder: "Search within" %>
+      
     </div><!-- /.input-group -->
 
   </div><!-- /.form-group -->

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,9 +1,9 @@
 <!-- OVERRIDE FROM HYRAX TO ADD SAVE BUTTON AND MODAL -->
 
-<div id="sortAndPerPage" class="sort-pagination d-md-flex justify-content-between col-md-9 col-sm-8" aria-label="<%= t('blacklight.search.per_page.aria_label')%>">
-  <%= render_results_collection_tools wrapping_class: "search-widgets col-md-6 col-xs-12" %>
+<div id="sortAndPerPage" class="sort-pagination d-lg-flex justify-content-between col-lg-9 col-md-8" aria-label="<%= t('blacklight.search.per_page.aria_label')%>">
+  <%= render_results_collection_tools wrapping_class: "search-widgets d-block col-lg-6 col-sm-12" %>
 
-  <div class="save-widgets col-md-6 col-xs-12 text-right">
+  <div class="save-widgets col-lg-6 col-sm-12 text-right">
     <%= button_tag( class: 'select-button',
                     onclick: 'javascript:selectAllSearchResults()') do %>
                       <span aria-hidden='true'><%= t('hyrax.dashboard.my.action.select_all') %></span>
@@ -14,7 +14,7 @@
                       <span aria-hidden='true'><%= t('hyrax.dashboard.my.action.none') %></span>
                       <span class="sr-only"> Deselect all works for adding </span>
                     <% end %>
-    <%= button_tag( class: 'btn btn-default submits-batches submits-batches-add',
+    <%= button_tag( class: 'btn btn-sm btn-secondary submits-batches submits-batches-add',
                     data: { toggle: "modal", target: "#collection-list-container" }) do %>
                       <span aria-hidden='true'><%= t('hyrax.dashboard.my.action.add_selected_to') %></span>
                       <span class="sr-only"> Add selected works to a collection </span>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -3,12 +3,12 @@
   <%= t('blacklight.search.sort.title') %>
   <span class="sr-only" id="search-sort"> Sort results by </span>
   <div class="btn-group">
-    <button type="button" id="search-sort-button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-controls="search-sort-list" aria-expanded="false" aria-haspopup="true" aria-label="Sort by">
-      <%= t('blacklight.search.sort.button_label', :field =>sort_field_label(current_sort_field.key)) %> <span class="caret-dropdown"></span>
+    <button type="button" id="search-sort-button" class="btn btn-sm btn-secondary dropdown-toggle" data-toggle="dropdown" aria-controls="search-sort-list" aria-expanded="false" aria-haspopup="true" aria-label="Sort by">
+      <%= t('blacklight.search.sort.button_label', :field =>sort_field_label(current_sort_field.key)) %>
     </button>
     <ul id="search-sort-list" class="dropdown-menu" role="menu" aria-labelledby="search-sort-button">
       <%- active_sort_fields.each do |sort_key, field_config| %>
-        <li role="none"><%= link_to(sort_field_label(sort_key), url_for(search_state.params_for_search(sort: sort_key)), role: 'menuitem', tabindex: -1) %></li>
+        <li role="none"><%= link_to(sort_field_label(sort_key), url_for(search_state.params_for_search(sort: sort_key)), class: 'dropdown-item', role: 'menuitem', tabindex: -1) %></li>
       <%- end -%>
     </ul>
   </div>

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,7 +1,6 @@
-<div class="col-xs-12 col-sm-4 col-md-3">
+<div class="col-12 col-md-4 col-lg-3 float-left">
   <div class="list-thumbnail <%= 'blurred-image' if document.mask_content.include?('Search Results Page') %>">
     <%# LINK: Add in a link to collection page on the thumbnail %>
     <%= link_to (render_thumbnail_tag document, alt: document.title_or_label.truncate_words(10), suppress_link: true), Hyrax::Engine.routes.url_helpers.collection_path(document) %>
   </div>
 </div>
-

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,4 +1,4 @@
-<div class="col-xs-12 col-sm-4 col-md-3">
+<div class="col-12 col-md-4 col-lg-3 float-left">
   <div class="list-thumbnail <%= 'blurred-image' if document.mask_content.include?('Search Results Page') %>">
     <%= link_to url_for_document(document) do %>
       <%= document_presenter(document)&.thumbnail&.thumbnail_tag({alt: document.title_or_label.truncate_words(10)}, { suppress_link: true }) %>

--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -19,7 +19,7 @@
   <%= form_tag search_form_action, method: :get, class: "form-horizontal search-form", id: "zero-results-search-form", role: "search" do %>
     <%= hidden_field_tag :search_field, 'all_fields', id: 'zero_results_search_field' %>
     <div class="form-group">
-      <div class="no-results-wrapper col-sm-8">
+      <div class="no-results-wrapper col-md-8">
         <div class="input-group">
           <label class="sr-only" for="zero-results-search-field">
             <%= t("hyrax.search.form.q.label", application_name: application_name) %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -7,15 +7,15 @@
 
 <div class="flex-container row container">
 <%- unless @response.empty? %>
-  <div id="sidebar" class="flex-item col-md-3 col-sm-4 col-xs-12">
+  <div id="sidebar" class="flex-item col-lg-3 col-md-4 col-sm-12">
     <%= render 'search_sidebar' %>
   </div>
 <% end %>
 
 <%- if @response.empty? %>
-  <div id="content" class="flex-item col-xs-12">
+  <div id="content" class="flex-item col-sm-12">
 <% else %>
-  <div id="content" class="flex-item col-md-9 col-sm-8 col-xs-12">
+  <div id="content" class="flex-item col-lg-9 col-md-8 col-sm-12">
 <% end %>
     <%= render 'search_results' %>
   </div>


### PR DESCRIPTION
For #3217 

## Changes 
- Sidebar
  - Update facet filter font size and weight
  - Fix sidebar search bar
  - Add chevron icons to facet filters
  - Fix responsive breakpoints in sidebar
  - Fix padding on facet dropdowns
- Sort/Show widgets
  - Update icons for 'Sort' and 'Show' dropdowns
  - Update dropdown items styling for 'Sort' and 'Show' dropdowns
  - 'Show' dropdown appears above border at correct responsive breakpoint
  - Fix responsive breakpoints for sort and show widgets
- Document views
  - Fix responsive breakpoints for List and Gallery views
  - Update Gallery and List view icon colors
  - Fix spacing for document display
- General
  - Update button classes to match prod sizing

## Screenshots
### Desktop List/Gallery
<img width="800" alt="Desktop list view of search screen" src="https://github.com/user-attachments/assets/eb2f112b-1f8c-43e0-ad2c-b0340c286ceb" />
<img width="800" alt="Desktop gallery view of search screen" src="https://github.com/user-attachments/assets/9cc0cc3a-526a-4954-8579-c7df4b82b31c" />

### Mobile List/Gallery
<img height="400" alt="Mobile list view of search screen" src="https://github.com/user-attachments/assets/d7eaae12-48d4-4087-a70c-fb93e13f364e" />
<img height="400" alt="Mobile list view of search screen collection" src="https://github.com/user-attachments/assets/b6628bf9-34ce-4445-9a10-c62a2b9e0eae" />
<img height="400" alt="Search screen facets on mobile" src="https://github.com/user-attachments/assets/2b916762-4bcb-408f-87d8-cb673c19d00b" />
<img height="400" alt="Mobile gallery view of search screen" src="https://github.com/user-attachments/assets/3b21b26b-987d-4169-b939-4c5c4f28b542" />

