### PR TITLE
Return library as a controlled vocab in valkyrie resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: Save code cache
           key: v1-source-{{ .Branch }}-{{ .Revision }}
           paths:
-            - ".git"
+            - '.git'
       - persist_to_workspace:
           root: ~/
           paths:
@@ -84,20 +84,20 @@ jobs:
           FEDORA_URL: http://localhost:8080/fcrepo/rest
           IIIF_SERVER_BASE_URL: http://localhost:8080/iiif
           HONEYCOMB_DATASET: od2-rails-test
-          HONEYCOMB_DEBUG: "true"
+          HONEYCOMB_DEBUG: 'true'
           HONEYCOMB_WRITEKEY: buzzzzzzzzzzzzzzzz
           HONEYCOMB_SERVICE: od2
           HYRAX_VALKYRIE: true
           VALKYRIE_SOLR_CORE: hydra-test
-          VALKYRIE_SOLR_PORT: "8985"
+          VALKYRIE_SOLR_PORT: '8985'
           RAILS_ENV: test
           RDS_DB_NAME: test
           RDS_HOSTNAME: localhost
-          RDS_PASSWORD: "postgres"
-          RDS_PORT: "5432"
+          RDS_PASSWORD: 'postgres'
+          RDS_PORT: '5432'
           RDS_USERNAME: postgres
           REDIS_HOST: localhost
-          REDIS_PORT: "6379"
+          REDIS_PORT: '6379'
           SECRET_KEY_BASE: bobross1234bobross1234bobross1234bobross1234bobross1234
           SOLR_URL: http://localhost:8985/solr/hydra-test
           TRIPLESTORE_ADAPTER_TYPE: blazegraph
@@ -111,7 +111,7 @@ jobs:
       - image: circleci/redis:4
       - image: ualbertalib/docker-fcrepo4:4.7
         environment:
-          CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC"
+          CATALINA_OPTS: '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC'
       - image: solr:8.3-slim
         command: bin/solr -cloud -noprompt -f -p 8985
     working_directory: ~/app
@@ -208,15 +208,15 @@ jobs:
     parameters:
       repo:
         type: string
-        default: ""
+        default: ''
       environment:
         type: string
-        default: "production"
+        default: 'production'
       fedora_url:
         type: string
-        default: "http://fcrepo:8080/fcrepo/rest"
+        default: 'http://fcrepo:8080/fcrepo/rest'
     executor:
-      name: "docker/docker"
+      name: 'docker/docker'
     environment:
       DOCKER_LOGIN: admin
       DOCKER_PASSWORD: admin
@@ -257,15 +257,15 @@ jobs:
       - docker/build:
           registry: registry.library.oregonstate.edu
           image: od2_web_cache
-          tag: "latest"
+          tag: 'latest'
           extra_build_args: --target gems
           cache_from: registry.library.oregonstate.edu/od2_web_cache:latest
-          step-name: "Rebuild cache image"
+          step-name: 'Rebuild cache image'
       - docker/push:
           registry: registry.library.oregonstate.edu
           image: od2_web_cache
           tag: latest
-          step-name: "Push cache image"
+          step-name: 'Push cache image'
 workflows:
   ci:
     jobs:
@@ -276,18 +276,18 @@ workflows:
       - lint:
           requires:
             - bundle
-      # - test:
-      #     requires:
-      #       - lint
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
+      - test:
+          requires:
+            - lint
+          filters:
+            branches:
+              ignore:
+                - master
       - build_and_push_beavernetes:
           name: Build and push application image to Beavernetes image repository
           requires:
             - lint
-            # - test
+            - test
           filters:
             branches:
               only:

--- a/config/initializers/hacks/wings_resource_mapper_patch.rb
+++ b/config/initializers/hacks/wings_resource_mapper_patch.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal:true
+
+Rails.application.config.to_prepare do
+  Wings::ResourceMapper.class_eval do
+    ##
+    # Valkyrie objects contain a URI string for location objects so we need
+    # to return just the string for mapping from Fedora
+    # OVERRIDE FROM HYRAX/WINGS: We're not doing that remapping
+    #
+    # @return [RDF::Term || String]
+    def result
+      value.to_term
+    end
+  end
+end

--- a/spec/search_builders/oregon_digital/non_user_collections_search_builder_spec.rb
+++ b/spec/search_builders/oregon_digital/non_user_collections_search_builder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe OregonDigital::NonUserCollectionsSearchBuilder do
   describe '#show_only_collections_not_created_users' do
     subject { search_builder.show_only_collections_not_created_users({}).first }
 
-    it { is_expected.to include "{!raw f=collection_type_gid_ssim}#{user_collection_type.gid}" }
-    it { is_expected.to include "{!raw f=collection_type_gid_ssim}#{oai_collection_type.gid}" }
+    it { is_expected.to include "{!raw f=collection_type_gid_ssim}#{user_collection_type&.to_global_id}" }
+    it { is_expected.to include "{!raw f=collection_type_gid_ssim}#{oai_collection_type&.to_global_id}" }
   end
 end


### PR DESCRIPTION
https://github.com/samvera/hyrax/blob/main/lib/wings/transformer_value_mapper.rb#L57
This caused specifically basedNear/location to return strings instead of CV. This probably has utility in Valkyrie/Wings, but we're expecting CVs everywhere