### PR TITLE
Update bulkrax to get alt_text to work for FileSet

### DIFF
--- a/app/factories/bulkrax/oregon_digital_object_factory.rb
+++ b/app/factories/bulkrax/oregon_digital_object_factory.rb
@@ -5,7 +5,7 @@ module Bulkrax
   class OregonDigitalObjectFactory < ObjectFactory
     # Override to add the _attributes properties
     def permitted_attributes
-      attribute_properties + oembed_attribute + accessibility_attributes + alt_text_attributes + super
+      attribute_properties + oembed_attribute + accessibility_attributes + super
     end
 
     # Gather the attribute_properties
@@ -21,11 +21,6 @@ module Bulkrax
 
     def accessibility_attributes
       %i[accessibility_feature accessibility_summary]
-    end
-
-    # NEW: Add alt_text to permitted attributes
-    def alt_text_attributes
-      %i[alt_text]
     end
   end
 end

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -89,7 +89,6 @@ Bulkrax.setup do |config|
   fieldhash_csv['oembed_urls'] = { from:['oembed_urls'], split: true }
   fieldhash_csv['accessibility_feature'] = { from:['accessibilityFeature'], split: true }
   fieldhash_csv['accessibility_summary'] = { from:['accessibilitySummary'], split: true }
-  fieldhash_csv['alt_text'] = { from:['alt_text'], split: true }
   fieldhash_csv['full_size_download_allowed'][:parsed] = true
   config.field_mappings['Bulkrax::CsvParser'] = fieldhash_csv
 end
@@ -160,17 +159,12 @@ Bulkrax::CsvEntry.class_eval do
     sanitize_controlled_uri_values!
     add_local
     add_oembed
-    add_alt_text
 
     self.parsed_metadata
   end
 
   def add_oembed
       self.parsed_metadata['oembed_urls'] = [record['oembed_urls']]
-  end
-
-  def add_alt_text
-      self.parsed_metadata['alt_text'] = [record['alt_text']]
   end
 
   # commented change to avoid urls in the export headers


### PR DESCRIPTION
`UPDATE:` Create an update to remove some function of `alt_text` in Bulkrax due to it being at work level not FileSet level.