### PR TITLE
Force our indexers to convert to ActiveFedora before indexing

### DIFF
--- a/app/indexers/generic_indexer.rb
+++ b/app/indexers/generic_indexer.rb
@@ -12,6 +12,7 @@ class GenericIndexer < Hyrax::WorkIndexer
   # Valkyrie compatibility hack to allow Hyrax.indexing_adapter to see AF based indexers
   def initialize(obj)
     obj = obj[:resource] if obj.is_a?(Hash) && obj.key?(:resource)
+    obj = Wings::ActiveFedoraConverter.new(resource: obj).convert if obj.is_a?(Valkyrie::Resource)
     super(obj)
   end
 


### PR DESCRIPTION
If valkyrie indexing is called traces back to our AF indexing (good) but passes the valkyrie resource (bad). This'll force our AF indexer to run on AF objects