### PR TITLE
Display oembed viewer above uv if both available in children

### DIFF
--- a/app/actors/oregon_digital/actors/create_with_oembed_url_actor.rb
+++ b/app/actors/oregon_digital/actors/create_with_oembed_url_actor.rb
@@ -42,7 +42,6 @@ module OregonDigital
       # rubocop:disable Metrics/MethodLength
       def create_file_from_url(env, uri)
         oembed_url = URI.decode_www_form_component(uri.to_s)
-        use_valkyrie = false
         fs_class = env.curation_concern.is_a?(Valkyrie::Resource) ? Hyrax::FileSet : ::FileSet
 
         file_set = fs_class.new(oembed_url: oembed_url) do |fs|
@@ -60,12 +59,9 @@ module OregonDigital
           fs.title = Array(title)
         end
 
-        if env.curation_concern.is_a? Valkyrie::Resource
-          file_set = Hyrax.persister.save(resource: file_set)
-          use_valkyrie = true
-        end
+        file_set = Hyrax.persister.save(resource: file_set) if env.curation_concern.is_a? Valkyrie::Resource
 
-        actor = Hyrax::Actors::FileSetActor.new(file_set, env.user, use_valkyrie: use_valkyrie)
+        actor = Hyrax::Actors::FileSetActor.new(file_set, env.user)
         actor.create_metadata(visibility: env.curation_concern.visibility)
         actor.attach_to_work(env.curation_concern)
         file_set.save! if file_set.respond_to?(:save!)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -168,6 +168,10 @@ class SolrDocument
     self['oai_collections_ssim']
   end
 
+  def oembed_url
+    self['oembed_url_sim']
+  end
+
   # METHOD: Fetch the ssim for 'label$uri'
   def label_uri_helpers(attribute_name)
     OregonDigital::LabelParserService.parse_label_uris(self["#{attribute_name}_parsable_label_ssim"])
@@ -184,6 +188,6 @@ class SolrDocument
   solrized_methods Generic.controlled_properties
   solrized_methods Generic.controlled_property_labels
   solrized_methods FileSet.characterization_terms
-  solrized_methods %w[resource_type_label language_label rights_statement_label oembed_url]
+  solrized_methods %w[resource_type_label language_label rights_statement_label]
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/presenters/hyrax/generic_presenter.rb
+++ b/app/presenters/hyrax/generic_presenter.rb
@@ -28,10 +28,15 @@ module Hyrax
       fileset_viewable || work_viewable
     end
 
+    # Look for any direct filesets for oembed or any child works with oembed filesets
     def oembed_viewer?
-      file_set_presenters.any? do |presenter|
+      fileset_viewable = file_set_presenters.any? do |presenter|
         oembed?(presenter)
       end
+      work_viewable = work_presenters.any? do |presenter|
+        oembed?(presenter)
+      end
+      fileset_viewable || work_viewable
     end
 
     def page_title
@@ -86,9 +91,17 @@ module Hyrax
       (presenter.image? || presenter.pdf? || presenter.video? || presenter.audio?) && current_ability.can?(:read, presenter.id)
     end
 
+    # if the given presenter is an oEmbed the user is allowed to see
     def oembed?(presenter)
       curation_concern = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: presenter.id, use_valkyrie: false)
-      !curation_concern.oembed_url.nil? && !curation_concern.oembed_url.empty? && current_ability.can?(:read, presenter.id)
+
+      if curation_concern.respond_to?(:oembed_url)
+        # You're a fileset
+        !curation_concern.oembed_url.blank? && current_ability.can?(:read, presenter.id)
+      else
+        # Or you're a work with filesets
+        curation_concern.file_sets.any?(&:oembed_url) && current_ability.can?(:read, presenter.id)
+      end
     end
   end
 end

--- a/app/presenters/oregon_digital/iiif_presenter.rb
+++ b/app/presenters/oregon_digital/iiif_presenter.rb
@@ -70,12 +70,16 @@ module OregonDigital
 
       presenters = work_ids.map do |id|
         doc = SolrDocument.new(document_hash[id])
+        # We don't want the works that contain oembed to be put into the IIIF manifest
+        # They don't have a canvas and breaks the viewer
+        next unless doc.file_sets.map(&:oembed_url).flatten.compact.blank?
+
         presenter = IIIFPresenter.new(doc, current_ability, request)
         presenter.file_sets = doc.file_sets
         presenter.collections = cached_collections
         presenter
       end
-      presenters
+      presenters.compact
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength

--- a/app/views/hyrax/base/_oembed_media.html.erb
+++ b/app/views/hyrax/base/_oembed_media.html.erb
@@ -1,4 +1,4 @@
-<div class='oembed-widget'>
+<div class='oembed-widget col-12'>
   <%= content_tag(:div, '',
       data: {
         embed_url:

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -28,10 +28,23 @@
           <%= render 'workflow_actions_widget', presenter: @presenter %>
         <% end %>
         <% if @presenter.oembed_viewer? %>
-          <% @presenter.file_set_presenters.each do |presenter| %>
-            <%= render 'oembed_media', presenter: presenter %>
+          <%#
+            Either we have filesets or children with filesets that include oembed
+            member_presents returns presents for filesets + child works so we'll iterate that
+          %>
+          <% @presenter.member_presenters.each do |presenter| %>
+            <% if presenter.respond_to?(:oembed_url) %>
+              <%# we could be a fileset presenter, that's easy %>
+              <%= render 'oembed_media', presenter: presenter %>
+            <% else %>
+              <%# or we're a child work presenter, with oembed filesets. We'll have to iterate those filesets too %>
+              <% presenter.file_set_presenters.flatten.each do |fs_presenter| %>
+                <%= render 'oembed_media', presenter: fs_presenter unless fs_presenter.oembed_url.blank? %>
+              <% end %>
+            <% end %>
           <% end %>
-        <% elsif @presenter.iiif_viewer? %>
+        <% end %>
+        <% if @presenter.iiif_viewer? %>
           <div class="col-sm-12">
             <%= render 'representative_media', presenter: @presenter, viewer: true %>
           </div>

--- a/spec/presenters/oregon_digital/oembed_presenter_spec.rb
+++ b/spec/presenters/oregon_digital/oembed_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OregonDigital::OembedPresenter do
   let(:attributes) do
     {
       'title_tesim' => ['Hey guys!'],
-      'oembed_url_tesim' => ['https://www.youtube.com/watch?v=8ZtInClXe1Q'],
+      'oembed_url_sim' => ['https://www.youtube.com/watch?v=8ZtInClXe1Q'],
       'human_readable_type_tesim' => ['File']
     }
   end


### PR DESCRIPTION
Fixes #3608 
@petersec @jsimic It's a bit of a rough fix but UV isn't super stoked about handling iframes, so the video can't go into UV.
<img width="1590" height="950" alt="image" src="https://github.com/user-attachments/assets/fd94e088-b63c-401e-bf19-1eb45e48cb03" />
