### PR TITLE
Store fail URI fetch into Triplestore

### DIFF
--- a/app/indexers/oregon_digital/deep_indexing_service.rb
+++ b/app/indexers/oregon_digital/deep_indexing_service.rb
@@ -57,11 +57,13 @@ module OregonDigital
 
     # override Hyrax fetch_value to get rid of misleading logging
     def fetch_value(value)
-      Thread.current[:work_id] = @object.id
       value.fetch(headers: { 'Accept' => default_accept_header })
     rescue IOError, SocketError, TriplestoreAdapter::TriplestoreException => e
       # IOError could result from a 500 error on the remote server
       # SocketError results if there is no server to connect to
+      # Add in the fail fetch attempt to store the info what is being fail
+      OregonDigital::Triplestore.create_and_check_directory
+      OregonDigital::Triplestore.store_failed_fetch(@object.id, [{ uri: value.rdf_subject.to_s, error: e.message }])
       Rails.logger.error "Unable to fetch #{value.rdf_subject}.\n#{e.message}"
     end
 

--- a/app/indexers/oregon_digital/deep_indexing_service.rb
+++ b/app/indexers/oregon_digital/deep_indexing_service.rb
@@ -57,6 +57,7 @@ module OregonDigital
 
     # override Hyrax fetch_value to get rid of misleading logging
     def fetch_value(value)
+      Thread.current[:work_id] = @object.id
       value.fetch(headers: { 'Accept' => default_accept_header })
     rescue IOError, SocketError, TriplestoreAdapter::TriplestoreException => e
       # IOError could result from a 500 error on the remote server

--- a/app/mailers/oregon_digital/failed_fetch_mailer.rb
+++ b/app/mailers/oregon_digital/failed_fetch_mailer.rb
@@ -10,7 +10,7 @@ module OregonDigital
         file_path = "#{Rails.root.join('tmp')}/#{params[:filename]}"
         attachments[params[:filename]] = File.read(file_path) if File.exist?(file_path)
       else
-        file_text = "#{Rails.root.join('tmp', 'failed_fetch')}/#{params[:filename]}"
+        file_text = "#{Rails.root.join('tmp', 'shared', 'failed_fetch')}/#{params[:filename]}"
         attachments[params[:filename]] = File.read(file_text) if File.exist?(file_text)
       end
 

--- a/app/workers/fetch_graph_worker.rb
+++ b/app/workers/fetch_graph_worker.rb
@@ -7,13 +7,8 @@ class FetchGraphWorker
   sidekiq_options queue: 'fetch' # Use the 'fetch' queue
 
   # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
   # user not needed any longer?
   def perform(pid, _user_key)
-    # Create an array to store failed fetch & call method to check/create exist of tmp folder
-    failed_cv = []
-    create_and_check_directory
-
     # Here be dragons
     # A valkyrie work's controlled properties don't resolve to our OregonDigital::ControlledVocabularies::* objects
     # They resolve to RDF::URI, we need to find a way to get the right CV & index it
@@ -24,20 +19,15 @@ class FetchGraphWorker
 
         val.fetch(headers: { 'Accept' => default_accept_header })
         val.persist!
-      rescue TriplestoreAdapter::TriplestoreException, IOError, OregonDigital::ControlledVocabularies::ControlledVocabularyFetchError => e
-        failed_cv << { uri: val.to_s, error: e.message }
+      rescue TriplestoreAdapter::TriplestoreException, IOError, OregonDigital::ControlledVocabularies::ControlledVocabularyFetchError
         fetch_failed_graph(val)
         next
       end
     end
 
-    # CALL: Invoke the creation of failed_fetch file if array is not empty
-    store_failed_fetch(pid, failed_cv) unless failed_cv.blank?
     work.update_index
   end
   # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/AbcSize
-
   # TODO: WILL INTEGRATE THIS WHEN REDOING EMAILING FOR THESE JOBS
   # def fetch_failed_callback(user, val)
   #   Hyrax.config.callback.run(:ld_fetch_failure, user, val.rdf_subject.value)
@@ -49,35 +39,5 @@ class FetchGraphWorker
 
   def default_accept_header
     RDF::Util::File::HttpAdapter.default_accept_header.sub(%r{, \*\/\*;q=0\.1\Z}, '')
-  end
-
-  # METHOD: Create a method store all fails CV fetch
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
-  def store_failed_fetch(pid, failed_cv)
-    # PATH: Setup a path for the txt file
-    path = Rails.root.join('tmp', 'failed_fetch', "#{pid}.txt").to_s
-
-    # SEARCH: Look for works to create a link & get URL path
-    work = SolrDocument.find(pid)
-    url_path = Rails.application.routes.url_helpers.polymorphic_url(work)
-    # STORE: Add in data to txt file
-    File.open(path, 'w+') do |f|
-      f.puts('Failed Fetch Record')
-      f.puts("Work ID: #{pid}")
-      f.puts("Work Link: #{url_path}")
-      failed_cv.each do |w|
-        f.puts("Error Placement: #{w[:uri]}   Error on Value: #{w[:error]}")
-      end
-      f.puts("Time Recorded: #{Time.now.strftime('%m-%d-%Y %I:%M %p')}")
-    end
-  end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/MethodLength
-
-  # METHOD: Create and check exist of folder
-  def create_and_check_directory
-    dir_path = Rails.root.join('tmp', 'failed_fetch').to_s
-    FileUtils.mkdir_p(dir_path)
   end
 end

--- a/lib/oregon_digital/failed_fetch_notification.rb
+++ b/lib/oregon_digital/failed_fetch_notification.rb
@@ -11,6 +11,7 @@ module OregonDigital
     end
 
     # METHOD: Add user to the 'map_user' list
+    # rubocop:disable Metrics/MethodLength
     def add_list_of_users
       # CHECK: See if folder exist
       return unless folder_exist?
@@ -30,6 +31,7 @@ module OregonDigital
         user_map << { doc['depositor_ssim'].first => "#{doc['id']}.txt" }
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     # METHOD: Add method to fetch metadeities
     def fetch_metadeities

--- a/lib/oregon_digital/failed_fetch_notification.rb
+++ b/lib/oregon_digital/failed_fetch_notification.rb
@@ -11,7 +11,6 @@ module OregonDigital
     end
 
     # METHOD: Add user to the 'map_user' list
-    # rubocop:disable Metrics/MethodLength
     def add_list_of_users
       # CHECK: See if folder exist
       return unless folder_exist?
@@ -20,18 +19,12 @@ module OregonDigital
       pid_arr = fetch_pids
 
       # LOOP: Go through Solr Doc to find depositor to user_map
-      solr_docs = pid_arr.filter_map do |pid|
-        SolrDocument.find(pid)
-      rescue Blacklight::Exceptions::RecordNotFound
-        Rails.logger.warn "SolrDocument not found for pid: #{pid}"
-        nil
-      end
+      solr_docs = SolrDocument.find(pid_arr)
 
       solr_docs.each do |doc|
         user_map << { doc['depositor_ssim'].first => "#{doc['id']}.txt" }
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     # METHOD: Add method to fetch metadeities
     def fetch_metadeities

--- a/lib/oregon_digital/failed_fetch_notification.rb
+++ b/lib/oregon_digital/failed_fetch_notification.rb
@@ -19,7 +19,13 @@ module OregonDigital
       pid_arr = fetch_pids
 
       # LOOP: Go through Solr Doc to find depositor to user_map
-      solr_docs = SolrDocument.find(pid_arr)
+      solr_docs = pid_arr.filter_map do |pid|
+        SolrDocument.find(pid)
+      rescue Blacklight::Exceptions::RecordNotFound
+        Rails.logger.warn "SolrDocument not found for pid: #{pid}"
+        nil
+      end
+
       solr_docs.each do |doc|
         user_map << { doc['depositor_ssim'].first => "#{doc['id']}.txt" }
       end
@@ -36,7 +42,7 @@ module OregonDigital
       pids = []
 
       # FETCH: Ensure the directory exists and is not empty
-      fetch_dir = Rails.root.join('tmp', 'failed_fetch').to_s
+      fetch_dir = Rails.root.join('tmp', 'shared', 'failed_fetch').to_s
 
       # LOOP: Loop through the directory to check on file
       Dir.foreach(fetch_dir) do |filename|
@@ -56,7 +62,7 @@ module OregonDigital
     # Create zip file to send to metadeities
     def create_zip_file
       # GET: Get path to folder
-      dir_path = Rails.root.join('tmp', 'failed_fetch').to_s
+      dir_path = Rails.root.join('tmp', 'shared', 'failed_fetch').to_s
 
       # CHECK: Ensure the directory exists and is not empty
       return unless folder_exist?
@@ -81,7 +87,7 @@ module OregonDigital
 
     # METHOD: Return a bool to see if folder exist
     def folder_exist?
-      dir_path = Rails.root.join('tmp', 'failed_fetch').to_s
+      dir_path = Rails.root.join('tmp', 'shared', 'failed_fetch').to_s
       File.exist?(dir_path) && !Dir.empty?(dir_path)
     end
 
@@ -95,7 +101,7 @@ module OregonDigital
     # METHOD: Delete all files in folder to clear up
     def delete_files
       # PATH: Define the folder path using Rails.root.join for safety
-      folder = Rails.root.join('tmp', 'failed_fetch').to_s
+      folder = Rails.root.join('tmp', 'shared', 'failed_fetch').to_s
 
       # CHECK: Check if the directory exists before trying to delete files
       return unless Dir.exist?(folder)

--- a/lib/oregon_digital/triplestore.rb
+++ b/lib/oregon_digital/triplestore.rb
@@ -85,6 +85,10 @@ module OregonDigital
       cache_check = Rails.cache.read(uri)
       return nil if cache_check == 'failed'
 
+      # Create an array to store failed fetch & call method to check/create exist of tmp folder
+      failed_cv = []
+      create_and_check_directory
+
       begin
         # CONDITION: Check on one of the CV is Homosaurus or BNE
         graph = if uri.to_s.include?('homosaurus') || uri.to_s.include?('datos.bne.es')
@@ -94,13 +98,51 @@ module OregonDigital
                 end
         Rails.logger.info "Fetch successful from external source: #{uri}"
         graph
-      rescue TriplestoreAdapter::TriplestoreException
+      rescue TriplestoreAdapter::TriplestoreException => e
         Rails.logger.warn "Fetch failed from external source: #{uri}"
         Rails.cache.write(uri, 'failed', expires_in: ENV.fetch('FETCH_EXTERNAL_FAILED_WAIT', 1.week).to_i)
+        failed_cv << { uri: uri.to_s, error: e.message }
+
+        # GET: Fetch the id in thread
+        work_id = Thread.current[:work_id]
+
+        # CALL: Invoke the creation of failed_fetch file if array is not empty
+        store_failed_fetch(work_id, failed_cv) unless failed_cv.blank?
         raise TriplestoreAdapter::TriplestoreException
       end
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
+
+    # METHOD: Create a method store all fails CV fetch
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
+    def self.store_failed_fetch(id, failed_cv)
+      # PATH: Setup a path for the txt file
+      path = Rails.root.join('tmp', 'failed_fetch', "#{id}.txt").to_s
+
+      # SEARCH: Look for works to create a link & get URL path
+      work = SolrDocument.find(id)
+      url_path = Rails.application.routes.url_helpers.polymorphic_url(work)
+
+      # STORE: Add in data to txt file & check on exist file
+      File.open(path, File.exist?(path) ? 'a' : 'w+') do |f|
+        f.puts('Failed Fetch Record')
+        f.puts("Work ID: #{id}")
+        f.puts("Work Link: #{url_path}")
+        failed_cv.each do |w|
+          f.puts("Error Placement: #{w[:uri]}   Error on Value: #{w[:error]}")
+        end
+        f.puts("Time Recorded: #{Time.now.strftime('%m-%d-%Y %I:%M %p')}")
+      end
+    end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
+
+    # METHOD: Create and check exist of folder
+    def self.create_and_check_directory
+      dir_path = Rails.root.join('tmp', 'failed_fetch').to_s
+      FileUtils.mkdir_p(dir_path)
+    end
   end
 end

--- a/lib/oregon_digital/triplestore.rb
+++ b/lib/oregon_digital/triplestore.rb
@@ -94,7 +94,7 @@ module OregonDigital
                 end
         Rails.logger.info "Fetch successful from external source: #{uri}"
         graph
-      rescue TriplestoreAdapter::TriplestoreException => e
+      rescue TriplestoreAdapter::TriplestoreException
         Rails.logger.warn "Fetch failed from external source: #{uri}"
         Rails.cache.write(uri, 'failed', expires_in: ENV.fetch('FETCH_EXTERNAL_FAILED_WAIT', 1.week).to_i)
         raise TriplestoreAdapter::TriplestoreException

--- a/lib/oregon_digital/triplestore.rb
+++ b/lib/oregon_digital/triplestore.rb
@@ -85,10 +85,6 @@ module OregonDigital
       cache_check = Rails.cache.read(uri)
       return nil if cache_check == 'failed'
 
-      # Create an array to store failed fetch & call method to check/create exist of tmp folder
-      failed_cv = []
-      create_and_check_directory
-
       begin
         # CONDITION: Check on one of the CV is Homosaurus or BNE
         graph = if uri.to_s.include?('homosaurus') || uri.to_s.include?('datos.bne.es')
@@ -101,13 +97,6 @@ module OregonDigital
       rescue TriplestoreAdapter::TriplestoreException => e
         Rails.logger.warn "Fetch failed from external source: #{uri}"
         Rails.cache.write(uri, 'failed', expires_in: ENV.fetch('FETCH_EXTERNAL_FAILED_WAIT', 1.week).to_i)
-        failed_cv << { uri: uri.to_s, error: e.message }
-
-        # GET: Fetch the id in thread
-        work_id = Thread.current[:work_id]
-
-        # CALL: Invoke the creation of failed_fetch file if array is not empty
-        store_failed_fetch(work_id, failed_cv) unless failed_cv.blank?
         raise TriplestoreAdapter::TriplestoreException
       end
     end
@@ -119,7 +108,7 @@ module OregonDigital
     # rubocop:disable Metrics/AbcSize
     def self.store_failed_fetch(id, failed_cv)
       # PATH: Setup a path for the txt file
-      path = Rails.root.join('tmp', 'failed_fetch', "#{id}.txt").to_s
+      path = Rails.root.join('tmp', 'shared', 'failed_fetch', "#{id}.txt").to_s
 
       # SEARCH: Look for works to create a link & get URL path
       work = SolrDocument.find(id)
@@ -141,7 +130,7 @@ module OregonDigital
 
     # METHOD: Create and check exist of folder
     def self.create_and_check_directory
-      dir_path = Rails.root.join('tmp', 'failed_fetch').to_s
+      dir_path = Rails.root.join('tmp', 'shared', 'failed_fetch').to_s
       FileUtils.mkdir_p(dir_path)
     end
   end

--- a/spec/mailers/oregon_digital/failed_fetch_mailer_spec.rb
+++ b/spec/mailers/oregon_digital/failed_fetch_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OregonDigital::FailedFetchMailer do
   let(:filename) { 'somefile.txt' }
   let(:params) { { to: email, filename: filename } }
   let(:mail) { described_class.with(params).failed_fetch_email }
-  let(:path) { "#{Rails.root.join('tmp', 'failed_fetch')}/#{params[:filename]}" }
+  let(:path) { "#{Rails.root.join('tmp', 'shared', 'failed_fetch')}/#{params[:filename]}" }
 
   # MOCK: Mock the file existence to simulate real file checks
   before do

--- a/spec/workers/fetch_graph_worker_spec.rb
+++ b/spec/workers/fetch_graph_worker_spec.rb
@@ -26,8 +26,6 @@ RSpec.describe FetchGraphWorker, type: :worker do
         stub_request(:get, 'http://opaquenamespace.org/ns/creator/ChabreWayne').to_return(status: 200, body: '', headers: {})
         stub_request(:get, 'https://opaquenamespace.org/ns/creator/ChabreWayne').to_return(status: 200, body: '', headers: {})
         stub_request(:get, 'http://opaquenamespace.org/ns/genus/Acnanthes').to_return(status: 200, body: '', headers: {})
-
-        allow(worker).to receive(:store_failed_fetch).and_return(true)
       end
 
       it 'fetches all of its linked data labels' do
@@ -52,7 +50,6 @@ RSpec.describe FetchGraphWorker, type: :worker do
         stub_request(:get, 'https://opaquenamespace.org/ns/creator/ChabreWayne').to_return(status: 500, body: '', headers: {})
         stub_request(:get, 'http://opaquenamespace.org/ns/genus/Acnanthes').to_return(status: 500, body: '', headers: {})
         allow(location_controlled_val).to receive('fetch')
-        allow(worker).to receive(:store_failed_fetch).and_return(true)
       end
 
       it 'calls #fetch_failed_graph to fire off new job' do


### PR DESCRIPTION
`UDPATE:` Add the fail fetch to the `triplestore` rather than `workers` to do the work.