### PR TITLE
Add native mediainfo and link python to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,13 @@ RUN apt update && apt -y upgrade && \
   build-essential zip xz-utils autoconf automake libtool texinfo libltdl7 \
   bash bash-completion java-common openjdk-17-jre-headless graphicsmagick ffmpeg \
   poppler-utils tesseract-ocr libopenjp2-7-dev libopenjp2-tools libopenjp2-7 \
-  libffi-dev tini libxslt1-dev libxml2-dev tzdata lsb-release cmake
+  libffi-dev tini libxslt1-dev libxml2-dev tzdata lsb-release cmake mediainfo libmediainfo-dev
 
 # Set the timezone to America/Los_Angeles (Pacific) then get rid of tzdata
 RUN cp -f /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && \
   echo 'America/Los_Angeles' > /etc/timezone
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Install ImageMagick with jp2/tiff support
 # Install ImageMagick with full support
@@ -49,8 +51,8 @@ RUN mkdir -p /tmp/im && \
 # install FITS for file characterization
 RUN mkdir -p /opt/fits && \
   curl -fSL -o /opt/fits-1.6.0.zip https://github.com/harvard-lts/fits/releases/download/1.6.0/fits-1.6.0.zip && \
-  cd /opt/fits && unzip /opt/fits-1.6.0.zip  && chmod +X fits.sh && \
-  rm -f /opt/fits-1.6.0.zip
+  cd /opt/fits && unzip /opt/fits-1.6.0.zip  && chmod a+x fits.sh && \
+  rm -rf /opt/fits-1.6.0.zip /opt/fits/tools/mediainfo/linux
 
 ARG UID=8083
 ARG GID=8083


### PR DESCRIPTION
The `mediainfo` provided by FITS is built for Ubuntu Jammy, but it supports calling system `mediainfo` if you blow up their packaged library

jplyzer also doesn't like to run unless it finds the `python` command. Linux has moved onto using `python3` a long time ago but a common work around is either installing `python3-as-python` which is a package that simply symlinks `/usr/bin/python` to `/usr/bin/python3` allowing `python` use system-wide and allowing jplyzer to run without complaint. I chose to do the symlinking ourselves since the package is ancient and unmaintained.