### PR TITLE
Adds in ability for Bulkrax to see Valkyrie::Resources

### DIFF
--- a/config/initializers/hacks/bulkrax_importer_helper_hack.rb
+++ b/config/initializers/hacks/bulkrax_importer_helper_hack.rb
@@ -1,0 +1,13 @@
+Rails.application.config.to_prepare do
+  Bulkrax::ImportersHelper.module_eval do
+    # borrowed from batch-importer https://github.com/samvera-labs/hyrax-batch_ingest/blob/main/app/controllers/hyrax/batch_ingest/batches_controller.rb
+    def available_admin_sets
+      # Restrict available_admin_sets to only those current user can deposit to.
+      @available_admin_sets ||= Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability, source_type: 'admin_set').map do |admin_set_id|
+        [Bulkrax.object_factory.find_or_nil(admin_set_id)&.title&.first || admin_set_id, admin_set_id]
+      end
+      @available_admin_sets << Hyrax.query_service.find_all_of_model(model: Hyrax::AdministrativeSet)
+      @available_admin_sets.flatten
+    end
+  end
+end

--- a/config/initializers/hacks/bulkrax_importer_helper_hack.rb
+++ b/config/initializers/hacks/bulkrax_importer_helper_hack.rb
@@ -6,7 +6,7 @@ Rails.application.config.to_prepare do
       @available_admin_sets ||= Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability, source_type: 'admin_set').map do |admin_set_id|
         [Bulkrax.object_factory.find_or_nil(admin_set_id)&.title&.first || admin_set_id, admin_set_id]
       end
-      @available_admin_sets << Hyrax.query_service.find_all_of_model(model: Hyrax::AdministrativeSet)
+      @available_admin_sets << Hyrax.query_service.find_all_of_model(model: Hyrax::AdministrativeSet).delete_if {|item| current_user.cannot?(:manage, item)}
       @available_admin_sets.flatten
     end
   end


### PR DESCRIPTION
This fix updates bulkrax to see Hyrax::AdministrativeSets. Once we cut over to v5, it should just use the default mechanism to create AdminSets. Bulkrax needs to know how to find the Hyrax::AdministrativeSets and this gets that done.

Once bulkrax gets updated to by compatible with hyrax 5, then this code can be removed.