### PR TITLE
Remove extra code on Download option & update show page

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -28,11 +28,10 @@
           </button>
           <ul id="download-list" class="dropdown-menu" role="menu" aria-labelledby="download-button">
             <% if current_ability.can? :download, Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: presenter.id) %>
-              <li class="<%= 'disabled-link-dropdown' if @disable_link == false %>"><%= link_to "Files (High Quality)", main_app.send(:"download_hyrax_#{presenter.model_name.name.downcase}_path", presenter.id) %></li>
+              <li class="<%= 'disabled-link-dropdown' if @disable_link == false %>"><%= link_to "Download Files (High Quality)", main_app.send(:"download_hyrax_#{presenter.model_name.name.downcase}_path", presenter.id) %></li>
             <% end %>
-            <li class="<%= 'disabled-link-dropdown' if @disable_link == false %>"><%= link_to "Files (Standard Quality)", main_app.send(:"download_low_hyrax_#{presenter.model_name.name.downcase}_path", presenter.id) unless (presenter.file_set_presenters.map { |p| p.mime_type }.include?('application/pdf') || presenter.file_set_presenters.map { |p| p.mime_type }.include?('application/vnd.ms-'))  %></li>
-            <li><%= link_to "Metadata Only (CSV)", main_app.send(:"metadata_hyrax_#{presenter.model_name.name.downcase}_path", presenter.id) %></li>
-            <li><%= link_to "Individual Files", "#file-set-individual" %></li>
+            <li class="<%= 'disabled-link-dropdown' if @disable_link == false %>"><%= link_to "Download Files (Standard Quality)", main_app.send(:"download_low_hyrax_#{presenter.model_name.name.downcase}_path", presenter.id) unless (presenter.file_set_presenters.map { |p| p.mime_type }.include?('application/pdf') || presenter.file_set_presenters.map { |p| p.mime_type }.include?('application/vnd.ms-'))  %></li>
+            <li><%= link_to "Download Individual Files", "#file-set-individual" %></li>
           </ul>
         </div>
       </div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -150,25 +150,6 @@
           </div>
         </div>
       <% end %>
-      <% if current_ability.can?(:view, FileSet) %>
-        <div class='row'>
-          <!-- Renders file manager -->
-          <div class='col-sm-12'>
-            <div id='work-show-file-sets' class='flex-container'>
-              <div class='flex-item file-set-title' id='file-set-individual'>
-                <h2 class='h4'>Works and Files</h2>
-              </div>
-              <% if @presenter.member_presenters.size > 1 %>
-                <div class='flex-item file-set-manager'>
-                  <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, @presenter]), class: 'btn btn-primary pull-right' %>
-                </div>
-              <% end %>
-            </div>
-              <hr style='border-width: 3px;'>
-              <%= render 'items', presenter: @presenter %>
-          </div>
-        </div>
-      <% end %>
 
       <%# PUBLIC: Make the Works & Files area public to all users %>
       <div class='row'>


### PR DESCRIPTION
`BUG:` Discover and remove extra field in show page and remove a line of code for the metadata download button

fixes #3456 