### PR TITLE
Replace zip_tricks with zip_kit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'triplestore-adapter', git: 'https://github.com/osulp/triplestore-adapter'
 gem 'faraday_middleware'
 gem 'blacklight_iiif_search', '~> 2.0'
 gem 'rubyzip', '~> 2'
-gem 'zip_tricks', '~> 5.3'
+gem 'zip_kit', '~> 6.3'
 gem 'bulkrax', github: 'samvera/bulkrax', ref: 'c19534f3ec2bdf06a0313373ba68155c987616df' #v.9.3.1
 # gem 'willow_sword', github: 'notch8/willow_sword', branch: 'main'
 gem 'jquery-datatables-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1262,7 +1262,7 @@ GEM
       rdf (~> 3.3)
       rdf-xsd (~> 3.3)
     zeitwerk (2.7.1)
-    zip_tricks (5.6.0)
+    zip_kit (6.3.4)
 
 PLATFORMS
   aarch64-linux
@@ -1346,7 +1346,7 @@ DEPENDENCIES
   yabeda-puma-plugin
   yabeda-rails
   yabeda-sidekiq
-  zip_tricks (~> 5.3)
+  zip_kit (~> 6.3)
 
 BUNDLED WITH
    2.6.8

--- a/app/controllers/concerns/oregon_digital/download_controller_behavior.rb
+++ b/app/controllers/concerns/oregon_digital/download_controller_behavior.rb
@@ -29,7 +29,7 @@ module OregonDigital
         response.stream.write(chunk)
       end
     ensure
-      response.stream.close
+      response.stream&.close
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength

--- a/app/services/concerns/oregon_digital/streaming_download_behavior.rb
+++ b/app/services/concerns/oregon_digital/streaming_download_behavior.rb
@@ -54,7 +54,8 @@ module OregonDigital
         file_name = "#{folder}#{file_set.label}"
         deriv_name = derivative_name(file_set)
         # If this fileset doesn't have derivatives, stream in the original quality
-        return stream_files_from_fileset(file_set, zip, folder) if deriv_name.blank?
+        stream_files_from_fileset(file_set, zip, folder) if deriv_name.blank?
+        next if deriv_name.blank?
 
         # Stream the file from derivative on disk
         zip.write_deflated_file(file_name) do |file_writer|

--- a/app/services/oregon_digital/collection_streamer.rb
+++ b/app/services/oregon_digital/collection_streamer.rb
@@ -16,9 +16,9 @@ module OregonDigital
     end
 
     def each(&chunks)
-      writer = ZipTricks::BlockWrite.new(&chunks)
+      writer = ZipKit::BlockWrite.new(&chunks)
 
-      ZipTricks::Streamer.open(writer, auto_rename_duplicate_filenames: true) do |zip|
+      ZipKit::Streamer.open(writer, auto_rename_duplicate_filenames: true) do |zip|
         stream_collection(collection, '', zip)
       end
     end

--- a/app/services/oregon_digital/file_set_streamer.rb
+++ b/app/services/oregon_digital/file_set_streamer.rb
@@ -26,9 +26,9 @@ module OregonDigital
     end
 
     def each(&chunks)
-      writer = ZipTricks::BlockWrite.new(&chunks)
+      writer = ZipKit::BlockWrite.new(&chunks)
 
-      ZipTricks::Streamer.open(writer, auto_rename_duplicate_filenames: true) do |zip|
+      ZipKit::Streamer.open(writer, auto_rename_duplicate_filenames: true) do |zip|
         # Stream work files and child work files, determining if low original quality
         @standard ? stream_works_low(work, zip) : stream_works(work, zip)
         @children.each { |child| @standard ? stream_works_low(child, zip) : stream_works(child, zip) }

--- a/config/initializers/hacks/hyrax_collections_controller_behavior.rb
+++ b/config/initializers/hacks/hyrax_collections_controller_behavior.rb
@@ -38,8 +38,10 @@ Rails.application.config.to_prepare do
       OregonDigital::CollectionStreamer.stream_col(current_ability, collection) do |chunk|
         response.stream.write(chunk)
       end
+    rescue => e
+      Rails.logger.error("Download failed for collection #{collection.id}: #{e.message}")
     ensure
-      response.stream.close
+      response.stream.close if response.stream
     end
 
     # Get the path to institutional branding imag

--- a/config/initializers/hacks/hyrax_collections_controller_behavior.rb
+++ b/config/initializers/hacks/hyrax_collections_controller_behavior.rb
@@ -41,7 +41,7 @@ Rails.application.config.to_prepare do
     rescue => e
       Rails.logger.error("Download failed for collection #{collection.id}: #{e.message}")
     ensure
-      response.stream.close if response.stream
+      response.stream&.close
     end
 
     # Get the path to institutional branding imag


### PR DESCRIPTION
This will update our zip library to the successor of zip_tricks.
Adds a little extra error checking to prevent zips from crashing downloads
Better support PDFs