### PR TITLE
Fix bootstrap issues across site

### DIFF
--- a/app/assets/stylesheets/oregon_digital/_header.scss
+++ b/app/assets/stylesheets/oregon_digital/_header.scss
@@ -152,6 +152,7 @@ header {
   }
 
   #masthead {
+    z-index: 1001;
     box-shadow: 0 0 10px $dark-grey;
     border-width: 0 0 5px 0;
     padding: 1em 2em;

--- a/app/assets/stylesheets/oregon_digital/_header.scss
+++ b/app/assets/stylesheets/oregon_digital/_header.scss
@@ -170,8 +170,7 @@ header {
 
   #top-navbar-collapse {
     letter-spacing: 2px;
-
-    @media (max-width: breakpoint-max(lg)) {
+    @media (max-width: breakpoint-max(md)) {
       justify-content: flex-start !important;
     }
 

--- a/app/assets/stylesheets/oregon_digital/_header.scss
+++ b/app/assets/stylesheets/oregon_digital/_header.scss
@@ -193,10 +193,16 @@ header {
 
         a {
           color: #333;
-        }
 
-        & > a:hover{
-          text-decoration: none;
+          &:active{
+            background-color: #f5f5f5;
+            outline: 2px auto Highlight !important;
+            outline: 2px auto -webkit-focus-ring-color !important;
+          }
+
+          &:hover{
+            text-decoration: none;
+          }
         }
       }
       

--- a/app/assets/stylesheets/oregon_digital/_home-page.scss
+++ b/app/assets/stylesheets/oregon_digital/_home-page.scss
@@ -38,8 +38,10 @@ td.toggle .input-group-btn:last-child > input[type=submit]:not(:last-child) {
     text-align: center;
   }
 
-  .background-container img {
-    width: 100%;
+  @media (min-width: breakpoint-max(lg)) {
+    .background-container img {
+      width: 100%;
+    }
   }
 }
 #masthead {

--- a/app/assets/stylesheets/oregon_digital/_sidebar.scss
+++ b/app/assets/stylesheets/oregon_digital/_sidebar.scss
@@ -10,7 +10,7 @@
   }
 }
 
-.profile-data-name .h3 {
+.profile-data-name .h3, .card-user .card-header h3{
   margin-top: 20px;
   margin-bottom: 10px;
 }

--- a/app/assets/stylesheets/oregon_digital/_sign_up.scss
+++ b/app/assets/stylesheets/oregon_digital/_sign_up.scss
@@ -2,6 +2,10 @@
   max-width: map-get($container-max-widths, "md");;
   margin: auto;
 
+  h1 {
+    margin-top: 20px;
+  }
+
   .login-footer,
   .new_user {
     padding: 2em 0;

--- a/app/assets/stylesheets/oregon_digital/dashboard/_dashboard.scss
+++ b/app/assets/stylesheets/oregon_digital/dashboard/_dashboard.scss
@@ -130,3 +130,9 @@ table.dataTable td.dataTables_empty {
 .list-group-item > .badge, td.status .list-group-item > span {
   float: right;
 }
+
+#myTab {
+  .nav-link.active {
+    border-top: inherit !important;
+  }
+}

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,7 +3,7 @@
 
   <div class="login-select">
     <div class="row">
-      <ul class="flex-container">
+      <ul class="flex-container w-100 justify-content-between">
         <li class="osu-login flex-item">
           <div>
             <label>
@@ -34,23 +34,23 @@
 
   <div class="lime-green-hr" style="margin-bottom:1em"></div>
 
-  <div id="login-page-footer-OSU-footer" class=" login-footer text-center" style='display: none;'>
-    <div class='row'>
+  <div id="login-page-footer-OSU-footer" class=" login-footer" style='display: none;'>
+    <div class='row justify-content-center'>
       <%= button_to main_app.new_osu_session_path, method: :post, class: 'btn btn-primary' do %>
         <span class="university-login">CONTINUE TO OSU LOG IN</span>
       <% end %>
     </div>
-    <div class='row'>
+    <div class='row justify-content-center'>
       Questions about logging in? Contact us.
     </div>
   </div>
-  <div id="login-page-footer-UO-footer" class=" login-footer text-center" style='display: none;'>
-    <div class='row'>
+  <div id="login-page-footer-UO-footer" class=" login-footer" style='display: none;'>
+    <div class='row justify-content-center'>
       <%= button_to main_app.new_uo_session_path, method: :post, class: 'btn btn-primary' do %>
         <span class="university-login">CONTINUE TO UO LOG IN</span>
       <% end %>
     </div>
-    <div class='row'>
+    <div class='row justify-content-center'>
       Questions about logging in? Contact us.
     </div>
   </div>

--- a/app/views/hyrax/users/_profile_tabs.html.erb
+++ b/app/views/hyrax/users/_profile_tabs.html.erb
@@ -1,8 +1,8 @@
 <%# OVERRIDE: Override the original tab to remove the highlighted tab as no longer needed %>
 <ul class="nav nav-tabs" id="myTab">
-  <li class="active"><a href="#activity_log"><span class="glyphicon glyphicon-calendar"></span> <%= I18n.t('hyrax.user_profile.tab_activity') %></a></li>
+  <li class="nav-link active"><a href="#activity_log"><span class="fa fa-calendar"></span> <%= I18n.t('hyrax.user_profile.tab_activity') %></a></li>
 </ul>
 
-<div class="tab-content panel-body">
+<div class="tab-content card-body">
   <%= render 'activity', presenter: presenter %>
 </div> <!-- /tab-content -->

--- a/app/views/hyrax/users/_user.html.erb
+++ b/app/views/hyrax/users/_user.html.erb
@@ -1,5 +1,5 @@
-<div class="panel panel-default panel-user">
-  <div class="panel-heading">
+<div class="card card-default card-user">
+  <div class="card-header">
     <%= image_tag user.avatar.url(:thumb), width: 100 if user.avatar.present? %>
     <h3>
       <%= user.name %>
@@ -21,10 +21,10 @@
     <% end %>
   </div>
 
-  <div class="panel-footer clearfix">
+  <div class="card-footer clearfix">
     <% if can? :edit, user %>
       <%= link_to hyrax.edit_dashboard_profile_path(user), class: "btn btn-default pull-right" do %>
-        <i class="glyphicon glyphicon-edit"></i> <%= t("hyrax.edit_profile") %>
+        <i class="fa fa-edit"></i> <%= t("hyrax.edit_profile") %>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
Related to #3219 

## Fixes:
- Navbar element spacing updated to match v3 between the medium and large screen breakpoints
- The user utility link behavior when active now matches v3
- Reduce warping of background image on home page when adjusting the window size
- Fixes spacing on log in pages
- Update user profile page to match v3

## Screenshots
### Header before
<img width="1466" height="95" alt="header before fix" src="https://github.com/user-attachments/assets/6bb648bd-417f-49df-a587-b1e71c52a462" />

### Header after
<img width="1460" height="88" alt="header after fix" src="https://github.com/user-attachments/assets/f0af0a5a-26a2-4aa2-a086-fe91d327ec91" />

### User utility links
<img width="271" height="256" alt="user utility link being clicked" src="https://github.com/user-attachments/assets/70b475a7-c98b-4f55-8135-df22ddd17af7" />

### Homepage background image
<img height="300" alt="Screenshot 2026-06-15 at 15 40 51" src="https://github.com/user-attachments/assets/8c97058d-3128-4394-834b-adec9bb3dd27" />

### Log in page
<img height="300" alt="Log in page for other affiliation" src="https://github.com/user-attachments/assets/4f4b59d9-540a-4536-9b23-059a41669288" />
<img height="300" alt="Log in page for institution" src="https://github.com/user-attachments/assets/e0c39ae3-62f2-4575-98f4-d845a1b9bd57" />

### User profile page
<img height="500" alt="User profile" src="https://github.com/user-attachments/assets/9b8c9536-f688-4320-8cc8-1944a243fe1b" />
