### PR TITLE
Update homepage styling

### DIFF
--- a/app/assets/stylesheets/oregon_digital/_home-page.scss
+++ b/app/assets/stylesheets/oregon_digital/_home-page.scss
@@ -141,42 +141,20 @@ body {
   background: none;
 }
 
-.advanced-link {
-      float: right;
-      font-size: 10px;
-      font-weight: 700;
-      letter-spacing: 1.5px;
-      padding: 0;
-      top: -.75em;
-      color: white;
-}
-ul.nav.homepage-nav {
-  text-transform: unset;
-  width: 100%;
 
-  #masthead-search-field-header {
-    width: 100%;
+#masthead-search-form-header {
+  .advanced-link {
+    text-transform: unset;
+    float: right;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    padding: 0;
+    top: -.75em;
+    color: $white;
   }
-  #masthead-search-form-header {
-    .advanced-link {
-      text-transform: unset;
-    }
-  }
-  li {
-    background: none;
-    width: 100%;
-  }
-  form {
-    width: 100%;
-    a.advanced-link {
-      position: relative;
-      float: right;
-      font-size: 10px;
-      font-weight: 700;
-      letter-spacing: 1.5px;
-      padding: 0;
-      top: -.75em;
-    }
+
+  .form-group {
     .input-group {
       width: 100%;
       button {
@@ -187,7 +165,6 @@ ul.nav.homepage-nav {
         border: unset;
         width: 3.25em;
         height: calc(100% - 1.25em);
-        margin-top: 10px;
         margin-bottom: 10px;
         border-right: 1.5px solid $very-light-grey;
         i {
@@ -225,10 +202,6 @@ ul.nav.homepage-nav {
     -ms-transform: translateX(-50%);
     -o-transform: translateX(-50%);
     transform: translateX(-50%);
-
-    @media (min-width: breakpoint-min(lg)) {
-      width: 100%;
-    }
   }
 }
 
@@ -243,7 +216,7 @@ ul.nav.homepage-nav {
 
 .home-content #showcase {
   h2 {
-    @media (max-width: breakpoint-min(md)) {
+    @media (max-width: breakpoint-min(lg)) {
       & {
         text-align: center;
         font-size: 32px;
@@ -251,7 +224,7 @@ ul.nav.homepage-nav {
       }
     }
   }
-  .visible-sm.visible-xs {
+  .d-lg-none.d-block {
     a.btn {
       margin-bottom: 3.5em;
     }
@@ -273,7 +246,7 @@ ul.nav.homepage-nav {
     font-size: 20px;
     font-weight: bold;
     line-height: 30px;
-    @media (max-width: breakpoint-min(md)) {
+    @media (max-width: breakpoint-min(lg)) {
       & {
         font-size: 28px;
       }
@@ -287,7 +260,7 @@ ul.nav.homepage-nav {
   }
 
   .collection-items {
-    @media (max-width: breakpoint-min(md)) {
+    @media (max-width: breakpoint-min(lg)) {
       & {
         font-size: 22px;
       }
@@ -326,7 +299,7 @@ ul.nav.homepage-nav {
 
 .about-oregondigital-container {
   img {
-    @media (max-width: breakpoint-min(md)) {
+    @media (max-width: breakpoint-min(lg)) {
       padding-bottom: 1em;
     }
   }
@@ -344,7 +317,7 @@ ul.nav.homepage-nav {
 
 .chevron-align {
   height: 1%;
-  @media (max-width: breakpoint-min(md)) {
+  @media (max-width: breakpoint-min(lg)) {
     margin-top: 13px;
   }
   margin-right: 5px;

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="container-fluid">
     <div class="row">
-      <div class="col-md-4 offset-md-4">
+      <div class="col-sm-10 offset-sm-1 col-md-8 offset-md-2">
         <%= form_tag search_form_action, method: :get, class: "form-horizontal search-form", id: "masthead-search-form-header", role: "search" do %>
           <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
           <%= hidden_field_tag :search_field, 'all_fields', id: 'masthead_search_field' %>

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -39,8 +39,12 @@
         </span>
       <% end %>
     <% end %>
-    <div class="flex-container feature-collection-divider hidden-xs hidden-sm">
+    <div class="flex-container feature-collection-divider d-none d-lg-flex">
       <div class="featured-collection-border"></div>
+      <%= link_to 'View All Collections', Rails.application.routes.url_helpers.all_collections_path, class: 'btn btn-primary btn-lg all-collections-homepage' %>
+      <div class="featured-collection-border"></div>
+    </div>
+    <div class="d-lg-none d-block center-text">
       <%= link_to 'View All Collections', Rails.application.routes.url_helpers.all_collections_path, class: 'btn btn-primary btn-lg all-collections-homepage' %>
       <div class="featured-collection-border"></div>
     </div>


### PR DESCRIPTION
Tweaks for #3214

## Description
- Adjust scope for advanced search link styling so that it doesn't affect the advanced search link in the header
- Update CSS selectors for search form on home page 
- Adjust search form width to match production
- Update responsive breakpoints for homepage content 
- Update layout of 'View All Collections' button and green border at different responsive breakpoints

## Screenshots
Search form and advanced search link
<img width="871" height="294" alt="Home page search form" src="https://github.com/user-attachments/assets/34248698-f04e-4621-a65f-ef0d29d4392c" />

Home page content at medium responsive breakpoint 
<img width="500" alt="Homepage on medium size screen" src="https://github.com/user-attachments/assets/8df02b84-5864-4ace-a1b9-ce4552fdea89" />

HOme page content at large responsive breakpoint
<img width="2206" height="2836" alt="Home page on large size screen" src="https://github.com/user-attachments/assets/caff03c1-f607-480e-979e-deae4505f31a" />

