### PR TITLE
Update search page to match production

### DIFF
--- a/app/assets/javascripts/oregon_digital/facets_button.js
+++ b/app/assets/javascripts/oregon_digital/facets_button.js
@@ -1,0 +1,13 @@
+// ON LOAD: When page refresh, it will switch on click for the label on facets display button
+$(function() {
+  // CHANGE: On click, change the button label between 'More' and 'Less'
+  $('.secondary-facets, .secondary-advanced-facets').on('click', function() {
+    // DECLARE: Get the modify text
+    const moreText = $(this).data('more-text');
+    const lessText = $(this).data('less-text');
+    
+    // CHECK: Get the current text and check the value to switch on display when click  
+    const currentText = $.trim($(this).text());
+    $(this).text(currentText === moreText ? lessText : moreText);
+  });
+});

--- a/app/assets/stylesheets/oregon_digital/_search.scss
+++ b/app/assets/stylesheets/oregon_digital/_search.scss
@@ -108,7 +108,7 @@
   }
   .save-widgets button {
     color: $navy-blue;
-    font-size: 14pt;
+    font-size: 14px;
   }
 
   #sort-dropdown,
@@ -190,6 +190,10 @@
   .top-panel-heading {
     background: none;
     border-bottom: 0;
+  }
+
+  .more_facets_link {
+    font-size: 12px;
   }
 
   @media (max-width: breakpoint-min(md)) {
@@ -446,7 +450,7 @@ ul.pagination {
       background: none;
       padding-top: 1em;
       a {
-        text-align: left;
+        text-align: center;
 
         img {
           width: 100%;

--- a/app/views/catalog/_facet_limit.html.erb
+++ b/app/views/catalog/_facet_limit.html.erb
@@ -1,0 +1,11 @@
+<ul class="facet-values list-unstyled">
+  <% paginator = facet_paginator(facet_field, display_facet) %>
+  <%= render_facet_limit_list paginator, facet_field.key %>
+
+  <% unless paginator.last_page? || params[:action] == "facet" %>
+    <li class="more_facets_link">
+      <%= link_to t("more_#{field_name}_html", scope: 'blacklight.search.facets', default: :more_html, field_name: facet_field_label(facet_field.field).pluralize),
+          search_facet_path(id: facet_field.key), class: "more_facets_link btn btn-primary btn-sm ajax_modal_launch", data: { blacklight_modal: 'trigger' } %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,21 +1,21 @@
 <% param_name = blacklight_config.facet_paginator_class.request_keys[:page] %>
 <div class="prev_next_links btn-group pull-left">
-  <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: param_name, class: 'btn btn-link', data: { ajax_modal: "preserve", href: prev_page_path(@pagination, param_name: param_name) } do %>
-    <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn btn-disabled' %>
+  <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: param_name, class: 'btn btn-link btn-sm', data: { ajax_modal: "preserve", href: prev_page_path(@pagination, param_name: param_name) } do %>
+    <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn btn-disabled btn-sm' %>
   <% end %>
 
-  <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: param_name, class: 'btn btn-link',  data: { ajax_modal: "preserve", href: next_page_path(@pagination, param_name: param_name) } do %>
-    <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn btn-disabled' %>
+  <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: param_name, class: 'btn btn-link btn-sm',  data: { ajax_modal: "preserve", href: next_page_path(@pagination, param_name: param_name) } do %>
+    <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn btn-disabled btn-sm' %>
   <% end %>
 </div>
 
 <div class="sort_options btn-group pull-right">
   <% if @pagination.sort == 'index' -%>
-    <span class="disabled az btn btn-default"><%= t('blacklight.search.facets.sort.index') %></span>
-    <a type="button" class="sort_change numeric btn btn-default" href="<%= url_for(@pagination.params_for_resort_url('count', search_state.to_h)) %>" data-blacklight-modal="preserve"><%= t('blacklight.search.facets.sort.count') %></a>
+    <span class="disabled az btn btn-default btn-sm"><%= t('blacklight.search.facets.sort.index') %></span>
+    <a type="button" class="sort_change numeric btn btn-default btn-sm" href="<%= url_for(@pagination.params_for_resort_url('count', search_state.to_h)) %>" data-blacklight-modal="preserve"><%= t('blacklight.search.facets.sort.count') %></a>
     <%=  %>
   <% elsif @pagination.sort == 'count' -%>
-    <a type="button" class="sort_change az btn btn-default" href="<%= url_for(@pagination.params_for_resort_url('index', search_state.to_h)) %>" data-blacklight-modal="preserve"><%= t('blacklight.search.facets.sort.index') %></a>
-    <span class="disabled numeric btn btn-default"><%= t('blacklight.search.facets.sort.count') %></span>
+    <a type="button" class="sort_change az btn btn-default btn-sm" href="<%= url_for(@pagination.params_for_resort_url('index', search_state.to_h)) %>" data-blacklight-modal="preserve"><%= t('blacklight.search.facets.sort.index') %></a>
+    <span class="disabled numeric btn btn-default btn-sm"><%= t('blacklight.search.facets.sort.count') %></span>
   <% end -%>
 </div>

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -26,7 +26,8 @@
 
     <%# RENDER: Render the primary facets and add a dropdown for the remaining secondary facets %>
     <%= render_facet_partials(@prime_facets) %>
-    <button type="button" class="btn btn-sm btn-secondary btn-block secondary-facets" data-toggle="collapse" aria-haspopup="true" aria-expanded="false" href="#dropdown-secondary-facets">
+    <button type="button" class="btn btn-sm btn-secondary btn-block secondary-facets" data-toggle="collapse" aria-haspopup="true" aria-expanded="false" href="#dropdown-secondary-facets" data-more-text="<%= t('blacklight.facets.more_option') %>"
+    data-less-text="<%= t('blacklight.facets.less_option') %>">
       <%= t('blacklight.facets.more_option') %>
     </button>
     

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -41,3 +41,4 @@ en:
 
     facets:
       more_option: 'More'
+      less_option: 'Less'


### PR DESCRIPTION
For #3217

## Changes
- Update ‘Add Selected to…’ button font size
<img width="286" height="74" alt="Add selected to... button" src="https://github.com/user-attachments/assets/6763664c-56cc-4985-88b9-a7eb76ac94ba" />

- Make ‘more’ button for facet values match production
<img width="232" height="464" alt="Facet with more button" src="https://github.com/user-attachments/assets/0abe9da6-71d2-448c-a69b-6b2b1e0904b4" />

- Apply https://github.com/OregonDigital/OD2/pull/3390/commits/f93c7d19b2493a0f8065d44d655dc1757013b3e9 (‘More’ facet toggle switches text value to ‘Less’ when expanded’)
<img width="230" height="578" alt="Expanded facet list" src="https://github.com/user-attachments/assets/5d6b36aa-b86f-49ff-b44b-e26f3efe0eeb" />

- Center item titles in gallery view
<img width="779" height="396" alt="Search items in gallery view" src="https://github.com/user-attachments/assets/d21a1ef5-850a-4c5b-ba69-d41226db5994" />

- Adjust button sizes in facet pagination modal to match production
<img width="485" height="412" alt="Buttons in facet pagination modal" src="https://github.com/user-attachments/assets/350c1ab3-e2af-404d-a8fd-8485596b8c2c" />



