### PR TITLE
Tweak styling in header

### DIFF
--- a/app/assets/stylesheets/oregon_digital/_header.scss
+++ b/app/assets/stylesheets/oregon_digital/_header.scss
@@ -75,7 +75,12 @@ header {
 
   .navbar-nav > li > a {
     padding-top:15px;
-    padding-bottom:15px
+    padding-bottom:15px;
+
+    &:hover {
+      text-decoration: none;
+      background-color: #eee;
+    }
   }
 
   #user_utility_links {
@@ -119,7 +124,7 @@ header {
       }
       .input-group {
         margin: auto;
-        @media (max-width: breakpoint-max(lg)) {
+        @media (max-width: breakpoint-min(lg)) {
           width: 75%;
         }
 
@@ -182,8 +187,18 @@ header {
       }
     }
     #user-util-links {
+      margin-top: -0.6em;
+      
       li {
-        font-size: 0.875rem;
+        font-size: 14px;
+
+        a {
+          color: #333;
+        }
+
+        & > a:hover{
+          text-decoration: none;
+        }
       }
       
       @media (max-width: breakpoint-max(sm)) {


### PR DESCRIPTION
Tweaks related to #3214

## Description
Small header styling fixes
- Update text decoration on hover for the 'Explore Collections' link to match production
- Fix breakpoint for search input so that it displays properly on large screens
- Fix user dropdown so that it displays directly under the dropdown trigger instead of floating below
- Update styling for user dropdown links to match production

## Screenshots
Explore Collections link
<img width="192" height="49" alt="Explore Collections link on hover" src="https://github.com/user-attachments/assets/07168515-a526-41ba-959b-a09f46a10448" />

Search input on large screens vs. smaller screens
<img width="305" height="71" alt="Search input in header on large screen" src="https://github.com/user-attachments/assets/826092e8-b3c6-45ba-8551-72540065c0be" />
<img width="341" height="73" alt="Search input in header on smaller screen" src="https://github.com/user-attachments/assets/ff1e52c8-69ef-400b-b1a5-e3aa8f79e9c4" />

User dropdown 
<img width="257" height="233" alt="User dropdown" src="https://github.com/user-attachments/assets/57f75357-2093-4568-8d63-6a9a28afc79b" />