### PR TITLE
Create an alt text job for FileSet

### DIFF
--- a/app/assets/stylesheets/oregon_digital/_work-show.scss
+++ b/app/assets/stylesheets/oregon_digital/_work-show.scss
@@ -355,3 +355,10 @@ dl.work-show {
   width: 100%;
   height: 100%;
 }
+
+// TEXT DISPLAY: Add in display customize for :alt_text
+.alt-text-display {
+  font-weight: normal; 
+  word-break: normal; 
+  white-space: normal;
+}

--- a/app/factories/bulkrax/oregon_digital_object_factory.rb
+++ b/app/factories/bulkrax/oregon_digital_object_factory.rb
@@ -5,7 +5,7 @@ module Bulkrax
   class OregonDigitalObjectFactory < ObjectFactory
     # Override to add the _attributes properties
     def permitted_attributes
-      attribute_properties + oembed_attribute + accessibility_attributes + super
+      attribute_properties + oembed_attribute + accessibility_attributes + alt_text_attributes + super
     end
 
     # Gather the attribute_properties
@@ -21,6 +21,11 @@ module Bulkrax
 
     def accessibility_attributes
       %i[accessibility_feature accessibility_summary]
+    end
+
+    # NEW: Add alt_text to permitted attributes
+    def alt_text_attributes
+      %i[alt_text]
     end
   end
 end

--- a/app/indexers/oregon_digital/file_set_indexer.rb
+++ b/app/indexers/oregon_digital/file_set_indexer.rb
@@ -10,8 +10,9 @@ module OregonDigital
         solr_doc['all_text_timv'] = find_all_text_value
         solr_doc['hocr_text_timv'] = find_hocr_text
         index_additional_characterization_terms(solr_doc)
-        # Add in an indexing to accessibility_feature
+        # Add in an indexing to accessibility_feature & alt_text
         accessibility_label(solr_doc, object)
+        alt_text_label(solr_doc, object)
       end
     end
 
@@ -36,6 +37,13 @@ module OregonDigital
       solr_doc['accessibility_feature_label_sim'] = feature_labels
       solr_doc['accessibility_feature_label_ssim'] = feature_labels
       solr_doc['accessibility_feature_label_tesim'] = feature_labels
+    end
+
+    # METHOD: Create index for alt_text
+    def alt_text_label(solr_doc, object)
+      solr_doc['alt_text_label_sim'] = object.alt_text
+      solr_doc['alt_text_label_ssim'] = object.alt_text
+      solr_doc['alt_text_label_tesim'] = object.alt_text
     end
   end
 end

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -31,6 +31,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
   def perform(file_set, file_id, filepath = nil)
     raise "#{file_set.class.characterization_proxy} was not found for FileSet #{file_set.id}" unless file_set.characterization_proxy?
+
     # Ensure a fresh copy of the repo file's latest version is being worked on, if no filepath is directly provided
     filepath = Hyrax::WorkingDirectory.copy_repository_resource_to_working_directory(Hydra::PCDM::File.find(file_id), file_set.id) unless filepath && File.exist?(filepath)
     characterize(file_set, file_id, filepath)
@@ -63,6 +64,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
     file_set.save!
   end
 
+  # rubocop:disable Metrics/MethodLength
   def characterize(file_set, _file_id, filepath) # rubocop:disable Metrics/AbcSize
     # store this so we can tell if the original_file is actually changing
     previous_checksum = file_set.characterization_proxy.original_checksum.first
@@ -87,7 +89,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
     # mod time. This is done in the versioning code.
     file_set.date_modified = Hyrax::TimeService.time_in_utc if file_set.characterization_proxy.original_checksum.first != previous_checksum
 
-    file_set.characterization_proxy.original_name.force_encoding("UTF-8")
+    file_set.characterization_proxy.original_name.force_encoding('UTF-8')
     # set title to label (i.e. file name, `original_name`) if that's how it was before this characterization
     file_set.title = [file_set.characterization_proxy.original_name] if reset_title
     # always set the label to the original_name
@@ -95,6 +97,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
 
     file_set.save!
   end
+  # rubocop:enable Metrics/MethodLength
 
   def clear_metadata(file_set)
     # The characterization of additional file versions adds new height/width/size/checksum values to un-orderable...

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+##
+# a +ActiveJob+ job to process file characterization.
+#
+# the characterization process is handled by a service object, which is
+# configurable via {CharacterizeJob.characterization_service}.
+#
+# @example setting a custom characterization service
+#   class MyCharacterizer
+#     def run(file, path)
+#       # do custom characterization
+#     end
+#   end
+#
+#   # in a Rails initializer
+#   CharacterizeJob.characterization_service = MyCharacterizer.new
+# end
+
+# OVERRIDE: Add in a new function to do an extraction on alt text (import from v4)
+class CharacterizeJob < Hyrax::ApplicationJob
+  queue_as Hyrax.config.ingest_queue_name
+
+  class_attribute :characterization_service
+  self.characterization_service = Hydra::Works::CharacterizationService
+
+  # Characterizes the file at 'filepath' if available, otherwise, pulls a copy from the repository
+  # and runs characterization on that file.
+  # @param [FileSet] file_set
+  # @param [String] file_id identifier for a Hydra::PCDM::File
+  # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
+  def perform(file_set, file_id, filepath = nil)
+    raise "#{file_set.class.characterization_proxy} was not found for FileSet #{file_set.id}" unless file_set.characterization_proxy?
+    # Ensure a fresh copy of the repo file's latest version is being worked on, if no filepath is directly provided
+    filepath = Hyrax::WorkingDirectory.copy_repository_resource_to_working_directory(Hydra::PCDM::File.find(file_id), file_set.id) unless filepath && File.exist?(filepath)
+    characterize(file_set, file_id, filepath)
+
+    Hyrax.publisher.publish('file.characterized',
+                            file_set: file_set,
+                            file_id: file_id,
+                            path_hint: filepath)
+
+    # CALL: Call for the alt text extractor
+    alt_text_extract(file_set, filepath)
+  end
+
+  private
+
+  # METHOD: Call to extract text and put it back into object
+  def alt_text_extract(file_set, filepath)
+    # CHECK: Before anything happen, check to see if file is image & filepath does exist
+    return unless filepath.present?
+    return unless file_set.mime_type.to_s.start_with?('image/')
+
+    # CALL: Call the extraction
+    alt_texts = OregonDigital::FileSetAltTextsExtractorService.extract(filepath)
+
+    # IF: If no alt text extracted, then return nothing
+    return unless alt_texts.present?
+
+    # STORE: Now store the alt_text into its field in fileSet obj
+    file_set.alt_text = alt_texts
+    file_set.save!
+  end
+
+  def characterize(file_set, _file_id, filepath) # rubocop:disable Metrics/AbcSize
+    # store this so we can tell if the original_file is actually changing
+    previous_checksum = file_set.characterization_proxy.original_checksum.first
+
+    clear_metadata(file_set)
+
+    # If the current FileSet title is the same as the label, it must be a filename as opposed to a user-entered...
+    # value. So later we'll ensure it's set to the new file's filename.
+    reset_title = file_set.title.first == file_set.label
+
+    characterization_service.run(file_set.characterization_proxy, filepath)
+    Hyrax.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
+    file_set.characterization_proxy.alpha_channels = channels(filepath) if file_set.image? && Hyrax.config.iiif_image_server?
+    file_set.characterization_proxy.save!
+
+    # Ensure that if the actual file content has changed, the mod timestamp on the FileSet object changes.
+    # Otherwise this does not happen when rolling back to a previous version. Perhaps this should be set as part of...
+    # `FileActor.revert_to` (or its replacement Transaction?!), where the FileSet is saved. Not sure if the...
+    # before/after checksum is readily available there though. I like this checksum verification because it allows...
+    # all changes to the current FileSet version to be detected, which in our case triggers re-creation of a...
+    # "cold storage" archive of the parent Work. It's worth noting that adding a *new* version always touches this...
+    # mod time. This is done in the versioning code.
+    file_set.date_modified = Hyrax::TimeService.time_in_utc if file_set.characterization_proxy.original_checksum.first != previous_checksum
+
+    file_set.characterization_proxy.original_name.force_encoding("UTF-8")
+    # set title to label (i.e. file name, `original_name`) if that's how it was before this characterization
+    file_set.title = [file_set.characterization_proxy.original_name] if reset_title
+    # always set the label to the original_name
+    file_set.label = file_set.characterization_proxy.original_name
+
+    file_set.save!
+  end
+
+  def clear_metadata(file_set)
+    # The characterization of additional file versions adds new height/width/size/checksum values to un-orderable...
+    # `ActiveTriples::Relation` fields on `original_file`. Values from those are then randomly pulled into Solr...
+    # fields which may have scalar or vector cardinality. So for height/width you get two scalar values pulled from...
+    # "randomized parallel arrays". Upshot is to reset all of these before (re)characterization to stop the mayhem.
+    file_set.characterization_proxy.height = []
+    file_set.characterization_proxy.width  = []
+    file_set.characterization_proxy.original_checksum = []
+    file_set.characterization_proxy.file_size = []
+    file_set.characterization_proxy.format_label = []
+  end
+
+  def channels(filepath)
+    ch = MiniMagick::Tool::Identify.new do |cmd|
+      cmd.format '%[channels]'
+      cmd << filepath
+    end
+    [ch]
+  end
+
+  ##
+  # @api public
+  # @return [#run]
+  def characterization_service
+    self.class.characterization_service
+  end
+end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -17,6 +17,11 @@ class FileSet < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  # NEW FIELD: Add predicate for image alt text
+  property :alt_text, predicate: ::RDF::URI.new('http://opaquenamespace.org/ns/altText'), multiple: false, basic_searchable: true do |index|
+    index.as :stored_searchable
+  end
+
   include ::Hyrax::FileSetBehavior
   include OregonDigital::AccessControls::Visibility
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -23,6 +23,11 @@ class SolrDocument
     end
   end
 
+  # METHOD: Fetch out :alt_text from SolrDocument
+  def alt_text
+    self['alt_text_label_ssim']
+  end
+
   # Add support for querying for multiple ids
   def self.find(ids)
     return super(ids) unless ids.is_a? Array

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -34,7 +34,7 @@ module Hyrax
              :depositor, :keyword, :title_or_label, :keyword,
              :date_created, :date_modified, :itemtype,
              :original_file_id, :oembed_url, :all_text, :hocr_text,
-             :accessibility_feature,
+             :accessibility_feature, :alt_text,
              to: :solr_document
 
     def self.characterization_terms

--- a/app/services/oregon_digital/file_set_alt_texts_extractor_service.rb
+++ b/app/services/oregon_digital/file_set_alt_texts_extractor_service.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module OregonDigital
+  # A service to extract the metadata of alt text in image file
+  class FileSetAltTextsExtractorService
+    # PATH: Setup path for tool usage of EXIFTOOL
+    EXIFTOOL = '/opt/fits/tools/exiftool/perl/exiftool'
+
+    # METHOD: Extract the text out of file
+    def self.extract(file_path)
+      # EXECUTE: Call the command to fetch the alt text out of the file while ignore header & warning message
+      texts_extracted = `perl #{EXIFTOOL} -AltTextAccessibility -ImageDescription -s3 "#{file_path}" 2>/dev/null`
+      texts_extracted.split("\n").map(&:strip).reject(&:empty?).first
+    end
+  end
+end

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -16,6 +16,11 @@
       <% end %>
       <%= "Accessibility Features: #{member.solr_document['accessibility_feature_tesim'].map { |a| accessibility_display(a) }.join(', ')}" %>
     <% end %>
+    <%# FIELD: Add in the :alt_text field if the data was able to extract from it %>
+    <% if member.alt_text.present? %>
+      <br/><br/>
+      <span aria-label="Alternative Text">Alternative Text:</span> <span class="alt-text-display"><%= "#{member.alt_text.first}" %></span>
+    <% end %>
   </td>
   <td class="attribute attribute-date_uploaded"><%= member.try(:date_uploaded) %></td>
   <td class="attribute attribute-permission"><%= member.permission_badge %></td>

--- a/app/views/hyrax/file_sets/_show_details.html.erb
+++ b/app/views/hyrax/file_sets/_show_details.html.erb
@@ -23,6 +23,13 @@
       <dd class="col-7"><%= @presenter.solr_document['oembed_url_sim'] %></dd>
     </div>
   <% end %>
+  <%# OVERRIDE FROM HYRAX to show :alt_text %>
+  <% if @presenter.solr_document['alt_text_label_sim'].present? %>
+    <div class="row">
+      <dt class="col-5"><%= t(".alt_text") %></dt>
+      <dd class="col-7"><%= @presenter.solr_document['alt_text_label_tesim'].first %></dd>
+    </div>
+  <% end %>
   <div class="row">
     <dt class="col-5"><%= t(".characterization") %></dt>
     <dd class="col-7">

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -89,6 +89,7 @@ Bulkrax.setup do |config|
   fieldhash_csv['oembed_urls'] = { from:['oembed_urls'], split: true }
   fieldhash_csv['accessibility_feature'] = { from:['accessibilityFeature'], split: true }
   fieldhash_csv['accessibility_summary'] = { from:['accessibilitySummary'], split: true }
+  fieldhash_csv['alt_text'] = { from:['alt_text'], split: true }
   fieldhash_csv['full_size_download_allowed'][:parsed] = true
   config.field_mappings['Bulkrax::CsvParser'] = fieldhash_csv
 end
@@ -143,7 +144,7 @@ Bulkrax::CsvEntry.class_eval do
     Array.wrap(content.to_s.strip).join('; ')
   end
 
-  # override to use add_oembed & add_accessibilities
+  # override to use add_oembed & add_alt_text
   def build_metadata
     validate_record
 
@@ -159,12 +160,17 @@ Bulkrax::CsvEntry.class_eval do
     sanitize_controlled_uri_values!
     add_local
     add_oembed
+    add_alt_text
 
     self.parsed_metadata
   end
 
   def add_oembed
       self.parsed_metadata['oembed_urls'] = [record['oembed_urls']]
+  end
+
+  def add_alt_text
+      self.parsed_metadata['alt_text'] = [record['alt_text']]
   end
 
   # commented change to avoid urls in the export headers

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -280,6 +280,8 @@ en:
         save: Save
         title: Title
         accessibility_feature: Accessibility Feature
+      show_details:
+        alt_text: Alternative Text
     search:
       form:
         facet:

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe FileSet, type: :model do
     end
   end
 
+  describe 'alt_text_metadata' do
+    it 'accepts alt_text metadata' do
+      expect(model).to respond_to(:alt_text)
+    end
+  end
+
   describe 'oembed?' do
     it 'returns false when an oembed_url is not present' do
       expect(model.oembed?).to be false

--- a/spec/services/oregon_digital/file_set_alt_texts_extractor_service_spec.rb
+++ b/spec/services/oregon_digital/file_set_alt_texts_extractor_service_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe OregonDigital::FileSetAltTextsExtractorService do
+  # SETUP: Create a test variable
+  let(:service) { described_class.new }
+  let(:file_path) { '/path/image.tif' }
+  let(:alt_text_value) { 'test value' }
+
+  # TEST: To see the alt text can be extracted from the file
+  describe '#extract' do
+    context 'when file has alt text in the field' do
+      before do
+        # MOCK: Fake the shell command so we dont need a real file
+        allow_any_instance_of(Object).to receive(:`).and_return("#{alt_text_value}\n")
+      end
+
+      it 'returns the alt text value' do
+        result = service.extract(file_path)
+        expect(result).to eq('test value')
+      end
+    end
+  end
+end

--- a/spec/services/oregon_digital/file_set_alt_texts_extractor_service_spec.rb
+++ b/spec/services/oregon_digital/file_set_alt_texts_extractor_service_spec.rb
@@ -2,7 +2,6 @@
 
 describe OregonDigital::FileSetAltTextsExtractorService do
   # SETUP: Create a test variable
-  let(:service) { described_class.new }
   let(:file_path) { '/path/image.tif' }
   let(:alt_text_value) { 'test value' }
 
@@ -15,7 +14,7 @@ describe OregonDigital::FileSetAltTextsExtractorService do
       end
 
       it 'returns the alt text value' do
-        result = service.extract(file_path)
+        result = described_class.extract(file_path)
         expect(result).to eq('test value')
       end
     end


### PR DESCRIPTION
`FEATURE:` Add an embedded `alt_text` field to the FileSet and automatically extract content with image metadata that has `alt_text` in it.

**Step to Do it:**
_Part No.1: Setup Model and Service_
- [x] Add in `alt_text` field to the FileSet
- [x] Create a `service` to extract the data from FileSet

_Part No.2: Create extraction & index_
- [x] Setup the `characterize_job` to do the extraction once image upload
- [x] Create an indexing for the new field

_Part No.3: Update View_
- [x] Update the view on show page to include in the `:alt_text`
- [x] Do the same for the FileSet view as well

_Part No.4: Bulkrax_
- [x] Add the field in Bulkrax

_Part No.5: Spec_
- [x] Create any spec needed for the new creation
