### PR TITLE
Add another solr wrapper monkey patch and generalize the monkey patch file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,8 +135,8 @@ jobs:
           name: Compile imagemagick with jp2 support
           command: |
             mkdir -p /tmp/im && \
-            curl -sL https://www.imagemagick.org/archive/releases/ImageMagick-7.1.0-27.tar.xz \
-            | tar -xJvf - -C /tmp/im && cd /tmp/im/ImageMagick-7.1.0-27 && \
+            curl -sL https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.0-62.tar.gz \
+            | tar -xz -C /tmp/im && cd /tmp/im/ImageMagick-7.1.0-62 && \
               ./configure \
                 --build=$CBUILD \
                 --host=$CHOST \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # Install ImageMagick with jp2/tiff support
 # Install ImageMagick with full support
 RUN mkdir -p /tmp/im && \
-  curl -sL https://www.imagemagick.org/archive/releases/ImageMagick-7.1.0-27.tar.xz \
-  | tar -xJvf - -C /tmp/im && cd /tmp/im/ImageMagick-7.1.0-27 && \
+  curl -sL https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.0-62.tar.gz \
+  | tar -xz -C /tmp/im && cd /tmp/im/ImageMagick-7.1.0-62 && \
   ./configure \
   --build=$CBUILD \
   --host=$CHOST \

--- a/config/initializers/hacks/blacklight_oai_patch.rb
+++ b/config/initializers/hacks/blacklight_oai_patch.rb
@@ -51,4 +51,33 @@ Rails.application.config.to_prepare do
       [@asset_show_uri, @asset_image_uri]
     end
   end
+
+
+
+  OAI::Provider::Base.class_eval do
+    # Override the process_request method to use the provider_context instance
+    # instead of self.class, so the real request URL is used in error responses.
+    def process_request(params = {})
+      begin
+
+        # Allow the request to pass in a url
+        provider_context.url = params['url'] ? params.delete('url') : self.url
+
+        verb = params.delete('verb') || params.delete(:verb)
+
+        unless verb and OAI::Const::VERBS.keys.include?(verb)
+          raise OAI::VerbException.new
+        end
+
+        send(methodize(verb), params)
+
+      rescue => err
+        if err.respond_to?(:code)
+          OAI::Provider::Response::Error.new(provider_context, err).to_xml
+        else
+          raise err
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes an issue with OAI endpoint, where Request URL would not populate unless a valid verb was provided. This was preventing some old tooling to break for MWDL