### PR TITLE
Restore facet modal persistance

### DIFF
--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,10 +1,10 @@
 <% param_name = blacklight_config.facet_paginator_class.request_keys[:page] %>
 <div class="prev_next_links btn-group pull-left">
-  <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: param_name, class: 'btn btn-link btn-sm', data: { ajax_modal: "preserve", href: prev_page_path(@pagination, param_name: param_name) } do %>
+  <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: param_name, class: 'btn btn-link btn-sm', data: { blacklight_modal: "preserve" } do %>
     <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn btn-disabled btn-sm' %>
   <% end %>
 
-  <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: param_name, class: 'btn btn-link btn-sm',  data: { ajax_modal: "preserve", href: next_page_path(@pagination, param_name: param_name) } do %>
+  <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: param_name, class: 'btn btn-link btn-sm',  data: { blacklight_modal: "preserve" } do %>
     <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn btn-disabled btn-sm' %>
   <% end %>
 </div>


### PR DESCRIPTION
Fixes issue where facet modals pagination links out to a separate page instead of flipping pages