### PR TITLE
Adjust collection featured thumbnail positions

### DIFF
--- a/app/views/hyrax/collections/_showcase_tile.html.erb
+++ b/app/views/hyrax/collections/_showcase_tile.html.erb
@@ -1,4 +1,4 @@
-<div class="masonry collection document">
+<div class="masonry collection document position-static">
   <% parent = document.parents.first %>
   <div class="thumbnail">
     <%= link_to(url_for_document(parent), document_link_params(parent, :counter => document_counter_with_offset(document_counter)))  do |body| %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -6,7 +6,7 @@
 <div class="hyc-container container collection-header" itemscope itemtype="http://schema.org/CollectionPage">
   <div class="row hyc-header">
     <%# Title, view, and description %>
-    <div class="hyc-generic">
+    <div class="hyc-generic w-100">
       <div class="row">
         <div class="col-lg-8 col-sm-12">
           <div class="hyc-title">
@@ -80,7 +80,7 @@
     <div class="hyc-blacklight hyc-bl-results hyc-bl-search hyc-bl-collection col-12">
       <div id="documents">
         <% # container for all documents in index view -%>
-        <div class="<%= 'blurred-image' if @collection.mask_content.include?('Item Show Page') %>" id="thumbnails" data-behavior="masonry-gallery">
+        <div class="<%= 'blurred-image' if @collection.mask_content.include?('Item Show Page') %> d-flex flex-sm-wrap justify-content-between h-100" id="thumbnails" data-behavior="masonry-gallery">
           <div id="masonry-sizer"></div>
           <div id="masonry-gutter-sizer"></div>
           <%= render collection: controller.collection.representative_docs, as: :document, partial: 'showcase_tile', locals: {count: @member_docs.length} %>


### PR DESCRIPTION
Closes #3218 

Fixes the featured thumbnails on the collection landing page so that the images consistently show up correctly and don't overlap.

## Screenshots
<img alt="collection landing page large screen" src="https://github.com/user-attachments/assets/3f4b11f4-5080-4d58-a4d5-7f64911f2bd3" />
<img alt="collection landing page small screen" src="https://github.com/user-attachments/assets/434a9eae-ec1f-4ac9-b528-960fcc006783" />
