### PR TITLE
Add rescue statement to SolrDocument find

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -36,6 +36,8 @@ class SolrDocument
 
     docs = repository.find(ids)
     docs.documents
+  rescue Blacklight::Exceptions::RecordNotFound
+    []
   end
 
   # Turn document type into FontAwesome icon class


### PR DESCRIPTION
Fixes an issue with SolrDocument#find related to finding no documents. Discovered by @KevinJonesMeta in the following slack message:

> Hi. While investigating some solr oddness I'm getting intermittent errors accessing works in the OSU Queer Archives Oral History Collection. Sometimes they open, sometimes I get the banner. Also true of searches for it