### PR TITLE
 Allow filtering by collection ID

### DIFF
--- a/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/blacklight_config_behavior.rb
@@ -232,6 +232,9 @@ module OregonDigital
         config.add_facet_field 'series_number_sim', label: I18n.translate('simple_form.labels.defaults.series_number'), index_range: 'A'..'Z', limit: 5
         config.add_facet_field 'exhibit_sim', label: I18n.translate('simple_form.labels.defaults.exhibit'), index_range: 'A'..'Z', limit: 5
 
+        config.add_facet_field 'non_user_collections_ssim', label: 'Collection', show: false
+        config.add_facet_field 'user_collections_ssim', label: 'User Collection', show: false
+
         # Iterate all metadata and facet the properties that are configured for facets and not facetable yet
         # Do not show these facets, they're for collection configurable facets
         (Generic::ORDERED_PROPERTIES + Generic::UNORDERED_PROPERTIES).each do |prop|


### PR DESCRIPTION
Fixes #3458 

Enables filtering by ID for user and non-user collections by adding non-showing facet fields to blacklight config. 

## Screenshots
<img width="874" height="655" alt="Search results filtered by non-user collection id" src="https://github.com/user-attachments/assets/9245e792-fd3c-45ee-9a6f-914b0fc85c20" />
<img width="862" height="669" alt="Search results filtered by user collection id" src="https://github.com/user-attachments/assets/1f0c3093-2f35-4b66-b736-4914c19435be" />
