### PR TITLE
Add check for existence of derivative file before streaming

### DIFF
--- a/app/services/concerns/oregon_digital/streaming_download_behavior.rb
+++ b/app/services/concerns/oregon_digital/streaming_download_behavior.rb
@@ -59,6 +59,8 @@ module OregonDigital
 
         # Stream the file from derivative on disk
         zip.write_deflated_file(file_name) do |file_writer|
+          next unless File.exist?(Hyrax::DerivativePath.derivative_path_for_reference(file_set, deriv_name))
+
           File.open(Hyrax::DerivativePath.derivative_path_for_reference(file_set, deriv_name), 'rb') do |source|
             IO.copy_stream(source, file_writer)
           end


### PR DESCRIPTION
Fixes the writing of file paths that dont exist