### PR TITLE
Add in option to remove thumbnail for Branding

### DIFF
--- a/app/assets/javascripts/hyrax/thumbnail_select.es6
+++ b/app/assets/javascripts/hyrax/thumbnail_select.es6
@@ -11,6 +11,7 @@ export default class {
   // Dynamically load the file options into the "Thumbnail" select field.
   loadThumbnailOptions(url, field) {
     field.select2({
+      allowClear: true,  // Allow to remove thumbnail from Select2
       ajax: { // Use the jQuery.ajax wrapper provided by Select2
         url: url,
         dataType: "json",

--- a/app/assets/stylesheets/autocomplete/_select2.scss
+++ b/app/assets/stylesheets/autocomplete/_select2.scss
@@ -27,3 +27,9 @@
   line-height: 1.3;
   max-width: 33em !important;
 }
+
+// CUSTOM #4: Scale the remove thumbnail button so it more visible
+.select2-search-choice-close {
+  transform: scale(1.3);
+  transform-origin: center;
+}


### PR DESCRIPTION
`FEATURE:` Update the `select2` method to include an option to clear the thumbnail from branding.