### PR TITLE
Have the tools pod go into infinite sleep

### DIFF
--- a/build/entrypoint-tools.sh
+++ b/build/entrypoint-tools.sh
@@ -6,6 +6,6 @@ echo "Starting tools container ${RAILS_ENV}"
 echo "Installing gems..."
 ./build/install_gems.sh
 
-# Start init
-echo "Starting init"
-exec /sbin/init
+# Start sleep to keep pod running
+echo "Entering INFINITE sleep"
+exec sleep infinity


### PR DESCRIPTION
Puts the tools pod into sleep rather than using `init.d`