### PR TITLE
Add publisher into the creator field

### DIFF
--- a/lib/oregon_digital/controlled_vocabularies/creator.rb
+++ b/lib/oregon_digital/controlled_vocabularies/creator.rb
@@ -10,6 +10,7 @@ module OregonDigital
           OregonDigital::ControlledVocabularies::Vocabularies::LocNames,
           OregonDigital::ControlledVocabularies::Vocabularies::OnsCreator,
           OregonDigital::ControlledVocabularies::Vocabularies::OnsPeople,
+          OregonDigital::ControlledVocabularies::Vocabularies::OnsPublisher,
           OregonDigital::ControlledVocabularies::Vocabularies::OnsOsuAcademicUnits,
           OregonDigital::ControlledVocabularies::Vocabularies::Wikidata
         ]


### PR DESCRIPTION
`METADATA:` Allow the `publisher ONS` to be added into the `creator` field in OD2.