### PR TITLE
Explore collections style update

### DIFF
--- a/app/assets/stylesheets/oregon_digital/explore_collections/_showcase.scss
+++ b/app/assets/stylesheets/oregon_digital/explore_collections/_showcase.scss
@@ -44,7 +44,7 @@ form#explore-collection-search {
     font-weight: bold;
     padding-bottom: 2em;
 
-    @media (max-width: breakpoint-max(lg)) {
+    @media (max-width: breakpoint-max(md)) {
       & {
         display: block;
       }
@@ -52,7 +52,7 @@ form#explore-collection-search {
   }
 
   .explore-collections-search-widgets {
-    @media (max-width: breakpoint-max(lg)) {
+    @media (max-width: breakpoint-max(md)) {
       & {
         display: flex;
         flex-direction: column;
@@ -60,12 +60,13 @@ form#explore-collection-search {
       }
     }
 
-    @media (min-width: breakpoint-max(lg)) {
+    @media (min-width: breakpoint-max(md)) {
       transform: 0 15%;
     }
 
     .search-widgets {
       display: inline-block;
+      text-align: left;
 
       #per_page-dropdown {
         margin-right: 1.5em !important;
@@ -82,6 +83,24 @@ form#explore-collection-search {
         font-size: 14px;
       }
     }
+  }
+}
+
+.view-type .btn-default {
+  background-color: $very-light-grey;
+  border-radius: 5px !important;
+  border: none;
+  box-shadow: none;
+  padding: .2em .25em;
+  padding-top: 0;
+  font-size: 18pt;
+  color: $navy-blue !important;
+  &.active {
+    background-color: $contrast-orange !important;
+  }
+  &.view-type-gallery,
+  &.view-type-masonry {
+    margin-left: .5em;
   }
 }
 

--- a/app/assets/stylesheets/oregon_digital/explore_collections/_table_view.scss
+++ b/app/assets/stylesheets/oregon_digital/explore_collections/_table_view.scss
@@ -2,7 +2,7 @@ table#documents-table {
   width: 100%;
   thead th {
     padding: 2em 0;
-    @media (max-width: breakpoint-max(lg)) {
+    @media (max-width: breakpoint-max(md)) {
       & {
         position: absolute;
         width: 1px;
@@ -24,7 +24,7 @@ table#documents-table {
     b {
       font-weight: bold;
     }
-    @media (max-width: breakpoint-max(lg)) {
+    @media (max-width: breakpoint-max(md)) {
       &, th, td {
         display: block;
       }


### PR DESCRIPTION
Fixes for #3216 

## Description 
- Fix responsive breakpoints in table view
- Shift sort menu to the left on medium screens
- Update active view button styling

## Screenshots
<img width="1173" height="535" alt="Explore collections table view on large screen" src="https://github.com/user-attachments/assets/30b77d22-b628-4da7-9462-4b8f9f50f666" />


<img width="947" height="399" alt="Explore collections sort widgets on medium screen" src="https://github.com/user-attachments/assets/ccf3cbf2-ba14-40f4-99d9-b02dfb75005c" />


<img width="191" height="100" alt="View type select buttons" src="https://github.com/user-attachments/assets/5db37d20-4089-4df3-8b81-ac15a5d685fc" />
