### PR TITLE
Update footer responsive breakpoints

### DIFF
--- a/app/assets/stylesheets/oregon_digital/_footer.scss
+++ b/app/assets/stylesheets/oregon_digital/_footer.scss
@@ -17,7 +17,7 @@
   margin-left: 10px;
 }
 
-@media (max-width: breakpoint-min(xl)) {
+@media (max-width: breakpoint-min(lg)) {
 
   .osu-logo,
   .uo-logo {
@@ -38,7 +38,7 @@
     margin: 0 0 10px;
   }
 
-  @media (max-width: breakpoint-min(xl)) {
+  @media (max-width: breakpoint-min(lg)) {
     .row {
       display: block;
     }
@@ -101,7 +101,7 @@ a.toc-link {
   border-left: $lime-green 2px solid;
   height: fit-content;
 
-  @media (max-width: breakpoint-min(xl)) {
+  @media (max-width: breakpoint-min(lg)) {
     & {
       text-align: center;
       border: none;
@@ -109,7 +109,7 @@ a.toc-link {
   }
 }
 
-@media (max-width: breakpoint-min(xl)) {
+@media (max-width: breakpoint-min(lg)) {
   .horizontal-sm {
     width: 4em;
     border-bottom: $lime-green 2px solid;
@@ -120,7 +120,7 @@ a.toc-link {
 .right-align {
   text-align: right;
 
-  @media (max-width: breakpoint-min(xl)) {
+  @media (max-width: breakpoint-min(lg)) {
     & {
       text-align: center;
     }


### PR DESCRIPTION
Updates for #3215

## Description
Adjusts responsive breakpoints for site footer to switch at 1200px instead of 768px.

## Screenshots
Above 1200px screen:
<img width="1198" height="344" alt="OD footer above 1200px" src="https://github.com/user-attachments/assets/cb6ea7c9-1adf-4637-a609-28cda3604862" />

Below 1200px screen:
<img width="1097" height="586" alt="OD footer below 1200px" src="https://github.com/user-attachments/assets/43cf0cb2-c3a1-4f78-9df9-afa0b8f1deb3" />

