### PR TITLE
Check for FilePresenter class directly

### DIFF
--- a/app/presenters/hyrax/generic_presenter.rb
+++ b/app/presenters/hyrax/generic_presenter.rb
@@ -94,13 +94,14 @@ module Hyrax
     # if the given presenter is an oEmbed the user is allowed to see
     def oembed?(presenter)
       solr_doc = ::SolrDocument.find presenter.id
+      return false unless current_ability.can?(:read, presenter.id)
 
       if solr_doc.file_set?
         # You're a fileset
-        !solr_doc.oembed_url.blank? && current_ability.can?(:read, presenter.id)
+        !solr_doc.oembed_url.blank?
       else
         # Or you're a work with filesets
-        solr_doc.file_sets.any?(&:oembed_url) && current_ability.can?(:read, presenter.id)
+        solr_doc.file_sets.any?(&:oembed_url)
       end
     end
   end

--- a/app/presenters/hyrax/generic_presenter.rb
+++ b/app/presenters/hyrax/generic_presenter.rb
@@ -101,7 +101,7 @@ module Hyrax
         !solr_doc.oembed_url.blank?
       else
         # Or you're a work with filesets
-        solr_doc.file_sets.any?(&:oembed_url)
+        solr_doc.file_sets.any? { |fs_sd| !fs_sd.oembed_url.blank? }
       end
     end
   end

--- a/app/presenters/hyrax/generic_presenter.rb
+++ b/app/presenters/hyrax/generic_presenter.rb
@@ -95,7 +95,7 @@ module Hyrax
     def oembed?(presenter)
       solr_doc = ::SolrDocument.find presenter.id
 
-      if solr_doc.respond_to?(:oembed_url)
+      if solr_doc.file_set?
         # You're a fileset
         !solr_doc.oembed_url.blank? && current_ability.can?(:read, presenter.id)
       else

--- a/app/views/hyrax/base/_oembed_media.html.erb
+++ b/app/views/hyrax/base/_oembed_media.html.erb
@@ -2,7 +2,7 @@
   <%= content_tag(:div, '',
       data: {
         embed_url:
-          Blacklight::Oembed::Engine.routes.url_helpers.embed_path(url: Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: presenter.id, use_valkyrie: false).oembed_url)
+          Blacklight::Oembed::Engine.routes.url_helpers.embed_path(url: SolrDocument.find(presenter.id).oembed_url.first)
       }
     )
   %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -33,7 +33,7 @@
             member_presents returns presents for filesets + child works so we'll iterate that
           %>
           <% @presenter.member_presenters.each do |presenter| %>
-            <% if presenter.respond_to?(:oembed_url) %>
+            <% if presenter.is_a?(Hyrax::FileSetPresenter) %>
               <%# we could be a fileset presenter, that's easy %>
               <%= render 'oembed_media', presenter: presenter %>
             <% else %>

--- a/spec/presenters/hyrax/generic_presenter_spec.rb
+++ b/spec/presenters/hyrax/generic_presenter_spec.rb
@@ -8,10 +8,15 @@ RSpec.describe Hyrax::GenericPresenter do
   let(:solr_document) { SolrDocument.new(model.attributes) }
   let(:props) { Generic.generic_properties.map(&:to_sym) }
   let(:file_set) { instance_double('FileSet') }
+  let(:fs_solr_document) { SolrDocument.new(file_set) }
 
   before do
     allow(presenter).to receive(:file_set_presenters).and_return(presenters)
+    allow(SolrDocument).to receive(:find).with(solr_document.id).and_return solr_document
     allow(solr_document).to receive(:file_set?).and_return(false)
+    allow(solr_document).to receive(:file_sets).and_return([fs_solr_document])
+    allow(SolrDocument).to receive(:find).with(fs_solr_document.id).and_return fs_solr_document
+    allow(fs_solr_document).to receive(:file_set?).and_return(true)
     allow(file_set).to receive(:id).and_return 'abcde1234'
     allow(file_set).to receive(:oembed_url).and_return 'google.com'
   end
@@ -103,7 +108,6 @@ RSpec.describe Hyrax::GenericPresenter do
       presenters.each do |p|
         allow(p).to receive(:id).and_return solr_document.id
       end
-      allow(SolrDocument).to receive(:find).with(solr_document.id).and_return solr_document
       allow(solr_document).to receive(:oembed_url).and_return nil
       allow(Hyrax.query_service).to receive(:find_by_alternate_identifier).with(alternate_identifier: file_set.id, use_valkyrie: false).and_return file_set
     end
@@ -133,7 +137,7 @@ RSpec.describe Hyrax::GenericPresenter do
     context 'when none are oembeds' do
       it 'returns false' do
         allow(ability).to receive(:can?).with(:read, solr_document.id).and_return true
-        allow(solr_document).to receive(:oembed_url).and_return []
+        allow(fs_solr_document).to receive(:oembed_url).and_return nil
         expect(presenter.oembed_viewer?).to eq(false)
       end
     end

--- a/spec/presenters/hyrax/generic_presenter_spec.rb
+++ b/spec/presenters/hyrax/generic_presenter_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Hyrax::GenericPresenter do
 
   before do
     allow(presenter).to receive(:file_set_presenters).and_return(presenters)
+    allow(solr_document).to receive(:file_set?).and_return(false)
     allow(file_set).to receive(:id).and_return 'abcde1234'
     allow(file_set).to receive(:oembed_url).and_return 'google.com'
   end


### PR DESCRIPTION
Fix for message from Slack:

I think [this](https://github.com/OregonDigital/OD2/pull/3689) deploy may have overwritten the Complex Object features that were passed through with [#3608](https://github.com/orgs/OregonDigital/projects/23/views/1?pane=issue&itemId=186827523&issue=OregonDigital%7COD2%7C3608). They were rendering on Prod as of July 10 but aren't showing up anymore ([example](https://oregondigital.org/concern/generics/zc77sr07v)). The same is true on Staging. ([example](https://staging.oregondigital.org/concern/generics/k930bx099)) - Chris Peterson