### PR TITLE
Account for new mpeg duration bug

### DIFF
--- a/app/presenters/oregon_digital/mp3_presenter.rb
+++ b/app/presenters/oregon_digital/mp3_presenter.rb
@@ -38,6 +38,7 @@ module OregonDigital
 
     private
 
+    # rubocop:disable Metrics/AbcSize
     def duration
       dur_array = @file_set.duration.first&.split(':')&.map(&:to_i) || [0, 0, -1]
 
@@ -47,6 +48,7 @@ module OregonDigital
         (dur_array.first / 1000).ceil
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     # The path to the derivative download
     def default_content_path


### PR DESCRIPTION
Fixes a bug in `.mpeg` file derivative generation where `duration` is calculated in milliseconds where `.mp3` calculates in `hh:mm:ss.ms`