### PR TITLE
Add checks to hide visibility badge if no features.

### DIFF
--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -5,11 +5,15 @@
   </td>
   <th scope="row" class="attribute attribute-filename ensure-wrapped"><%= link_to(member.link_name, contextual_path(member, @presenter)) %> <br/><br/>
     <% if (member.is_a?(Hyrax::FileSetPresenter)) && (!member.accessibility_feature.blank?) %>
-      <%= visibility_badge(OregonDigital::AccessControls::AccessRight::ACCESSIBLE_TEXT_VALUE) %> <br/>
-      <%= "Features: #{member.accessibility_feature.map { |a| accessibility_display(a) }.join(', ')}" %>
+      <% if (!member.accessibility_feature.include? 'none') && (!member.accessibility_feature.include? 'unknown') %>
+        <%= visibility_badge(OregonDigital::AccessControls::AccessRight::ACCESSIBLE_TEXT_VALUE) %> <br/>
+      <% end %>
+      <%= "Accessibility Features: #{member.accessibility_feature.map { |a| accessibility_display(a) }.join(', ')}" %>
     <% elsif (member.is_a?(Hyrax::WorkShowPresenter)) && (!member.solr_document['accessibility_feature_tesim'].blank?) %>
-      <%= visibility_badge(OregonDigital::AccessControls::AccessRight::ACCESSIBLE_TEXT_VALUE) %> <br/>
-      <%= "Features: #{member.solr_document['accessibility_feature_tesim'].map { |a| accessibility_display(a) }.join(', ')}" %>
+      <% if (!member.solr_document['accessibility_feature_tesim'].include? 'none') && (!member.solr_document['accessibility_feature_tesim'].include? 'unknown') %>
+        <%= visibility_badge(OregonDigital::AccessControls::AccessRight::ACCESSIBLE_TEXT_VALUE) %> <br/>
+      <% end %>
+      <%= "Accessibility Features: #{member.solr_document['accessibility_feature_tesim'].map { |a| accessibility_display(a) }.join(', ')}" %>
     <% end %>
   </td>
   <td class="attribute attribute-date_uploaded"><%= member.try(:date_uploaded) %></td>


### PR DESCRIPTION
Fixes #3515 

Changed "Features:" label to 'Accessibility Features:' to make it more clear, especially when 'Accessible Copy' badge doesn't show and it would've just said "Features: None".